### PR TITLE
Fixes #13011 - use standard way to join with task

### DIFF
--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -36,7 +36,11 @@ class JobInvocation < ActiveRecord::Base
   belongs_to :triggering, :class_name => 'ForemanTasks::Triggering'
   has_one :recurring_logic, :through => :triggering, :class_name => 'ForemanTasks::RecurringLogic'
 
-  scope :with_task, -> { joins('LEFT JOIN foreman_tasks_tasks ON foreman_tasks_tasks.id = job_invocations.task_id') }
+  if Rails::VERSION::MAJOR >= 4
+    scope :with_task, -> { references(:task) }
+  else
+    scope :with_task, -> { joins('LEFT JOIN foreman_tasks_tasks ON foreman_tasks_tasks.id = job_invocations.task_id') }
+  end
 
   default_scope -> { order('job_invocations.id DESC') }
 


### PR DESCRIPTION
Otherwise, the scoped search has issues producing valid sql