### PR TITLE
Fixes #13173 - Documentation button links for job invocations/templates

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -90,11 +90,10 @@ module RemoteExecutionHelper
   end
 
   def job_invocations_buttons
-    if authorized_for(hash_for_new_job_invocation_path)
-      link_to(_("Run Job"), new_job_invocation_path,
-              :class => "btn btn-default",
-              :title => _('Run Job'))
-    end
+    [
+      documentation_button_rex('3.2ExecutingaJob'),
+      display_link_if_authorized(_("Run Job"), hash_for_new_job_invocation_path)
+    ]
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -194,4 +193,14 @@ module RemoteExecutionHelper
     end
   end
 
+  def documentation_button_rex(section = '')
+    url = 'http://theforeman.org/plugins/foreman_remote_execution/' +
+      "#{ForemanRemoteExecution::VERSION.split('.').take(2).join('.')}/index.html#" +
+      section
+    link_to(
+      icon_text('help', _('Documentation'),
+                :class => 'icon-white', :kind => 'pficon'),
+      url,
+      :rel => 'external', :class => 'btn btn-info', :target => '_blank')
+  end
 end

--- a/app/views/job_templates/index.html.erb
+++ b/app/views/job_templates/index.html.erb
@@ -3,7 +3,9 @@
 <%= javascript 'template_input' %>
 
 <% title _("Job Templates") %>
-<% title_actions display_link_if_authorized(_("New Job Template"), hash_for_new_job_template_path) %>
+<% title_actions(documentation_button_rex('3.1JobTemplates'),
+                 display_link_if_authorized(_("New Job Template"),
+                                            hash_for_new_job_template_path)) %>
 
 <table class="table table-bordered table-striped table-two-pane">
   <thead>


### PR DESCRIPTION
As the rest of Foreman, this plugin can benefit from links to the
documentation straight from the app. Two easy places to start are the
job invocations/ job templates indexes.