### PR TITLE
Fixes #12437, refs #12288 - better handling of unexpected states

### DIFF
--- a/app/lib/actions/remote_execution/helpers/live_output.rb
+++ b/app/lib/actions/remote_execution/helpers/live_output.rb
@@ -1,0 +1,17 @@
+module Actions
+  module RemoteExecution
+    module Helpers
+      module LiveOutput
+        def exception_to_output(context, exception, timestamp = Time.now)
+          format_output(context + ": #{exception.class} - #{exception.message}", 'debug', timestamp)
+        end
+
+        def format_output(message, type = 'debug', timestamp = Time.now)
+          { 'output_type' => type,
+            'output' => message,
+            'timestamp' => timestamp.to_f }
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -2,6 +2,8 @@ module Actions
   module RemoteExecution
     class RunHostJob < Actions::EntryAction
 
+      include Actions::RemoteExecution::Helpers::LiveOutput
+
       def resource_locks
         :link
       end
@@ -42,7 +44,12 @@ module Actions
       end
 
       def live_output
-        planned_actions(RunProxyCommand).first.live_output
+        proxy_command_action = planned_actions(RunProxyCommand).first
+        if proxy_command_action
+          proxy_command_action.live_output
+        else
+          execution_plan.errors.map { |e| exception_to_output(_('Failed to initialize command'), e) }
+        end
       end
 
       def humanized_name

--- a/app/lib/actions/remote_execution/run_proxy_command.rb
+++ b/app/lib/actions/remote_execution/run_proxy_command.rb
@@ -68,8 +68,9 @@ module Actions
 
       def finalized_output
         records = []
-        if self.output[:proxy_output].present?
-          records.concat(self.output[:proxy_output].fetch(:result, []))
+
+        if proxy_result.present?
+          records.concat(proxy_result)
         else
           records << format_output(_('No output'))
         end
@@ -80,6 +81,10 @@ module Actions
           records << format_output(_("Job finished with error") + ": #{run_step.error.exception_class} - #{run_step.error.message}", 'debug', task.ended_at)
         end
         return records
+      end
+
+      def proxy_result
+        self.output.fetch(:proxy_output, {}).fetch(:result, []) || []
       end
     end
   end

--- a/app/lib/actions/remote_execution/run_proxy_command.rb
+++ b/app/lib/actions/remote_execution/run_proxy_command.rb
@@ -3,6 +3,7 @@ module Actions
     class RunProxyCommand < Actions::ProxyAction
 
       include ::Dynflow::Action::Cancellable
+      include Actions::RemoteExecution::Helpers::LiveOutput
 
       def plan(proxy, hostname, script, options = {})
         options = { :effective_user => nil }.merge(options)
@@ -79,16 +80,6 @@ module Actions
           records << format_output(_("Job finished with error") + ": #{run_step.error.exception_class} - #{run_step.error.message}", 'debug', task.ended_at)
         end
         return records
-      end
-
-      def exception_to_output(context, exception, timestamp = Time.now)
-        format_output(context + ": #{exception.class} - #{exception.message}", 'debug', timestamp)
-      end
-
-      def format_output(message, type = 'debug', timestamp = Time.now)
-        { 'output_type' => type,
-          'output' => message,
-          'timestamp' => timestamp.to_f }
       end
     end
   end


### PR DESCRIPTION
Don't raise cryptic errors when there is no reasonable output comming from the
proxy.

Also, improve the error message a proxy in missing (and proxy command fails in planning
phase). There is still work to be done to get to the erors from the job hosts list,
but this requires some changes on dynflow side that I don't want to rush to get
into stable relese. But at least, when going to the `Monitor -> Tasks` and showing
the failed `RuhHostJob` task, one doesn't see:

    undefined method `live_output' for nil:NilClass (NoMethodError)