### PR TITLE
fixes #11554, #11827 - execution proxy through subnet, with load balancing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,14 +21,15 @@ Style/TrailingComma:
 Style/AccessorMethodName:
   Enabled: false
 
-Rails/FindBy:
-  Enabled: false
-
 Style/RedundantSelf:
   Enabled: false
 
 Metrics/ClassLength:
   Max: 200
+
+Style/FileName:
+  Exclude:
+      - 'db/seeds.d/*'
 
 Style/WordArray:
   Enabled: false

--- a/app/assets/javascripts/execution_interface.js
+++ b/app/assets/javascripts/execution_interface.js
@@ -1,0 +1,6 @@
+$(document).on('click', '.interface_execution', function () {
+    confirm_flag_change(this, '.interface_execution', __("Another interface is already set as execution. Are you sure you want to use this one instead?"));
+
+    var modal_form = $('#interfaceModal').find('.modal-body').contents();
+    $('#interfaceForms .interface_execution:checked').attr("checked", false);
+});

--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -3,17 +3,55 @@ module ForemanRemoteExecution
     extend ActiveSupport::Concern
 
     included do
+      alias_method_chain :build_required_interfaces, :remote_execution
+      alias_method_chain :reload, :remote_execution
+      alias_method_chain :becomes, :remote_execution
+
       has_many :targeting_hosts, :dependent => :destroy, :foreign_key => 'host_id'
     end
 
-    # create or overwrite instance methods...
-    def instance_method_name
+    def execution_interface
+      get_interface_by_flag(:execution)
     end
 
-    module ClassMethods
-      # create or overwrite class methods...
-      def class_method_name
+    def remote_execution_proxies(provider)
+      proxies = {}
+      proxies[:subnet]   = execution_interface.subnet.remote_execution_proxies.with_features(provider) if execution_interface && execution_interface.subnet
+      proxies[:fallback] = smart_proxies.with_features(provider) if Setting[:remote_execution_fallback_proxy]
+
+      if Setting[:remote_execution_global_proxy]
+        proxy_scope = if Taxonomy.enabled_taxonomies.any?
+                        ::SmartProxy.with_taxonomy_scope_override(location, organization)
+                      else
+                        proxy_scope = ::SmartProxy
+                      end
+
+        proxies[:global] = proxy_scope.authorized.with_features(provider)
       end
+
+      proxies
+    end
+
+    def drop_execution_interface_cache
+      @execution_interface = nil
+    end
+
+    def becomes_with_remote_execution(*args)
+      became = becomes_without_remote_execution(*args)
+      became.drop_execution_interface_cache
+      became
+    end
+
+    def reload_with_remote_execution(*args)
+      drop_execution_interface_cache
+      reload_without_remote_execution(*args)
+    end
+
+    private
+
+    def build_required_interfaces_with_remote_execution(attrs = {})
+      build_required_interfaces_without_remote_execution(attrs)
+      self.primary_interface.execution = true if self.execution_interface.nil?
     end
   end
 end

--- a/app/models/concerns/foreman_remote_execution/nic_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/nic_extensions.rb
@@ -1,0 +1,25 @@
+module ForemanRemoteExecution
+  module NicExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      before_validation :set_execution_flag
+      attr_accessible :execution
+      validate :exclusive_execution_interface
+    end
+
+    private
+
+    def set_execution_flag
+      return unless primary? && host.present?
+      self.execution = true if host.interfaces.detect(&:execution).nil?
+    end
+
+    def exclusive_execution_interface
+      if host && self.execution?
+        executions = host.interfaces.select { |i| i.execution? && i != self }
+        errors.add :execution, _('host already has an execution interface') unless executions.empty?
+      end
+    end
+  end
+end

--- a/app/models/concerns/foreman_remote_execution/subnet_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/subnet_extensions.rb
@@ -1,0 +1,10 @@
+module ForemanRemoteExecution
+  module SubnetExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :target_remote_execution_proxies, :as => :target
+      has_many :remote_execution_proxies, :dependent => :destroy, :through => :target_remote_execution_proxies
+    end
+  end
+end

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -93,4 +93,20 @@ class JobInvocation < ActiveRecord::Base
   def time_format
     '%Y-%m-%d %H:%M'
   end
+
+  def template_invocation_for_host(host)
+    providers = available_providers(host)
+    providers.each do |provider|
+      template_invocations.each do |template_invocation|
+        if template_invocation.template.provider_type == provider
+          return template_invocation
+        end
+      end
+    end
+  end
+
+  # TODO: determine from the host and job_invocation details
+  def available_providers(host)
+    return RemoteExecutionProvider.provider_names
+  end
 end

--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -6,8 +6,13 @@ class Setting::RemoteExecution < Setting
 
     self.transaction do
       [
+        self.set('remote_execution_fallback_proxy',
+                 N_("Search the host for any proxy with Remote Execution, useful when the host has no subnet or the subnet does not have an execution proxy"),
+                 false),
         self.set('remote_execution_global_proxy',
-                 N_("Allows searching for remote execution proxy outside of the proxies assigned to the host: useful when missing the host proxies associations"),
+                 N_("Search for remote execution proxy outside of the proxies assigned to the host. " +
+                 "If locations or organizations are enabled, the search will be limited to the host's " +
+                 "organization or location."),
                  false),
       ].each { |s| self.create! s.update(:category => "Setting::RemoteExecution") }
     end

--- a/app/models/target_remote_execution_proxy.rb
+++ b/app/models/target_remote_execution_proxy.rb
@@ -1,0 +1,4 @@
+class TargetRemoteExecutionProxy < ActiveRecord::Base
+  belongs_to :remote_execution_proxy, :class_name => 'SmartProxy'
+  belongs_to :target, :polymorphic => true
+end

--- a/app/overrides/execution_interface.rb
+++ b/app/overrides/execution_interface.rb
@@ -1,0 +1,9 @@
+Deface::Override.new(:virtual_path    => 'hosts/_form',
+                     :name            => 'add_execution_interface_js',
+                     :insert_before   => 'div#primary',
+                     :text            => '<%= javascript "execution_interface" %>')
+
+Deface::Override.new(:virtual_path  => 'nic/_base_form',
+                     :name          => 'add_execution_interface',
+                     :insert_after  => 'erb[loud]:contains("interface_provision")',
+                     :partial       => '../overrides/foreman/nics/execution_interface')

--- a/app/overrides/foreman/nics/_execution_interface.html.erb
+++ b/app/overrides/foreman/nics/_execution_interface.html.erb
@@ -1,0 +1,1 @@
+<%= checkbox_f f, :execution, :help_inline => _("The execution interface is used for remote execution"), :class => :interface_execution %>

--- a/app/overrides/foreman/subnets/_rex_tab.html.erb
+++ b/app/overrides/foreman/subnets/_rex_tab.html.erb
@@ -1,0 +1,1 @@
+<li><a href="#rex_proxies" data-toggle="tab"><%= _('Remote Execution') %></a></li>

--- a/app/overrides/foreman/subnets/_rex_tab_pane.html.erb
+++ b/app/overrides/foreman/subnets/_rex_tab_pane.html.erb
@@ -1,0 +1,5 @@
+<div class="tab-pane" id="rex_proxies">
+  <%= fields_for :subnet do |f| %>
+    <%= multiple_selects f, :remote_execution_proxies, SmartProxy.authorized.with_features(RemoteExecutionProvider.provider_names), @subnet.remote_execution_proxy_ids, {:label => _("Proxies"), :help_inline => _("Select as many remote execution proxies as applicable for this subnet.  When multiple proxies with the same provider are added, actions will be load balanced among them.")} %>
+  <% end %>
+</div>

--- a/app/overrides/subnet_proxies.rb
+++ b/app/overrides/subnet_proxies.rb
@@ -1,0 +1,9 @@
+Deface::Override.new(:virtual_path => 'subnets/_form',
+                     :name => 'add_remote_execution_proxies_tab',
+                     :insert_after => 'li.active',
+                     :partial => '../overrides/foreman/subnets/rex_tab')
+
+Deface::Override.new(:virtual_path => 'subnets/_form',
+                     :name => 'add_remote_execution_proxies_tab_pane',
+                     :insert_after => 'div#proxies',
+                     :partial => '../overrides/foreman/subnets/rex_tab_pane')

--- a/app/services/proxy_load_balancer.rb
+++ b/app/services/proxy_load_balancer.rb
@@ -1,0 +1,31 @@
+class ProxyLoadBalancer
+  def initialize
+    @tasks   = {}
+    @offline = []
+  end
+
+  # Get the least loaded proxy from the given list of proxies
+  def next(proxies)
+    exclude = @tasks.keys + @offline
+    @tasks.merge!(get_counts(proxies - exclude))
+    next_proxy = @tasks.select { |proxy, _| proxies.include?(proxy) }.min_by { |_, job_count| job_count }.first
+    @tasks[next_proxy] += 1
+    next_proxy
+  end
+
+  private
+
+  def get_counts(proxies)
+    proxies.inject({}) do |result, proxy|
+      begin
+        proxy_api = ProxyAPI::ForemanDynflow::DynflowProxy.new(:url => proxy.url)
+        result[proxy] = proxy_api.tasks_count('running')
+        result
+      rescue
+        @offline << proxy
+        Rails.logger.error("Could not fetch task counts from #{proxy}, skipped.")
+        result
+      end
+    end
+  end
+end

--- a/db/migrate/20150826191632_create_target_remote_execution_proxies.rb
+++ b/db/migrate/20150826191632_create_target_remote_execution_proxies.rb
@@ -1,0 +1,14 @@
+class CreateTargetRemoteExecutionProxies < ActiveRecord::Migration
+  def change
+    create_table :target_remote_execution_proxies do |t|
+      t.integer :remote_execution_proxy_id
+      t.integer :target_id
+      t.string :target_type
+
+      t.timestamps
+    end
+
+    add_index :target_remote_execution_proxies, :remote_execution_proxy_id, :name => 'target_remote_execution_proxies_proxy_id'
+    add_index :target_remote_execution_proxies, [:target_id, :target_type], :name => 'target_remote_execution_proxies_target_id_target_type'
+  end
+end

--- a/db/migrate/20150903192731_add_execution_to_interface.rb
+++ b/db/migrate/20150903192731_add_execution_to_interface.rb
@@ -1,0 +1,22 @@
+class FakeNic < ActiveRecord::Base
+  self.table_name = 'nics'
+
+  def type
+    Nic::Managed
+  end
+end
+
+class AddExecutionToInterface < ActiveRecord::Migration
+  def up
+    add_column :nics, :execution, :boolean, :default => false
+
+    FakeNic.reset_column_information
+    FakeNic.all.each do |nic|
+      nic.update_column(:execution, true) if nic.primary
+    end
+  end
+
+  def down
+    remove_column :nics, :execution
+  end
+end

--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.test_files =       Dir['test/**/*']
   s.extra_rdoc_files = Dir['doc/**/*', 'README*', 'LICENSE']
 
+  s.add_dependency "deface"
   s.add_dependency "rails", "~> 3.2.8"
   s.add_dependency "foreman-tasks", "~> 0.7.5"
 

--- a/lib/foreman_remote_execution.rb
+++ b/lib/foreman_remote_execution.rb
@@ -1,5 +1,5 @@
+require 'deface'
 require 'foreman-tasks'
-
 require 'foreman_remote_execution/engine'
 
 module ForemanRemoteExecution

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -108,8 +108,15 @@ module ForemanRemoteExecution
         klass.send(:include, ForemanRemoteExecution::HostExtensions)
         klass.send(:include, ForemanTasks::Concerns::HostActionSubject)
       end
+
+      (Nic::Base.descendants + [Nic::Base]).each do |klass|
+        klass.send(:include, ForemanRemoteExecution::NicExtensions)
+      end
+
       Bookmark.send(:include, ForemanRemoteExecution::BookmarkExtensions)
       HostsHelper.send(:include, ForemanRemoteExecution::HostsHelperExtensions)
+
+      Subnet.send(:include, ForemanRemoteExecution::SubnetExtensions)
 
       # We need to explicitly force to load the Task model due to Rails loader
       # having issues with resolving it to Rake::Task otherwise

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -46,3 +46,46 @@ FactoryGirl.define do
     f.sequence(:value) { |n| "Input Value #{n}" }
   end
 end
+
+FactoryGirl.modify do
+  factory :feature do
+    trait :ssh do
+      name 'Ssh'
+    end
+  end
+
+  factory :smart_proxy do
+    trait :ssh do
+      features { [FactoryGirl.build(:feature, :ssh)] }
+    end
+  end
+
+  factory :subnet do
+    trait :execution do
+      remote_execution_proxies { [FactoryGirl.build(:smart_proxy, :ssh)] }
+    end
+  end
+
+  factory :host do
+    trait :with_execution do
+      managed
+      domain
+      subnet do
+        overrides = {
+          :remote_execution_proxies => [FactoryGirl.create(:smart_proxy, :ssh)]
+        }
+
+        overrides[:locations] = [location] unless location.nil?
+        overrides[:organizations] = [organization] unless organization.nil?
+
+        FactoryGirl.create(
+          :subnet,
+          overrides
+        )
+      end
+      interfaces do
+        [FactoryGirl.build(:nic_primary_and_provision, :ip => subnet.network.sub(/0\Z/, '1'), :execution => true)]
+      end
+    end
+  end
+end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -6,3 +6,21 @@ require 'dynflow/testing'
 # Add plugin to FactoryGirl's paths
 FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryGirl.reload
+
+# Foreman's setup doesn't handle cleaning up for Minitest::Spec
+DatabaseCleaner.strategy = :transaction
+
+class Minitest::Spec
+  class << self
+    alias_method :context, :describe
+  end
+
+  before :each do
+    DatabaseCleaner.start
+    Setting::RemoteExecution.load_defaults
+  end
+
+  after :each do
+    DatabaseCleaner.clean
+  end
+end

--- a/test/unit/actions/run_proxy_command_test.rb
+++ b/test/unit/actions/run_proxy_command_test.rb
@@ -4,16 +4,17 @@ module ForemanRemoteExecution
   class RunProxyCommandTest < ActiveSupport::TestCase
     include Dynflow::Testing
 
-    let(:proxy) { FactoryGirl.build(:smart_proxy) }
+    let(:host) { FactoryGirl.build(:host, :with_execution) }
+    let(:proxy) { host.remote_execution_proxies('Ssh')[:subnet].first }
     let(:hostname) { 'myhost.example.com' }
     let(:script) { 'ping -c 5 redhat.com' }
     let(:connection_options) { { 'retry_interval' => 15, 'retry_count' => 4, 'timeout' => 60 } }
     let(:action) do
-      create_and_plan_action(Actions::RemoteExecution::RunProxyCommand, proxy, hostname, script)
+      create_and_plan_action(Actions::RemoteExecution::RunProxyCommand, proxy, host.name, script)
     end
 
     it 'plans for running the command action on server' do
-      assert_run_phase action, { :hostname       => hostname,
+      assert_run_phase action, { :hostname       => host.name,
                                  :script         => script,
                                  :proxy_url      => proxy.url,
                                  :effective_user => nil,

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -1,0 +1,90 @@
+require 'test_plugin_helper'
+
+describe ForemanRemoteExecution::HostExtensions do
+  let(:provider) { 'Ssh' }
+
+  before do
+    User.current = FactoryGirl.build(:user, :admin)
+  end
+
+  after { User.current = nil }
+
+  context 'host has multiple nics' do
+    let(:host) { FactoryGirl.build(:host, :with_execution) }
+
+    it 'should only have one execution interface' do
+      host.interfaces << FactoryGirl.build(:nic_managed)
+      host.interfaces.each { |interface| interface.execution = true }
+      host.wont_be :valid?
+    end
+
+    it 'returns the execution interface' do
+      host.execution_interface.must_be_kind_of Nic::Managed
+    end
+  end
+
+  describe 'proxy determination strategies' do
+    context 'subnet strategy' do
+      let(:host) { FactoryGirl.build(:host, :with_execution) }
+      it { host.remote_execution_proxies(provider)[:subnet].must_include host.subnet.remote_execution_proxies.first }
+    end
+
+    context 'fallback strategy' do
+      let(:host) { FactoryGirl.build(:host, :with_puppet) }
+
+      context 'enabled' do
+        before do
+          Setting[:remote_execution_fallback_proxy] = true
+          host.puppet_proxy.features << FactoryGirl.create(:feature, :ssh)
+        end
+
+        it 'returns a fallback proxy' do
+          host.remote_execution_proxies(provider)[:fallback].must_include host.puppet_proxy
+        end
+      end
+
+      context 'disabled' do
+        before do
+          Setting[:remote_execution_fallback_proxy] = false
+          host.puppet_proxy.features << FactoryGirl.create(:feature, :ssh)
+        end
+
+        it 'returns no proxy' do
+          host.remote_execution_proxies(provider)[:fallback].must_be_empty
+        end
+      end
+    end
+
+    context 'global strategy' do
+      let(:organization) { FactoryGirl.build(:organization) }
+      let(:location) { FactoryGirl.build(:location) }
+      let(:host) { FactoryGirl.build(:host, :organization => organization, :location => location) }
+      let(:proxy_in_taxonomies) { FactoryGirl.create(:smart_proxy, :ssh, :organizations => [organization], :locations => [location]) }
+      let(:proxy_no_taxonomies) { FactoryGirl.create(:smart_proxy, :ssh) }
+
+      context 'enabled' do
+        before { Setting[:remote_execution_global_proxy] = true }
+
+        it 'returns correct proxies confined by taxonomies' do
+          proxy_in_taxonomies
+          proxy_no_taxonomies
+          host.remote_execution_proxies(provider)[:global].must_include proxy_in_taxonomies
+          host.remote_execution_proxies(provider)[:global].wont_include proxy_no_taxonomies
+        end
+
+        it 'returns all proxies when there\'s no taxonomies' do
+          Taxonomy.stubs(:enabled_taxonomies).returns([])
+          host.remote_execution_proxies(provider)[:global].must_include proxy_in_taxonomies
+          host.remote_execution_proxies(provider)[:global].must_include proxy_no_taxonomies
+        end
+      end
+
+      context 'disabled' do
+        before { Setting[:remote_execution_global_proxy] = false }
+        it 'returns no proxy' do
+          host.remote_execution_proxies(provider)[:global].must_be_empty
+        end
+      end
+    end
+  end
+end

--- a/test/unit/concerns/nic_extensions_test.rb
+++ b/test/unit/concerns/nic_extensions_test.rb
@@ -1,0 +1,9 @@
+require 'test_plugin_helper'
+
+describe ForemanRemoteExecution::NicExtensions do
+  let(:host) { FactoryGirl.create(:host) }
+
+  it 'sets the first primary interface as the execution interface' do
+    host.execution_interface.must_equal host.interfaces.first
+  end
+end

--- a/test/unit/proxy_load_balancer_test.rb
+++ b/test/unit/proxy_load_balancer_test.rb
@@ -1,0 +1,21 @@
+require 'test_plugin_helper'
+
+describe ProxyLoadBalancer do
+  let(:load_balancer) { ProxyLoadBalancer.new }
+
+  before do
+    ProxyAPI::ForemanDynflow::DynflowProxy.any_instance.stubs(:tasks_count).returns(0)
+  end
+
+  it 'load balances' do
+    proxies = FactoryGirl.create_list(:smart_proxy, 3, :ssh)
+    not_yet_seen = proxies.dup
+
+    3.times do
+      found = load_balancer.next(proxies)
+      not_yet_seen.delete(found)
+    end
+
+    not_yet_seen.must_be_empty
+  end
+end


### PR DESCRIPTION
## Background

Currently, when you schedule an action, we determine the proxy to handle the request by some magic, in the following order:

1. We look at all the proxies attached to the host (Puppet, TFTP, DNS) and see if any have remote execution features we're looking for.  We take the first we find.

1. If you enable the setting `remote_execution_global_proxy`, and we don't find a proxy on the Host, we'll expand our search to all proxies.

1. If nothing is found, fail for that host.

This works, but we need some more granular control over this in order to be deterministic in the proxies we choose in multi-proxy environments, and account for complex networking setups. We want to do it without making the user's life too difficult. 

## Execution Interface

This PR adds the concept of an "Execution Interface."  New hosts will automatically get one, and you can change it to be a different interface if desired:

![newhost](https://cloud.githubusercontent.com/assets/429763/9638100/8e8e52f4-5172-11e5-9703-0d9516706feb.gif)

The proxy to use is determined through the subnet assigned to the execution interface. You can actually assign *multiple* remote execution providers.  This buys us a nice way to have load balancing / HA..

![subnet](https://cloud.githubusercontent.com/assets/429763/9638231/8054b650-5173-11e5-94a7-7606c7583ec5.png)

### New Work Flow

The new process for determining the remote execution proxy:

1. If the host has an execution interface with a subnet, then we use the proxies associated to that subnet, if any.

1. Same as 1 above, except now gated by a new setting: `remote_execution_fallback_proxy`

1. Same as 2 above

1. Same as 3 above

## Load Balancing / HA

This is not yet implemented, bu we'll round robin load balance requests across the smart proxies for that subnet.  

## Some questions

1. How does this setup feel from a usability perspective? Any suggestions?

1. Should you *also* be able to assign remote execution proxies directly to hosts? The default action would always be inherit from subnet, but a user could want in some cases some one-off overrides.

1. Are there environments where this setup will not work well?

1. Any concerns about integration with Katello?

