### PR TITLE
fixes #12316 - make global proxy turned on by default

### DIFF
--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -13,7 +13,7 @@ class Setting::RemoteExecution < Setting
                  N_("Search for remote execution proxy outside of the proxies assigned to the host. " +
                  "If locations or organizations are enabled, the search will be limited to the host's " +
                  "organization or location."),
-                 false),
+                 true),
       ].each { |s| self.create! s.update(:category => "Setting::RemoteExecution") }
     end
 


### PR DESCRIPTION
With this as a default, then the plugin just works out of the box.  More
advanced users will likely want to turn it off and use subnet-based
proxy determination for segmented networks while getting proper HA, load
balancing, etc.