### PR TITLE
fixes #13088 - use !blank? instead of present? in ssh key snippet

### DIFF
--- a/app/views/unattended/snippets/_remote_execution_ssh_keys.erb
+++ b/app/views/unattended/snippets/_remote_execution_ssh_keys.erb
@@ -3,7 +3,7 @@
   name: remote_execution_ssh_keys
 %>
 
-<% if @host.params['remote_execution_ssh_keys'].present? %>
+<% if !@host.params['remote_execution_ssh_keys'].blank? %>
 <% ssh_user = @host.params['remote_execution_ssh_user'] || 'root' %>
 <% ssh_path = "~#{ssh_user}/.ssh" %>
 


### PR DESCRIPTION
Reported on IRC by a user.  present? not allowed in safemode on Array. I thought I tested this with safemode enabled, but guess not.  stbenjam--
