### PR TITLE
Fixes #11759 - fix include_javascript and lookup keys preparation

### DIFF
--- a/app/views/job_templates/index.html.erb
+++ b/app/views/job_templates/index.html.erb
@@ -1,4 +1,4 @@
-<%= include_javascript %>
+<%= include_javascript if SETTINGS[:version].short == '1.9' %>
 <%= javascript 'lookup_keys' %>
 <%= javascript 'template_input' %>
 

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -276,7 +276,8 @@ describe InputTemplateRenderer do
           context 'with existing variable implemented as smart variable' do
             let(:puppet_class) { FactoryGirl.create(:puppetclass, :environments => [environment], :hosts => [renderer.host]) }
             let(:lookup_key) do
-              FactoryGirl.create(:lookup_key,
+              lookup_key_factory = SETTINGS[:version].short == '1.9' ? :lookup_key : :variable_lookup_key
+              FactoryGirl.create(lookup_key_factory,
                                  :key => 'client_key',
                                  :puppetclass => puppet_class,
                                  :overrides => {"fqdn=#{renderer.host.fqdn}" => "RSA KEY"})
@@ -359,10 +360,12 @@ describe InputTemplateRenderer do
               FactoryGirl.create(:puppetclass, :environments => [environment], :hosts => [renderer.host], :name => 'nginx')
             end
             let(:lookup_key) do
-              FactoryGirl.create(:lookup_key, :as_smart_class_param, :with_override,
+              lookup_key_factory = SETTINGS[:version].short == '1.9' ? :lookup_key : :puppetclass_lookup_key
+              FactoryGirl.create(lookup_key_factory, :as_smart_class_param,
                                  :key => 'version',
                                  :puppetclass => puppet_class,
                                  :path => 'fqdn',
+                                 :override => true,
                                  :overrides => {"fqdn=#{renderer.host.fqdn}" => "1.4.7"})
             end
 


### PR DESCRIPTION
include_javascript is not needed (and present) anymore, and lookup keys
factories changed behavior and we need to use some specialized factories.