### PR TITLE
Fixes unknown column errors on last_task

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -45,7 +45,7 @@ class JobInvocationsController < ApplicationController
   end
 
   def index
-    @job_invocations = resource_base.search_for(params[:search]).paginate(:page => params[:page]).with_last_task.order(params[:order] || '"job_invocations"."id" DESC')
+    @job_invocations = resource_base.search_for(params[:search]).paginate(:page => params[:page]).with_task.order(params[:order] || '"job_invocations"."id" DESC')
   end
 
   # refreshes the form

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -107,7 +107,7 @@ module RemoteExecutionHelper
                          :title => _('Rerun on failed hosts'))
     end
     if authorized_for(:permission => :view_foreman_tasks, :auth_object => task)
-      buttons << link_to(_("Last Job Task"), foreman_tasks_task_path(task),
+      buttons << link_to(_("Job Task"), foreman_tasks_task_path(task),
                          :class => "btn btn-default",
                          :title => _('See the last task details'))
     end

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -30,13 +30,13 @@ class JobInvocation < ActiveRecord::Base
 
   scoped_search :on => [:job_name], :complete_value => true
 
-  scoped_search :in => :last_task, :on => :started_at, :rename => 'started_at', :complete_value => true
-  scoped_search :in => :last_task, :on => :ended_at, :rename => 'ended_at', :complete_value => true
+  scoped_search :in => :task, :on => :started_at, :rename => 'started_at', :complete_value => true
+  scoped_search :in => :task, :on => :ended_at, :rename => 'ended_at', :complete_value => true
 
   belongs_to :triggering, :class_name => 'ForemanTasks::Triggering'
   has_one :recurring_logic, :through => :triggering, :class_name => 'ForemanTasks::RecurringLogic'
 
-  scope :with_last_task, -> { joins('LEFT JOIN "foreman_tasks_tasks" ON "foreman_tasks_tasks"."id" = "job_invocations"."last_task_id"') }
+  scope :with_task, -> { joins('LEFT JOIN "foreman_tasks_tasks" ON "foreman_tasks_tasks"."id" = "job_invocations"."task_id"') }
 
   attr_accessor :start_before
   attr_writer :start_at

--- a/app/views/job_invocations/index.html.erb
+++ b/app/views/job_invocations/index.html.erb
@@ -22,7 +22,7 @@
         <td><%= invocation_count(invocation, :output_key => :failed_count) %></td>
         <td><%= invocation_count(invocation, :output_key => :pending_count) %></td>
         <td><%= invocation_count(invocation, :output_key => :total_count) %></td>
-	<td><%= time_ago(invocation.last_task.try(:started_at)) %></td>
+	<td><%= time_ago(invocation.task.try(:started_at)) %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
#44 broke jobs index and maybe something more because of renaming `last_task_id` column on `job_invocations` table to `task_id`.