### PR TITLE
fixes #11469 - Ship some default templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.sw?
 .idea
 .bundle/
 log/*.log

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -37,6 +37,25 @@ class JobTemplate < ::Template
   end
   self.table_name = 'templates'
 
+  # Import a template ERB, with metadata in the first YAML comment
+  def self.import(template, options = {})
+    metadata = parse_metadata(template)
+    return if metadata.blank? || metadata.delete('kind') != 'job_template' || self.find_by_name(metadata['name'])
+
+    inputs = metadata.delete('template_inputs')
+
+    # This awkward dance is because you can't instantiate a new template with :locked => true
+    template = self.create(metadata.merge(:template => template.gsub(/<%\#.+?.-?%>\n?/m, '')))
+    template.update_attributes(options)
+    template.assign_taxonomies
+
+    inputs.each do |input|
+      template.template_inputs << TemplateInput.create(input)
+    end
+
+    template
+  end
+
   # Override method in Taxonomix as Template is not used attached to a Host,
   # and matching a Host does not prevent removing a template from its taxonomy.
   def used_taxonomy_ids(type)
@@ -51,7 +70,19 @@ class JobTemplate < ::Template
     dup
   end
 
+  def assign_taxonomies
+    if default
+      organizations << Organization.all if SETTINGS[:organizations_enabled]
+      locations << Location.all if SETTINGS[:locations_enabled]
+    end
+  end
+
   private
+
+  def self.parse_metadata(template)
+    match = template.match(/<%\#(.+?).-?%>/m)
+    match.nil? ? {} : YAML.load(match[1])
+  end
 
   # we can't use standard validator, .provider_names output can change but the validator does not reflect it
   def provider_type_whitelist

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -6,7 +6,8 @@ class TemplateInput < ActiveRecord::Base
             :puppet_parameter => N_('Puppet parameter') }.with_indifferent_access
 
   attr_accessible :name, :required, :input_type, :fact_name, :variable_name,
-                  :puppet_class_name, :puppet_parameter_name, :description, :job_template_id
+                  :puppet_class_name, :puppet_parameter_name, :description, :job_template_id,
+                  :options
 
   belongs_to :template
   has_many :template_invocation_input_values, :dependent => :destroy
@@ -40,6 +41,10 @@ class TemplateInput < ActiveRecord::Base
 
   def value(renderer)
     get_resolver(renderer).value
+  end
+
+  def options_array
+    self.options.blank? ? [] : self.options.split(/\r?\n/).map(&:strip)
   end
 
   private

--- a/app/models/template_invocation_input_value.rb
+++ b/app/models/template_invocation_input_value.rb
@@ -5,4 +5,6 @@ class TemplateInvocationInputValue < ActiveRecord::Base
 
   validates :value, :presence => true, :if => proc { |v| v.template_input.required? }
 
+  validates :value, :inclusion => { :in => proc { |v| v.template_input.options_array } },
+                    :if => proc { |v| v.template_input.input_type == 'user' && v.template_input.options_array.present? }
 end

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -49,7 +49,11 @@
                   <%= job_template_fields.fields_for :input_values do |input_values_fields| %>
                     <% job_template.template_inputs.where(:input_type => 'user').each do |input| %>
                       <%= input_values_fields.fields_for input.id.to_s, @composer.template_invocation_input_value_for(input) do |input_fields| %>
-                        <%= text_f input_fields, :value, :label => input.name, :help_inline => input.description, :required => input.required %>
+                        <% unless input.options.blank? %>
+                          <%= selectable_f input_fields, :value, input.options_array, {:include_blank => !input.required }, :require => input.required, :label => input.name, :help_inline => input.description %>
+                        <% else %>
+                          <%= textarea_f input_fields, :value, :label => input.name, :help_inline => input.description, :required => input.required, :rows => 2 %>
+                        <% end %>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/app/views/template_inputs/_form.html.erb
+++ b/app/views/template_inputs/_form.html.erb
@@ -16,6 +16,9 @@
         <%= text_f f, :puppet_class_name, :class => 'puppet_parameter_input_type', :required => true %>
         <%= text_f f, :puppet_parameter_name, :class => 'puppet_parameter_input_type', :required => true %>
       </div>
+      <div class="user_input_type custom_input_type_fields" style="<%= (f.object.user_template_input? || f.object.new_record?) ? '' : 'display:none' %>">
+        <%= textarea_f f, :options, :rows => 3, :class => 'user_input_type', :help_inline => _("A list of options the user can select from. If not provided, the user will be given a free-form field") %>
+      </div>
       <%= textarea_f f, :description, :rows => 3 %>
     <% end %>
   </div>

--- a/app/views/templates/package_action.erb
+++ b/app/views/templates/package_action.erb
@@ -1,0 +1,52 @@
+<%#
+kind: job_template
+name: Package Action - SSH Default
+job_name: Package Action
+provider_type: Ssh
+template_inputs:
+- name: pre_script
+  description: A script to run prior to the package action
+  input_type: user
+  required: false
+- name: action
+  description: 'The package action: install, update, or remove'
+  input_type: user
+  required: true
+  options: "install\nupdate\nremove"
+- name: package
+  description: The name of the package, if any
+  input_type: user
+  required: false
+- name: post_script
+  description: A script to run after the package action
+  input_type: user
+  required: false
+%>
+
+die() {
+  echo "${1}, exiting..."
+  exit $2
+}
+
+<% unless input("pre_script").blank? -%>
+  # Pre Script
+  <%= input("pre_script") %>
+  RETVAL=$?
+  [ $RETVAL -eq 0 ] || die "Pre script failed" $RETVAL
+<% end -%>
+
+# Action
+<% if @host.operatingsystem.family == 'Redhat' -%>
+  yum -y <%= input("action") %> <%= input("package") %>
+<% elsif @host.operatingsystem.family == 'Debian' -%>
+  apt-get -y <%= input("action") %> <%= input("package") %>
+<% end -%>
+RETVAL=$?
+[ $RETVAL -eq 0 ] || die "Package action failed" $RETVAL
+
+<% unless input("post_script").blank? -%>
+  # Post Script
+  <%= input("post_script") %>
+  RETVAL=$?
+  [ $RETVAL -eq 0 ] || die "Post script failed" $RETVAL
+<% end -%>

--- a/app/views/templates/puppet_run_once.erb
+++ b/app/views/templates/puppet_run_once.erb
@@ -1,0 +1,12 @@
+<%#
+kind: job_template
+name: Puppet Run Once - SSH Default
+job_name: Puppet Run Once
+provider_type: Ssh
+template_inputs:
+- name: puppet_options
+  description: Additional options to pass to puppet
+  input_type: user
+  required: false
+%>
+puppet agent --onetime --no-usecacheonfailure <%= input("puppet_options") %>

--- a/app/views/templates/run_command.erb
+++ b/app/views/templates/run_command.erb
@@ -1,0 +1,12 @@
+<%#
+kind: job_template
+name: Run Command - SSH Default
+job_name: Run Command
+provider_type: Ssh
+template_inputs:
+- name: command
+  description: Command to run on the host
+  input_type: user
+  required: true
+%>
+<%= input("command") %>

--- a/app/views/templates/service_action.erb
+++ b/app/views/templates/service_action.erb
@@ -1,0 +1,21 @@
+<%#
+kind: job_template
+name: Service Action - SSH Default
+job_name: Service Action
+provider_type: Ssh
+template_inputs:
+- name: action
+  description: Action to perform on the service
+  input_type: user
+  options: "restart\nstart\nstop\nstatus"
+  required: true
+- name: service
+  description: Name of the service
+  input_type: user
+  required: true
+%>
+<% if @host.operatingsystem.family == "Redhat" && @host.operatingsystem.major.to_i > 6 %>
+systemctl <%= input("action") %> <%= input("service") %>
+<% else %>
+service <%= input("service") %> <%= input("action") %>
+<% end -%>

--- a/db/migrate/20150827152730_add_options_to_template_input.rb
+++ b/db/migrate/20150827152730_add_options_to_template_input.rb
@@ -1,0 +1,5 @@
+class AddOptionsToTemplateInput < ActiveRecord::Migration
+  def change
+    add_column :template_inputs, :options, :text
+  end
+end

--- a/db/seeds.d/70-job_templates.rb
+++ b/db/seeds.d/70-job_templates.rb
@@ -1,0 +1,7 @@
+User.as_anonymous_admin do
+  JobTemplate.without_auditing do
+    Dir[File.join("#{ForemanRemoteExecution::Engine.root}/app/views/templates/**/*.erb")].each do |template|
+      JobTemplate.import(File.read(template), :default => true, :locked => true)
+    end
+  end
+end

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -84,6 +84,33 @@ describe InputTemplateRenderer do
         end
       end
     end
+
+    context 'with options specified' do
+
+      let(:job_invocation) { FactoryGirl.create(:job_invocation) }
+      let(:template_invocation) { FactoryGirl.build(:template_invocation, :template => template) }
+      let(:result) { renderer.render }
+
+      before do
+        template.template_inputs << FactoryGirl.build(:template_input, :name => 'service_name', :input_type => 'user', :options => "httpd\nforeman")
+      end
+
+      context 'with a valid input defined' do
+        before do
+          job_invocation.template_invocations << template_invocation
+          renderer.invocation = template_invocation
+
+          FactoryGirl.create(:template_invocation_input_value,
+                             :template_invocation => template_invocation,
+                             :template_input => template.template_inputs.first,
+                             :value => 'foreman')
+        end
+
+        it 'can render with job invocation with corresponding value' do
+          renderer.render.must_equal 'service restart foreman'
+        end
+      end
+    end
   end
 
   context "renderer for template with fact input used" do

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -1,15 +1,54 @@
 require 'test_plugin_helper'
 
 describe JobTemplate do
-  let(:job_template) { FactoryGirl.build(:job_template, :with_input) }
+  context 'cloning' do
+    let(:job_template) { FactoryGirl.build(:job_template, :with_input) }
 
-  describe '#dup' do
-    it 'duplicates also template inputs' do
-      duplicate = job_template.dup
-      duplicate.wont_equal job_template
-      duplicate.template_inputs.wont_be_empty
-      duplicate.template_inputs.first.wont_equal job_template.template_inputs.first
-      duplicate.template_inputs.first.name.must_equal job_template.template_inputs.first.name
+    describe '#dup' do
+      it 'duplicates also template inputs' do
+        duplicate = job_template.dup
+        duplicate.wont_equal job_template
+        duplicate.template_inputs.wont_be_empty
+        duplicate.template_inputs.first.wont_equal job_template.template_inputs.first
+        duplicate.template_inputs.first.name.must_equal job_template.template_inputs.first.name
+      end
+    end
+  end
+
+  context 'importing a template' do
+    let(:template) do
+      template = <<-END_TEMPLATE
+      <%#
+      kind: job_template
+      name: Service Restart
+      job_name: Service Restart
+      provider_type: Ssh
+      template_inputs:
+      - name: service_name
+        input_type: user
+        required: true
+      %>
+
+      service <%= input("service_name") %> restart
+      END_TEMPLATE
+
+      JobTemplate.import(template, :default => true)
+    end
+
+    it 'sets the name' do
+      template.name.must_equal 'Service Restart'
+    end
+
+    it 'has a template' do
+      template.template.squish.must_equal 'service <%= input("service_name") %> restart'
+    end
+
+    it 'imports inputs' do
+      template.template_inputs.first.name.must_equal 'service_name'
+    end
+
+    it 'sets additional options' do
+      template.default.must_equal true
     end
   end
 end

--- a/test/unit/template_invocation_input_value_test.rb
+++ b/test/unit/template_invocation_input_value_test.rb
@@ -1,0 +1,29 @@
+require 'test_plugin_helper'
+
+describe TemplateInvocationInputValue do
+  let(:template) { FactoryGirl.build(:job_template, :template => 'service restart <%= input("service_name") -%>') }
+  let(:renderer) { InputTemplateRenderer.new(template) }
+  let(:job_invocation) { FactoryGirl.create(:job_invocation) }
+  let(:template_invocation) { FactoryGirl.build(:template_invocation, :template => template) }
+  let(:result) { renderer.render }
+
+  context 'with selectable options' do
+    before do
+      result # let is lazy
+      template.template_inputs << FactoryGirl.build(:template_input, :name => 'service_name', :input_type => 'user',
+                                                                     :required => true, :options => "foreman\nhttpd")
+    end
+
+    it 'fails with an invalid option' do
+      refute_valid FactoryGirl.build(:template_invocation_input_value, :template_invocation => template_invocation,
+                                                                       :template_input => template.template_inputs.first,
+                                                                       :value => 'sendmail')
+    end
+
+    it 'succeeds with valid option' do
+      assert_valid FactoryGirl.build(:template_invocation_input_value, :template_invocation => template_invocation,
+                                                                       :template_input => template.template_inputs.first,
+                                                                       :value => 'foreman')
+    end
+  end
+end


### PR DESCRIPTION
Provides:
 - Package Action
 - Puppet Run Once
 - Run Command
 - Service Action

Templates are seeded by YAML, essentially  a cleaned up `template.to_json(:includes => :template_inputs)`.  We could also go the Foreman route and put the metadata in an ERB comment at the top.

I add a new `select_options` input type, I wanted this for the package action where a user could select from install/update/etc. 

Here's a gif if you just want to see:

![rex](https://cloud.githubusercontent.com/assets/429763/9529134/a853088e-4cc6-11e5-8472-3952137de2e4.gif)

