### PR TITLE
Fixes #12246 - Validate job_name on template creation

### DIFF
--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -28,6 +28,7 @@ class JobTemplate < ::Template
                   end
                 }
 
+  validates :job_name, :presence => true, :unless => ->(job_template) { job_template.snippet }
   validates :provider_type, :presence => true
   validate :provider_type_whitelist
 

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -1,6 +1,19 @@
 require 'test_plugin_helper'
 
 describe JobTemplate do
+  context 'when creating a template' do
+    let(:job_template) { FactoryGirl.build(:job_template, :job_name => '') }
+
+    it 'needs a job_name' do
+      refute job_template.valid?
+    end
+
+    it 'does not need a job_name if it is a snippet' do
+      job_template.snippet = true
+      assert job_template.valid?
+    end
+  end
+
   context 'cloning' do
     let(:job_template) { FactoryGirl.build(:job_template, :with_input) }
 


### PR DESCRIPTION
**Problem**
You can create job templates without a job_name currently. This leads to a situation where you cannot use the template in a job invocation because it lacks a job_name. 

**Solution**
Validate that the job_name is present on save on every job template creation.