### PR TITLE
Refs #10753 - update foreman-tasks to 0.7.8

### DIFF
--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "deface"
   s.add_dependency "rails", "~> 3.2.8"
   s.add_dependency "dynflow", "~> 0.8.8"
-  s.add_dependency "foreman-tasks", "~> 0.7.6"
+  s.add_dependency "foreman-tasks", "~> 0.7.8"
 
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rdoc'


### PR DESCRIPTION
There were some changes since 0.7.6 that are required by the recurring logic
so we should make sure we have the latest version available.