### PR TITLE
refs #11633 - template support for deploying ssh keys

### DIFF
--- a/app/lib/proxy_api/remote_execution_ssh.rb
+++ b/app/lib/proxy_api/remote_execution_ssh.rb
@@ -1,0 +1,14 @@
+module ::ProxyAPI
+  class RemoteExecutionSSH < ::ProxyAPI::Resource
+    def initialize(args)
+      @url = args[:url] + '/ssh'
+      super args
+    end
+
+    def pubkey
+      get('pubkey').strip
+    rescue => e
+      raise ProxyException.new(url, e, N_('Unable to fetch public key'))
+    end
+  end
+end

--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -6,8 +6,16 @@ module ForemanRemoteExecution
       alias_method_chain :build_required_interfaces, :remote_execution
       alias_method_chain :reload, :remote_execution
       alias_method_chain :becomes, :remote_execution
+      alias_method_chain :params, :remote_execution
 
       has_many :targeting_hosts, :dependent => :destroy, :foreign_key => 'host_id'
+    end
+
+    def params_with_remote_execution
+      params = params_without_remote_execution
+      keys = remote_execution_ssh_keys
+      params['remote_execution_ssh_keys'] = keys unless keys.blank?
+      params
     end
 
     def execution_interface
@@ -30,6 +38,10 @@ module ForemanRemoteExecution
       end
 
       proxies
+    end
+
+    def remote_execution_ssh_keys
+      remote_execution_proxies('Ssh').values.flatten.uniq.map { |proxy| proxy.pubkey }.compact.uniq
     end
 
     def drop_execution_interface_cache

--- a/app/models/concerns/foreman_remote_execution/smart_proxy_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/smart_proxy_extensions.rb
@@ -1,0 +1,26 @@
+module ForemanRemoteExecution
+  module SmartProxyExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :refresh, :remote_execution
+    end
+
+    def pubkey
+      self[:pubkey] || update_pubkey
+    end
+
+    def update_pubkey
+      return unless has_feature?('Ssh')
+      key = ::ProxyAPI::RemoteExecutionSSH.new(:url => url).pubkey
+      self.update_attribute(:pubkey, key) if key
+      key
+    end
+
+    def refresh_with_remote_execution
+      errors = refresh_without_remote_execution
+      update_pubkey
+      errors
+    end
+  end
+end

--- a/app/views/unattended/snippets/_remote_execution_ssh_keys.erb
+++ b/app/views/unattended/snippets/_remote_execution_ssh_keys.erb
@@ -1,0 +1,18 @@
+<%#
+  kind: snippet
+  name: remote_execution_ssh_keys
+%>
+
+<% if @host.params['remote_execution_ssh_keys'].present? %>
+<% ssh_user = @host.params['remote_execution_ssh_user'] || 'root' %>
+<% ssh_path = "~#{ssh_user}/.ssh" %>
+
+mkdir -p <%= ssh_path %>
+
+cat << EOF >> <%= ssh_path %>/authorized_keys
+<%= @host.params['remote_execution_ssh_keys'].join("\n") %>
+EOF
+
+chmod 700 <%= ssh_path %>
+chmod 600 <%= ssh_path %>/authorized_keys
+<% end %>

--- a/db/migrate/20151013135415_add_pub_key_to_smart_proxy.rb
+++ b/db/migrate/20151013135415_add_pub_key_to_smart_proxy.rb
@@ -1,0 +1,5 @@
+class AddPubKeyToSmartProxy < ActiveRecord::Migration
+  def change
+    add_column :smart_proxies, :pubkey, :text
+  end
+end

--- a/db/seeds.d/80-provision_templates.rb
+++ b/db/seeds.d/80-provision_templates.rb
@@ -1,0 +1,21 @@
+ProvisioningTemplate.without_auditing do
+  templates = [{:name => "remote_execution_ssh_keys", :source => "snippets/_remote_execution_ssh_keys.erb", :snippet => true}]
+
+  defaults = {:vendor => "Remote Execution", :default => true, :locked => true}
+
+  templates.each do |template|
+    next if ProvisioningTemplate.find_by_name(template[:name])
+
+    template.merge!(defaults)
+
+    t= ProvisioningTemplate.create({
+      :snippet => false,
+      :template => File.read(File.join("#{ForemanRemoteExecution::Engine.root}/app/views/unattended", template.delete(:source)))
+    }.merge(template))
+
+    t.organizations << (Organization.all - t.organizations)
+    t.locations << (Location.all - t.locations)
+
+    raise "Unable to create template #{t.name}: #{format_errors t}" if t.nil? || t.errors.any?
+  end
+end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -103,10 +103,9 @@ module ForemanRemoteExecution
       (Taxonomy.descendants + [Taxonomy]).each { |klass| klass.send(:include, ForemanRemoteExecution::TaxonomyExtensions) }
 
       User.send(:include, ForemanRemoteExecution::UserExtensions)
-      (Host::Base.descendants + [Host::Base]).each do |klass|
-        klass.send(:include, ForemanRemoteExecution::HostExtensions)
-        klass.send(:include, ForemanTasks::Concerns::HostActionSubject)
-      end
+
+      Host::Managed.send(:include, ForemanRemoteExecution::HostExtensions)
+      Host::Managed.send(:include, ForemanTasks::Concerns::HostActionSubject)
 
       (Nic::Base.descendants + [Nic::Base]).each do |klass|
         klass.send(:include, ForemanRemoteExecution::NicExtensions)
@@ -115,6 +114,7 @@ module ForemanRemoteExecution
       Bookmark.send(:include, ForemanRemoteExecution::BookmarkExtensions)
       HostsHelper.send(:include, ForemanRemoteExecution::HostsHelperExtensions)
 
+      SmartProxy.send(:include, ForemanRemoteExecution::SmartProxyExtensions)
       Subnet.send(:include, ForemanRemoteExecution::SubnetExtensions)
 
       # We need to explicitly force to load the Task model due to Rails loader

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -9,6 +9,16 @@ describe ForemanRemoteExecution::HostExtensions do
 
   after { User.current = nil }
 
+  context 'ssh keys' do
+    let(:host) { FactoryGirl.build(:host, :with_execution) }
+
+    it 'has ssh keys in the parameters' do
+      sshkey = 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQ foo@example.com'
+      SmartProxy.any_instance.stubs(:pubkey).returns(sshkey)
+      host.remote_execution_ssh_keys.must_include sshkey
+    end
+  end
+
   context 'host has multiple nics' do
     let(:host) { FactoryGirl.build(:host, :with_execution) }
 


### PR DESCRIPTION
Includes a snippet to deploy the ssh keys to a host for all the relevant proxies.  You'll need to include

`<%= snippet 'remote_execution_ssh_keys' %>` 

in the %post of your provision template, or in the finish/userdata templates, and they'll automatically be setup for the authorized_keys.

The ssh keys are also included in the global parameters, so changes can be managed with a potential puppet module.  Should we provide one?

Also, this is based on how things currently are, we still need to have some discussion/planning about what more advanced use cases we need to support.