### PR TITLE
Fixes #12288 - disable transactions for plan phase in run host job action

### DIFF
--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "deface"
   s.add_dependency "rails", "~> 3.2.8"
+  s.add_dependency "dynflow", "~> 0.8.8"
   s.add_dependency "foreman-tasks", "~> 0.7.6"
 
   s.add_development_dependency 'rubocop'


### PR DESCRIPTION
Otherwise we lose the link from the task to the job invocation. Since
in this case, the execution plan is not driving a transaction between
local database and external systems, we can turn this logic off for
this action.

With this patch (that depends on https://github.com/Dynflow/dynflow/pull/174),
when there is an issue with running the job on proxy (as in case when the proxy
is just down), we show the tasks on per-host part as failed, with posibility to
show details, as with any other error.