### PR TITLE
Fixes #12233 - clean the interface cache only when becoming Managed::Host

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -38,7 +38,7 @@ module ForemanRemoteExecution
 
     def becomes_with_remote_execution(*args)
       became = becomes_without_remote_execution(*args)
-      became.drop_execution_interface_cache
+      became.drop_execution_interface_cache if became.respond_to? :drop_execution_interface_cache
       became
     end
 


### PR DESCRIPTION
Without the patch, discovery reboot fails on

``` NoMethodError: undefined method `drop_execution_interface_cache' for
```