### PR TITLE
Refs #12065 - fix foreman 1.9 compatibility with refresh js

### DIFF
--- a/app/assets/javascripts/template_invocation.js
+++ b/app/assets/javascripts/template_invocation.js
@@ -68,5 +68,5 @@ function job_invocation_refresh_data(){
 }
 
 function fetch_ids_of_hosts(attribute){
-  return _.map($('div#hosts td.host_' + attribute + '[data-refresh_required="true"]'), function(elem) { return $(elem).data('id') });
+  return $('div#hosts td.host_' + attribute + '[data-refresh_required="true"]').map(function() { return $(this).data('id') }).get();
 }


### PR DESCRIPTION
Foreman 1.9 didn't include underscore.js, but we are ok with jQuery in this
case.