### PR TITLE
Fix random loading issues when extending ForemanTasks::Task model

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -107,6 +107,10 @@ module ForemanRemoteExecution
       end
       Bookmark.send(:include, ForemanRemoteExecution::BookmarkExtensions)
       HostsHelper.send(:include, ForemanRemoteExecution::HostsHelperExtensions)
+
+      # We need to explicitly force to load the Task model due to Rails loader
+      # having issues with resolving it to Rake::Task otherwise
+      require_dependency 'foreman_tasks/task'
       ForemanTasks::Task.send(:include, ForemanRemoteExecution::ForemanTasksTaskExtensions)
     end
 

--- a/lib/foreman_remote_execution/version.rb
+++ b/lib/foreman_remote_execution/version.rb
@@ -1,3 +1,3 @@
 module ForemanRemoteExecution
-  VERSION = '0.0.2'
+  VERSION = '0.0.3'
 end


### PR DESCRIPTION
We need to explicitly force to load the Task model due to Rails loader having
issues with resolving it to Rake::Task otherwise