### PR TITLE
fixes #12125 - use git ls-files in gemspec

### DIFF
--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.description = 'A plugin bringing remote execution to the Foreman, completing the config ' +
                   'management functionality with remote management functionality.'
 
-  s.files =            Dir['{app,config,doc,db,lib,locale}/**/*', 'LICENSE', 'Rakefile', 'README.md']
-  s.test_files =       Dir['test/**/*']
-  s.extra_rdoc_files = Dir['doc/**/*', 'README*', 'LICENSE']
+  s.files =            `git ls-files`.split("\n")
+  s.test_files =       `git ls-files test`.split("\n")
+  s.extra_rdoc_files = `git ls-files doc`.split("\n") + Dir['README*', 'LICENSE']
 
   s.add_dependency "deface"
   s.add_dependency "rails", "~> 3.2.8"


### PR DESCRIPTION
fixes #24

`git ls-files` seems to be somewhat controversial based on Googling, but it works fine and ensures only committed files get released.
