### PR TITLE
Rendering templates with inputs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,9 @@ Metrics/MethodLength:
 
 Style/TrailingComma:
   Enabled: false
+
+Style/AccessorMethodName:
+  Enabled: false
+
+Rails/FindBy:
+  Enabled: false

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -4,8 +4,6 @@ module RemoteExecutionHelper
   end
 
   def template_input_types_options
-    TemplateInput::TYPES.map { |key, name|
-      [ _(name), key ]
-    }
+    TemplateInput::TYPES.map { |key, name| [ _(name), key ] }
   end
 end

--- a/app/models/concerns/foreman_remote_execution/template_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/template_extensions.rb
@@ -3,7 +3,6 @@ module ForemanRemoteExecution
     extend ActiveSupport::Concern
 
     included do
-      has_many :template_inputs
       accepts_nested_attributes_for :template_inputs, :allow_destroy => true
       attr_accessible :template_inputs_attributes
     end

--- a/app/models/concerns/foreman_remote_execution/template_relations.rb
+++ b/app/models/concerns/foreman_remote_execution/template_relations.rb
@@ -1,0 +1,9 @@
+module ForemanRemoteExecution
+  module TemplateRelations
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :template_inputs, :dependent => :destroy, :foreign_key => 'template_id'
+    end
+  end
+end

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -1,13 +1,16 @@
 class TemplateInput < ActiveRecord::Base
+  class ValueNotReady < ::Foreman::Exception
+  end
+
   TYPES = { :user => N_('User input'), :fact => N_('Fact value'), :variable => N_('Variable'),
             :puppet_parameter => N_('Puppet parameter') }.with_indifferent_access
 
   attr_accessible :name, :required, :input_type, :fact_name, :variable_name,
                   :puppet_class_name, :puppet_parameter_name, :description, :job_template_id
 
-  belongs_to :job_template
+  belongs_to :template
 
-  validates :name, :presence => true
+  validates :name, :presence => true, :uniqueness => { :scope => 'template_id' }
   validates :input_type, :presence => true, :inclusion => TemplateInput::TYPES.keys
 
   validates :fact_name, :presence => { :if => :fact_template_input? }
@@ -28,5 +31,118 @@ class TemplateInput < ActiveRecord::Base
 
   def puppet_parameter_template_input?
     input_type == 'puppet_parameter'
+  end
+
+  def preview(renderer)
+    get_resolver(renderer).preview
+  end
+
+  def value(renderer)
+    get_resolver(renderer).value
+  end
+
+  private
+
+  def get_resolver(renderer)
+    resolver_class = case input_type
+      when 'user'
+        UserInputResolver
+      when 'fact'
+        FactInputResolver
+      when 'variable'
+        VariableInputResolver
+      when 'puppet_parameter'
+        PuppetParameterInputResolver
+      else
+        raise "unknown template input type #{input_type.inspect}"
+      end
+    resolver_class.new(self, renderer)
+  end
+
+  class InputResolver
+    def initialize(input, renderer)
+      @input = input
+      @renderer = renderer
+    end
+
+    def preview
+      ready? ? resolved_value : preview_value
+    end
+
+    def value
+      ready? ? resolved_value : raise(ValueNotReady, "Input '#{@input.name}' is not ready for rendering")
+    end
+
+    def preview_value
+      "$#{@input.input_type.upcase}_INPUT[#{@input.name}]"
+    end
+
+    # should be defined in descendants
+    def ready?
+      raise NotImplementedError
+    end
+
+    # should be defined in descendants
+    def resolved_value
+      raise NotImplementedError
+    end
+  end
+
+  class UserInputResolver < InputResolver
+    def ready?
+      # TODO based on job invocation
+      false
+    end
+
+    def resolved_value
+      # TODO based on job invocation
+      raise StandardError
+    end
+  end
+
+  class FactInputResolver < InputResolver
+    # fact might not be present if it hasn't been uploaded yet, there's typo in name
+    def ready?
+      @renderer.host && get_fact.present?
+    end
+
+    def resolved_value
+      get_fact.value
+    end
+
+    private
+
+    def get_fact
+      @fact ||= @renderer.host.fact_values.includes(:fact_name).where(:'fact_names.name' => @input.fact_name).first
+    end
+  end
+
+  class VariableInputResolver < InputResolver
+    def ready?
+      @renderer.host && @renderer.host.params.key?(@input.variable_name)
+    end
+
+    def resolved_value
+      @renderer.host.params[@input.variable_name]
+    end
+  end
+
+  class PuppetParameterInputResolver < InputResolver
+    def ready?
+      @renderer.host &&
+        get_enc.key?(@input.puppet_class_name) &&
+        get_enc[@input.puppet_class_name].is_a?(Hash) &&
+        get_enc[@input.puppet_class_name].key?(@input.puppet_parameter_name)
+    end
+
+    def resolved_value
+      get_enc[@input.puppet_class_name][@input.puppet_parameter_name]
+    end
+
+    private
+
+    def get_enc
+      @enc ||= Classification::ClassParam.new(:host => @renderer.host).enc
+    end
   end
 end

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -1,12 +1,12 @@
 FactoryGirl.define do
-  factory :template_input do |f|
-    f.sequence(:name) { |n| "Template input #{n}" }
-    f.input_type 'user'
+  factory :job_template do |f|
+    f.sequence(:name) { |n| "Job template #{n}" }
+    f.template 'id'
+    f.provider_type 'ssh'
   end
 
-  factory :job_template do
-    sequence(:name) { |n| "template#{n}" }
-    template 'This is a remote execution job'
-    provider_type 'ssh'
+  factory :template_input do |f|
+    f.sequence(:name) { |n| "Template input #{n}" }
+    f.input_type TemplateInput::TYPES.keys.first
   end
 end

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -1,0 +1,367 @@
+require 'test_plugin_helper'
+
+describe InputTemplateRenderer do
+  context "renderer for simple template without inputs" do
+    let(:renderer) { InputTemplateRenderer.new(FactoryGirl.build(:job_template, :template => 'id')) }
+
+    it 'should render the content' do
+      renderer.render.must_equal 'id'
+    end
+
+    it 'should render preview' do
+      renderer.preview.must_equal 'id'
+    end
+  end
+
+  context "renderer for template with user input used" do
+    let(:template) { FactoryGirl.build(:job_template, :template => 'service restart <%= input("service_name") -%>') }
+    let(:renderer) { InputTemplateRenderer.new(template) }
+
+    context 'but without input defined' do
+      describe 'rendering' do
+        let(:result) { renderer.render }
+        it { result.must_equal false }
+
+        it 'registers an error' do
+          result # let is lazy
+          renderer.error_message.wont_be_nil
+          renderer.error_message.wont_be_empty
+        end
+      end
+
+      describe 'preview' do
+        let(:result) { renderer.preview }
+        it { result.must_equal false }
+
+        it 'registers an error' do
+          result # let is lazy
+          renderer.error_message.wont_be_nil
+          renderer.error_message.wont_be_empty
+        end
+      end
+    end
+
+    context 'with matching input defined' do
+      before { renderer.template.template_inputs<< FactoryGirl.build(:template_input, :name => 'service_name', :input_type => 'user') }
+      let(:result) { renderer.render }
+
+      describe 'rendering' do
+        it 'can\'t render the content without job invocation since we don\'t have values' do
+          refute result
+        end
+
+        it 'registers an error' do
+          result # let is lazy
+          renderer.error_message.wont_be_nil
+          renderer.error_message.wont_be_empty
+        end
+
+        context 'with invocation specified' do
+          let(:result) do
+            renderer.invocation = nil # TODO
+            renderer.render
+          end
+
+          it 'can render with job invocation with corresponding value' do
+            skip 'no invocation yet'
+          end
+        end
+      end
+
+      describe 'preview' do
+        it 'should render preview' do
+          renderer.preview.must_equal 'service restart $USER_INPUT[service_name]'
+        end
+
+        context 'with invocation specified' do
+          let(:result) do
+            renderer.invocation = nil # TODO
+            renderer.render
+          end
+
+          it 'uses the value even in preview' do
+            skip 'no invocation yet'
+          end
+        end
+      end
+    end
+  end
+
+  context "renderer for template with fact input used" do
+    let(:template) { FactoryGirl.build(:job_template, :template => 'echo <%= input("issue") -%> > /etc/issue') }
+    let(:renderer) { InputTemplateRenderer.new(template) }
+
+    context 'with matching input defined' do
+      before { renderer.template.template_inputs<< FactoryGirl.build(:template_input, :name => 'issue', :input_type => 'fact', :fact_name => 'issue') }
+      let(:result) { renderer.render }
+
+      describe 'rendering' do
+        it 'can\'t render the content without host since we don\'t have facts' do
+          refute result
+        end
+
+        it 'registers an error' do
+          result # let is lazy
+          renderer.error_message.wont_be_nil
+          renderer.error_message.wont_be_empty
+        end
+
+        context 'with host specified' do
+          before { renderer.host = FactoryGirl.create(:host) }
+
+          describe 'rendering' do
+            it 'can\'t render the content without host since we don\'t have fact value' do
+              refute result
+            end
+
+            it 'registers an error' do
+              result # let is lazy
+              renderer.error_message.wont_be_nil
+              renderer.error_message.wont_be_empty
+            end
+          end
+
+          describe 'preview' do
+            it 'should render preview' do
+              renderer.preview.must_equal 'echo $FACT_INPUT[issue] > /etc/issue'
+            end
+          end
+
+          context 'with existing fact' do
+            let(:fact) { FactoryGirl.create(:fact_name, :name => 'issue') }
+
+            describe 'rendering' do
+              it 'can\'t render the content without host since we don\'t have fact value' do
+                fact # let is lazy
+                refute result
+              end
+
+              it 'registers an error' do
+                result # let is lazy
+                renderer.error_message.wont_be_nil
+                renderer.error_message.wont_be_empty
+              end
+            end
+
+            describe 'preview' do
+              it 'should render preview' do
+                renderer.preview.must_equal 'echo $FACT_INPUT[issue] > /etc/issue'
+              end
+            end
+
+            context 'with fact issue value' do
+              before { FactoryGirl.create(:fact_value, :host => renderer.host, :fact_name => fact, :value => 'banner') }
+
+              let(:result) { renderer.render }
+
+              it 'can render with job invocation with corresponding value' do
+                result.must_equal 'echo banner > /etc/issue'
+              end
+            end
+          end
+        end
+      end
+
+      describe 'preview' do
+        it 'should render preview' do
+          renderer.preview.must_equal 'echo $FACT_INPUT[issue] > /etc/issue'
+        end
+
+        context 'with host specified' do
+          before do
+            host = FactoryGirl.create(:host)
+            fact = FactoryGirl.create(:fact_name, :name => 'issue')
+            FactoryGirl.create(:fact_value, :host => host, :fact_name => fact, :value => 'banner')
+            renderer.host = host
+          end
+
+          let(:result) { renderer.render }
+
+          it 'uses the value even in preview' do
+            result.must_equal 'echo banner > /etc/issue'
+          end
+        end
+      end
+    end
+  end
+
+  context "renderer for template with variable input used" do
+    let(:template) { FactoryGirl.build(:job_template, :template => 'echo <%= input("client_key") -%> > /etc/chef/client.pem') }
+    let(:renderer) { InputTemplateRenderer.new(template) }
+
+    context 'with matching input defined' do
+      before { renderer.template.template_inputs<< FactoryGirl.build(:template_input, :name => 'client_key', :input_type => 'variable', :variable_name => 'client_key') }
+      let(:result) { renderer.render }
+
+      describe 'rendering' do
+        it 'can\'t render the content without host since we don\'t have host so no classification' do
+          refute result
+        end
+
+        it 'registers an error' do
+          result # let is lazy
+          renderer.error_message.wont_be_nil
+          renderer.error_message.wont_be_empty
+        end
+
+        context 'with host specified' do
+          let(:environment) { FactoryGirl.create(:environment) }
+          before { renderer.host = FactoryGirl.create(:host, :environment => environment) }
+
+          describe 'rendering' do
+            it 'can\'t render the content without host since we don\'t have variable value in classification' do
+              refute result
+            end
+
+            it 'registers an error' do
+              result # let is lazy
+              renderer.error_message.wont_be_nil
+              renderer.error_message.wont_be_empty
+            end
+          end
+
+          describe 'preview' do
+            it 'should render preview' do
+              renderer.preview.must_equal 'echo $VARIABLE_INPUT[client_key] > /etc/chef/client.pem'
+            end
+          end
+
+
+          context 'with existing variable implemented as host parameter' do
+            let(:parameter) { FactoryGirl.create(:host_parameter, :host => renderer.host, :name => 'client_key', :value => 'RSA KEY') }
+
+            describe 'rendering' do
+              it 'renders the value from host parameter' do
+                parameter
+                renderer.host.reload
+                result.must_equal 'echo RSA KEY > /etc/chef/client.pem'
+              end
+            end
+
+            describe 'preview' do
+              it 'should render preview' do
+                parameter
+                renderer.host.reload
+                renderer.preview.must_equal 'echo RSA KEY > /etc/chef/client.pem'
+              end
+            end
+          end
+
+          context 'with existing variable implemented as smart variable' do
+            let(:puppet_class) { FactoryGirl.create(:puppetclass, :environments => [environment], :hosts => [renderer.host]) }
+            let(:lookup_key) do
+              FactoryGirl.create(:lookup_key,
+                                 :key => 'client_key',
+                                 :puppetclass => puppet_class,
+                                 :overrides => {"fqdn=#{renderer.host.fqdn}" => "RSA KEY"})
+            end
+
+            describe 'rendering' do
+              it 'renders the value from host parameter' do
+                lookup_key
+                result.must_equal 'echo RSA KEY > /etc/chef/client.pem'
+              end
+            end
+
+            describe 'preview' do
+              it 'should render preview' do
+                lookup_key
+                renderer.preview.must_equal 'echo RSA KEY > /etc/chef/client.pem'
+              end
+            end
+          end
+        end
+
+        describe 'preview' do
+          it 'should render preview' do
+            renderer.preview.must_equal 'echo $VARIABLE_INPUT[client_key] > /etc/chef/client.pem'
+          end
+        end
+      end
+    end
+  end
+
+  context "renderer for template with puppet parameter input used" do
+    let(:template) { FactoryGirl.build(:job_template, :template => 'echo "This is WebServer with nginx <%= input("nginx_version") -%>" > /etc/motd') }
+    let(:renderer) { InputTemplateRenderer.new(template) }
+
+    context 'with matching input defined' do
+      before do
+        renderer.template.template_inputs<< FactoryGirl.build(:template_input,
+                                                              :name => 'nginx_version',
+                                                              :input_type => 'puppet_parameter',
+                                                              :puppet_parameter_name => 'version',
+                                                              :puppet_class_name => 'nginx')
+      end
+      let(:result) { renderer.render }
+
+      describe 'rendering' do
+        it 'can\'t render the content without host since we don\'t have host so no classification' do
+          refute result
+        end
+
+        it 'registers an error' do
+          result # let is lazy
+          renderer.error_message.wont_be_nil
+          renderer.error_message.wont_be_empty
+        end
+
+        context 'with host specified' do
+          let(:environment) { FactoryGirl.create(:environment) }
+          before { renderer.host = FactoryGirl.create(:host, :environment => environment) }
+
+          describe 'rendering' do
+            it 'can\'t render the content without host since we don\'t have puppet parameter in classification' do
+              refute result
+            end
+
+            it 'registers an error' do
+              result # let is lazy
+              renderer.error_message.wont_be_nil
+              renderer.error_message.wont_be_empty
+            end
+          end
+
+          describe 'preview' do
+            it 'should render preview' do
+              renderer.preview.must_equal 'echo "This is WebServer with nginx $PUPPET_PARAMETER_INPUT[nginx_version]" > /etc/motd'
+            end
+          end
+
+          context 'with existing puppet parameter with matching override' do
+            let(:puppet_class) do
+              FactoryGirl.create(:puppetclass, :environments => [environment], :hosts => [renderer.host], :name => 'nginx')
+            end
+            let(:lookup_key) do
+              FactoryGirl.create(:lookup_key, :as_smart_class_param, :with_override,
+                                 :key => 'version',
+                                 :puppetclass => puppet_class,
+                                 :path => 'fqdn',
+                                 :overrides => {"fqdn=#{renderer.host.fqdn}" => "1.4.7"})
+            end
+
+            describe 'rendering' do
+              it 'renders the value from puppet parameter' do
+                lookup_key
+                result.must_equal 'echo "This is WebServer with nginx 1.4.7" > /etc/motd'
+              end
+            end
+
+            describe 'preview' do
+              it 'should render preview' do
+                lookup_key
+                renderer.preview.must_equal 'echo "This is WebServer with nginx 1.4.7" > /etc/motd'
+              end
+            end
+          end
+        end
+
+        describe 'preview' do
+          it 'should render preview' do
+            renderer.preview.must_equal 'echo "This is WebServer with nginx $PUPPET_PARAMETER_INPUT[nginx_version]" > /etc/motd'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds InputTemplateRenderer object which can render a template
that contains input("name") macros. It also allows previewing of such
templates which expands macros to placeholders if values are not ready
yet. Currently it supports fact, variable and puppet parameter input
types, user type is ready but can be implemented once we have job
invocation objects in place.