### PR TITLE
Refs #11805 - use before_create instead of after_create for default templates

### DIFF
--- a/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
@@ -4,6 +4,13 @@ module ForemanRemoteExecution
 
     included do
       has_many :job_templates, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'JobTemplate'
+
+      # FIXME - workaround for #11805 - use before_create for setting
+      # the default templates, remove after it's fixed in upstream
+      # (https://github.com/theforeman/foreman/pull/2723) and we don't
+      # support Foreman 1.9
+      skip_callback :create, :after, :assign_default_templates
+      before_create :assign_default_templates
     end
   end
 end


### PR DESCRIPTION
Otherwise we hit issues described in rails/rails#12180 (comment), will not be
needed once https://github.com/theforeman/foreman/pull/2723 is in and we don't
support older versions