### PR TITLE
Extend ForemanTasks after its loaded

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -21,6 +21,7 @@ module ForemanRemoteExecution
     end
 
     initializer "foreman_remote_execution.require_dynflow", :before => "foreman_tasks.initialize_dynflow" do |app|
+      ForemanTasks::Task.send(:include, ForemanRemoteExecution::ForemanTasksTaskExtensions)
       ForemanTasks.dynflow.require!
       ForemanTasks.dynflow.config.eager_load_paths << File.join(ForemanRemoteExecution::Engine.root, 'app/lib/actions')
     end
@@ -107,7 +108,6 @@ module ForemanRemoteExecution
       end
       Bookmark.send(:include, ForemanRemoteExecution::BookmarkExtensions)
       HostsHelper.send(:include, ForemanRemoteExecution::HostsHelperExtensions)
-      ForemanTasks::Task.send(:include, ForemanRemoteExecution::ForemanTasksTaskExtensions)
     end
 
     initializer 'foreman_remote_execution.register_gettext', after: :load_config_initializers do |_app|


### PR DESCRIPTION
The plugin doesn't load in production, because ForemanTasks gets loaded after RemoteExecution.

Not sure if this is the right place, but it does solve them problem for me.  @ehelms also suggested we could try the finisher hook.  Any thoughts?

```
undefined method `has_many' for Rake::Task:Class (NoMethodError)
  /opt/rh/ruby193/root/usr/share/gems/gems/foreman_remote_execution-0.0.2/app/models/concerns/foreman_remote_execution/foreman_tasks_task_extensions.rb:6:in `block in <module:ForemanTasksTaskExtensions>'
  /opt/rh/ruby193/root/usr/share/gems/gems/activesupport-3.2.8/lib/active_support/concern.rb:119:in `class_eval'
```