### PR TITLE
Fixes #10758 - allow execution limiting by permissions

### DIFF
--- a/app/controllers/template_invocations_controller.rb
+++ b/app/controllers/template_invocations_controller.rb
@@ -1,4 +1,6 @@
 class TemplateInvocationsController < ApplicationController
+  include Foreman::Controller::AutoCompleteSearch
+
   def controller_permission
     'job_invocations'
   end

--- a/app/models/template_invocation.rb
+++ b/app/models/template_invocation.rb
@@ -1,4 +1,5 @@
 class TemplateInvocation < ActiveRecord::Base
+  include Authorizable
   include ForemanTasks::Concerns::ActionSubject
 
   include ForemanRemoteExecution::ErrorsFlattener
@@ -11,10 +12,16 @@ class TemplateInvocation < ActiveRecord::Base
   belongs_to :job_invocation, :inverse_of => :template_invocations
   has_many :input_values, :class_name => 'TemplateInvocationInputValue', :dependent => :destroy
   has_one :targeting, :through => :job_invocation
+  belongs_to :host, :class_name => 'Host::Managed', :foreign_key => :host_id
+  has_one :host_group, :through => :host, :source => :hostgroup
 
   validates_associated :input_values
   validate :provides_required_input_values
   before_validation :set_effective_user
+
+  scoped_search :in => :host, :on => :name, :rename => 'host.name', :complete_value => true
+  scoped_search :in => :host_group, :on => :name, :rename => 'host_group.name', :complete_value => true
+  scoped_search :in => :template, :on => :job_name, :complete_value => true
 
   def to_action_input
     { :id => id, :name => template.name }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :template_invocations, :only => [:show]
+  # index is needed so the auto_complete_search can be constructed, otherwise autocompletion in filter does not work
+  resources :template_invocations, :only => [:show, :index] do
+    collection do
+      get 'auto_complete_search'
+    end
+  end
 
   namespace :api, :defaults => {:format => 'json'} do
     scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do

--- a/db/migrate/20151215114631_add_host_id_to_template_invocation.rb
+++ b/db/migrate/20151215114631_add_host_id_to_template_invocation.rb
@@ -1,0 +1,29 @@
+class AddHostIdToTemplateInvocation < ActiveRecord::Migration
+  class FakeTemplateInvocation < ActiveRecord::Base
+    set_table_name 'template_invocations'
+  end
+
+  def up
+    add_column :template_invocations, :host_id, :integer
+    add_foreign_key "template_invocations", "hosts", :name => "template_invocations_hosts_id_fk", :column => 'host_id'
+    FakeTemplateInvocation.reset_column_information
+
+    say 'Migrating existing execution locks to explicit relations, this may take a while'
+    FakeTemplateInvocation.all.each do |template_invocation|
+      task = ForemanTasks::Task.for_action_types('Actions::RemoteExecution::RunHostJob').joins(:locks).where(
+        :'foreman_tasks_locks.resource_type' => 'TemplateInvocation',
+        :'foreman_tasks_locks.resource_id' => template_invocation.id).first
+      next if task.nil? # skip invocations from very early versions of remote executions
+      host_id = task.locks.where(:'foreman_tasks_locks.resource_type' => 'Host::Managed').first.resource_id
+      next unless Host.find_by_id(host_id)
+
+      template_invocation.host_id = host_id
+      template_invocation.save!
+    end
+  end
+
+  def down
+    remove_foreign_key "template_invocations", :name => "template_invocations_hosts_id_fk"
+    remove_column :template_invocations, :host_id
+  end
+end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -48,10 +48,32 @@ module ForemanRemoteExecution
                                                 'api/v2/job_invocations' => [:create] }, :resource_type => 'JobInvocation'
           permission :view_job_invocations, { :job_invocations => [:index, :show, :auto_complete_search], :template_invocations => [:show],
                                               'api/v2/job_invocations' => [:index, :show, :output] }, :resource_type => 'JobInvocation'
+          permission :execute_template_invocation, {}, :resource_type => 'TemplateInvocation'
+          # this permissions grants user to get auto completion hints when setting up filters
+          permission :filter_autocompletion_for_template_invocation, { :template_invocations => [ :auto_complete_search, :index ] },
+                     :resource_type => 'TemplateInvocation'
         end
 
-        # Add a new role called 'ForemanRemoteExecution' if it doesn't exist
-        # role 'ForemanRemoteExecution', [:view_foreman_remote_execution]
+        USER_PERMISSIONS = [
+          :view_job_templates,
+          :view_job_invocations,
+          :create_job_invocations,
+          :execute_template_invocation,
+          :view_hosts,
+          :view_smart_proxies
+        ]
+        MANAGER_PERMISSIONS = USER_PERMISSIONS + [
+          :destroy_job_templates,
+          :edit_job_templates,
+          :create_job_templates,
+          :lock_job_templates,
+          :view_audit_logs,
+          :filter_autocompletion_for_template_invocation
+        ]
+
+        # Add a new role called 'Remote Execution User ' if it doesn't exist
+        role 'Remote Execution User', USER_PERMISSIONS
+        role 'Remote Execution Manager', MANAGER_PERMISSIONS
 
         # add menu entry
         menu :top_menu, :job_templates,


### PR DESCRIPTION
There are couple of things that has to be solved
* we have to link host of template_invocation somehow
* autocompletion in filters does not work, didn't have time to find why the path is wrong
* if the execution fails we don't display any nice message, in RunHostsJob we just know that sub task failed