### PR TITLE
fixes #11634 - allow customization of ssh user

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -25,7 +25,8 @@ module Actions
         link!(job_invocation)
         link!(template_invocation)
 
-        plan_action(RunProxyCommand, proxy, hostname, script, { :connection_options => connection_options })
+        provider = template_invocation.template.provider_type.to_s
+        plan_action(RunProxyCommand, proxy, hostname, script, { :connection_options => connection_options }.merge(provider_settings(provider, host)))
         plan_self
       end
 
@@ -60,6 +61,15 @@ module Actions
         end
 
         return host.fqdn
+      end
+
+      def provider_settings(provider, host)
+        case provider
+        when 'Ssh'
+          { :ssh_user => host.params['remote_execution_ssh_user'] || Setting[:remote_execution_ssh_user] }
+        else
+          {}
+        end
       end
     end
   end

--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -28,6 +28,7 @@ module ForemanRemoteExecution
       params = params_without_remote_execution
       keys = remote_execution_ssh_keys
       params['remote_execution_ssh_keys'] = keys unless keys.blank?
+      params['remote_execution_ssh_user'] = Setting[:remote_execution_ssh_user] unless params.key?('remote_execution_ssh_user')
       params
     end
 

--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -14,6 +14,9 @@ class Setting::RemoteExecution < Setting
                  "If locations or organizations are enabled, the search will be limited to the host's " +
                  "organization or location."),
                  true),
+        self.set('remote_execution_ssh_user',
+                 N_("Default user to use for SSH.  You may override per host by setting a parameter called remote_execution_ssh_user."),
+                 'root'),
       ].each { |s| self.create! s.update(:category => "Setting::RemoteExecution") }
     end
 

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -9,11 +9,30 @@ describe ForemanRemoteExecution::HostExtensions do
 
   after { User.current = nil }
 
+  context 'ssh user' do
+    let(:host) { FactoryGirl.build(:host, :with_execution) }
+    let(:sshkey) { 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQ foo@example.com' }
+
+    before do
+      SmartProxy.any_instance.stubs(:pubkey).returns(sshkey)
+      Setting[:remote_execution_ssh_user] = 'root'
+    end
+
+    it 'has ssh user in the parameters' do
+      host.params['remote_execution_ssh_user'].must_equal Setting[:remote_execution_ssh_user]
+    end
+
+    it 'can override ssh user' do
+      host.host_parameters << FactoryGirl.build(:host_parameter, :name => 'remote_execution_ssh_user', :value => 'amy')
+      host.params['remote_execution_ssh_user'].must_equal 'amy'
+    end
+  end
+
   context 'ssh keys' do
     let(:host) { FactoryGirl.build(:host, :with_execution) }
+    let(:sshkey) { 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQ foo@example.com' }
 
     it 'has ssh keys in the parameters' do
-      sshkey = 'ssh-rsa AAAAB3NzaC1yc2EAAAABJQ foo@example.com'
       SmartProxy.any_instance.stubs(:pubkey).returns(sshkey)
       host.remote_execution_ssh_keys.must_include sshkey
     end


### PR DESCRIPTION
Greatly simplified after discussing with @iNecas  this morning:

- Global setting `remote_execution_ssh_user` is used by default
- Parameter of same name can be set to allow customization - let user set user names as granularly as they want by using parameter hierarchy: per host, per host group, environment, etc.

Accompanies https://github.com/theforeman/smart_proxy_remote_execution_ssh/pull/10
