### PR TITLE
fixes #12407 - show 0 hosts in count and preview when there's no query

### DIFF
--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -119,7 +119,11 @@ class JobInvocationComposer
   end
 
   def targeted_hosts
-    Host.authorized(Targeting::RESOLVE_PERMISSION, Host).search_for(displayed_search_query)
+    if displayed_search_query.blank?
+      Host.where('1 = 0')
+    else
+      Host.authorized(Targeting::RESOLVE_PERMISSION, Host).search_for(displayed_search_query)
+    end
   end
 
   def targeted_hosts_count

--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -317,13 +317,13 @@ describe JobInvocationComposer do
       end
 
       describe '#targeted_hosts_count' do
+        let(:host) { FactoryGirl.create(:host) }
+
         it 'obeys authorization' do
-          composer
+          composer.stubs(:displayed_search_query => "name = #{host.name}")
           Host.expects(:authorized).with(:view_hosts, Host).returns(Host.scoped)
           composer.targeted_hosts_count
         end
-
-        let(:host) { FactoryGirl.create(:host) }
 
         it 'searches hosts based on displayed_search_query' do
           composer.stubs(:displayed_search_query => "name = #{host.name}")
@@ -332,6 +332,11 @@ describe JobInvocationComposer do
 
         it 'returns 0 for queries with syntax errors' do
           composer.stubs(:displayed_search_query => "name = ")
+          composer.targeted_hosts_count.must_equal 0
+        end
+
+        it 'returns 0 when no query is present' do
+          composer.stubs(:displayed_search_query => '')
           composer.targeted_hosts_count.must_equal 0
         end
       end


### PR DESCRIPTION
Otherwise when there's no query, it shows you all hosts