### PR TITLE
Fixes #12317 - Missing title on new job invocation

### DIFF
--- a/app/views/job_invocations/new.html.erb
+++ b/app/views/job_invocations/new.html.erb
@@ -1,8 +1,4 @@
 <% javascript 'template_invocation' %>
 <% stylesheet 'template_invocation' %>
-
-<div class="row form-group">
-  <h1 class="col-md-8"><%= _('New Job Invocation') %></h1>
-</div>
-
+<% title _('Job invocation') %>
 <%= render :partial => 'form' %>


### PR DESCRIPTION
**Problem**
When you click on 'Run Job' on a host, there is no title on that page.

**Solution**
Add a title to the new page for Job invocations.