### PR TITLE
Fixes #12769 - fix ajax refresh of invocation form

### DIFF
--- a/app/views/job_invocations/refresh.js.erb
+++ b/app/views/job_invocations/refresh.js.erb
@@ -1,1 +1,2 @@
-$('form#job_invocation_form').html("<%=j render :partial => 'form' %>");
+$('form#job_invocation_form').replaceWith("<%=j render :partial => 'form' %>");
+$('#job_invocation_form').find('a[rel="popover"]').popover();


### PR DESCRIPTION
Use `replaceWith` instead of `html` for updating the form data
and re-initiate the bootstrap `popup` to fix the inline help.