### PR TITLE
fixes #12753 - exit status should be last item

### DIFF
--- a/app/lib/actions/remote_execution/run_proxy_command.rb
+++ b/app/lib/actions/remote_execution/run_proxy_command.rb
@@ -76,11 +76,16 @@ module Actions
         end
 
         if exit_status
-          records << format_output(_("Exit status: %s") % exit_status, 'stdout', task.ended_at)
+          records << format_output(_("Exit status: %s") % exit_status, 'stdout', final_timestamp(records))
         elsif run_step && run_step.error
-          records << format_output(_("Job finished with error") + ": #{run_step.error.exception_class} - #{run_step.error.message}", 'debug', task.ended_at)
+          records << format_output(_("Job finished with error") + ": #{run_step.error.exception_class} - #{run_step.error.message}", 'debug', final_timestamp(records))
         end
         return records
+      end
+
+      def final_timestamp(records)
+        return task.ended_at if records.blank?
+        records.last.fetch('timestamp', task.ended_at) + 1
       end
 
       def proxy_result


### PR DESCRIPTION
The problem here is `task.ended_at` is according to the Foreman server's time, whereas other output lines happen in respect to the proxy's.  In my case, the two servers were several seconds off, causing "Exit status" to render in the middle of the output:

![exit status](https://cloud.githubusercontent.com/assets/429763/11723025/18c3fbee-9f3a-11e5-97ba-c5408411326b.png)

The simplicity of sorting by time though is nice, so just put exit status at  Sat, 20 Nov 2286 17:46:39 GMT, a.k.a 9999999999 seconds from the epoch.

Any other suggestions to handle this?

