### PR TITLE
Fixes #13130 - save template invocations for each host

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -49,7 +49,7 @@ class JobInvocationsController < ApplicationController
   end
 
   def show
-    @job_invocation = resource_base.find(params[:id])
+    @job_invocation = resource_base.includes(:template_invocations => :run_host_job_task).find(params[:id])
     @auto_refresh = @job_invocation.task.try(:pending?)
     hosts_base = @job_invocation.targeting.hosts.authorized(:view_hosts, Host)
     @hosts = hosts_base.search_for(params[:search], :order => params[:order] || 'name ASC').paginate(:page => params[:page])

--- a/app/controllers/template_invocations_controller.rb
+++ b/app/controllers/template_invocations_controller.rb
@@ -6,9 +6,9 @@ class TemplateInvocationsController < ApplicationController
   end
 
   def show
-    @template_invocation_task = ForemanTasks::Task.find(params[:id])
-    @template_invocation = @template_invocation_task.locks.where(:resource_type => 'TemplateInvocation').first.try(:resource)
-    @host = @template_invocation_task.locks.where(:resource_type => 'Host::Managed').first.try(:resource)
+    @template_invocation = TemplateInvocation.find(params[:id])
+    @template_invocation_task = @template_invocation.run_host_job_task
+    @host = @template_invocation.host
     @auto_refresh = @template_invocation_task.pending?
     @since = params[:since].to_f if params[:since].present?
     @line_sets = @template_invocation_task.main_action.live_output

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -79,15 +79,14 @@ module RemoteExecutionHelper
     end
   end
 
-  def template_invocation_actions(task, host, job_invocation)
+  def template_invocation_actions(task, host, job_invocation, template_invocation)
     [
       display_link_if_authorized(_('Host detail'), hash_for_host_path(host).merge(:auth_object => host, :permission => :view_hosts)),
       display_link_if_authorized(_('Rerun on %s') % host.name, hash_for_rerun_job_invocation_path(:id => job_invocation, :host_ids => [ host.id ])),
     ]
   end
 
-  def remote_execution_provider_for(task)
-    template_invocation = task.locks.where(:resource_type => 'TemplateInvocation').first.try(:resource) unless task.nil?
+  def remote_execution_provider_for(template_invocation)
     template_invocation.nil? ? _('N/A') : template_invocation.template.provider.humanized_name
   end
 

--- a/app/lib/actions/middleware/bind_job_invocation.rb
+++ b/app/lib/actions/middleware/bind_job_invocation.rb
@@ -6,7 +6,7 @@ module Actions
       def delay(*args)
         schedule_options, job_invocation = args
         if !job_invocation.task_id.nil? && job_invocation.task_id != task.id
-          job_invocation = job_invocation.deep_clone
+          job_invocation = job_invocation.deep_clone!
           args = [schedule_options, job_invocation]
         end
         pass(*args).tap { bind(job_invocation) }

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -12,7 +12,10 @@ module Actions
       def plan(job_invocation, host, template_invocation, proxy)
         action_subject(host, :job_category => job_invocation.job_category, :description => job_invocation.description)
 
-        template_invocation.update_attribute :host_id, host.id
+        template_invocation.host_id = host.id
+        template_invocation.run_host_job_task_id = task.id
+        template_invocation.save!
+
         link!(job_invocation)
         link!(template_invocation)
 

--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -24,8 +24,11 @@ module Actions
         job_invocation = JobInvocation.find(input[:job_invocation_id])
         load_balancer = ProxyLoadBalancer.new
 
+        # composer creates just "pattern" for template_invocations because target is evaluated
+        # during actual run (here) so we build template invocations from these patterns
         job_invocation.targeting.hosts.map do |host|
-          template_invocation = job_invocation.template_invocation_for_host(host)
+          template_invocation = job_invocation.pattern_template_invocation_for_host(host).deep_clone
+          template_invocation.host_id = host.id
           proxy = determine_proxy(template_invocation, host, load_balancer)
           trigger(RunHostJob, job_invocation, host, template_invocation, proxy)
         end

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -9,7 +9,14 @@ class JobTemplate < ::Template
 
   audited :allow_mass_assignment => true
   has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name
-  has_many :template_invocations, :dependent => :destroy, :foreign_key => 'template_id'
+  has_many :all_template_invocations, :dependent => :destroy, :foreign_key => 'template_id', :class_name => 'TemplateInvocation'
+  if Rails::VERSION::MAJOR >= 4
+    has_many :template_invocations, -> { where('host_id IS NOT NULL') }, :foreign_key => 'template_id'
+    has_many :pattern_template_invocations, -> { where('host_id IS NULL') }, :foreign_key => 'template_id', :class_name => 'TemplateInvocation'
+  else
+    has_many :template_invocations, :conditions => 'host_id IS NOT NULL', :foreign_key => 'template_id'
+    has_many :pattern_template_invocations, :conditions => 'host_id IS NULL', :foreign_key => 'template_id', :class_name => 'TemplateInvocation'
+  end
 
   # these can't be shared in parent class, scoped search can't handle STI properly
   # tested with scoped_search 3.2.0

--- a/app/models/template_invocation.rb
+++ b/app/models/template_invocation.rb
@@ -14,6 +14,7 @@ class TemplateInvocation < ActiveRecord::Base
   has_one :targeting, :through => :job_invocation
   belongs_to :host, :class_name => 'Host::Managed', :foreign_key => :host_id
   has_one :host_group, :through => :host, :source => :hostgroup
+  belongs_to :run_host_job_task, :class_name => 'ForemanTasks::Task'
 
   validates_associated :input_values
   validate :provides_required_input_values
@@ -30,8 +31,11 @@ class TemplateInvocation < ActiveRecord::Base
   def deep_clone
     self.dup.tap do |invocation|
       invocation.input_values = self.input_values.map(&:dup)
-      invocation.input_values.each(&:save!)
     end
+  end
+
+  def deep_clone!
+    deep_clone.tap { |clone| clone.input_values.each(&:save!) }
   end
 
   private

--- a/app/views/job_invocations/_host_actions_td.html.erb
+++ b/app/views/job_invocations/_host_actions_td.html.erb
@@ -1,3 +1,3 @@
 <td class="host_actions" id="<%= dom_id(host) %>-actions" data-refresh_required="" data-id="<%= host.id %>">
-  <%= action_buttons(template_invocation_actions(task, host, job_invocation)) %>
+  <%= action_buttons(template_invocation_actions(task, host, job_invocation, template_invocation)) %>
 </td>

--- a/app/views/job_invocations/_host_name_td.html.erb
+++ b/app/views/job_invocations/_host_name_td.html.erb
@@ -1,6 +1,6 @@
 <td class="host_name" id="<%= dom_id(host) %>-name" data-refresh_required="<%= task.nil? ? 'true' : '' %>" data-id="<%= host.id %>">
   <% if task %>
-    <%= link_to_if_authorized host.name, hash_for_template_invocation_path(:id => task).merge(:auth_object => host, :permission => :view_hosts) %>
+    <%= link_to_if_authorized host.name, hash_for_template_invocation_path(:id => template_invocation).merge(:auth_object => host, :permission => :view_hosts) %>
   <% else %>
     <%= host.name %>
   <% end %>

--- a/app/views/job_invocations/_tab_hosts.html.erb
+++ b/app/views/job_invocations/_tab_hosts.html.erb
@@ -26,9 +26,10 @@
 
     <tbody>
     <% hosts.each do |host| %>
-      <% task = job_invocation.sub_task_for_host(host) %>
+      <% template_invocation = job_invocation.template_invocations.find { |template_invocation| template_invocation.host_id == host.id } %>
+      <% task = template_invocation.try(:run_host_job_task) %>
       <tr>
-        <% options = { :host => host, :task => task, :job_invocation => job_invocation } %>
+        <% options = { :host => host, :task => task, :job_invocation => job_invocation, :template_invocation => template_invocation } %>
         <%= render 'host_name_td', options %>
         <%= render 'host_status_td', options %>
         <%= render 'host_actions_td', options %>

--- a/app/views/job_invocations/_tab_overview.html.erb
+++ b/app/views/job_invocations/_tab_overview.html.erb
@@ -13,8 +13,8 @@
   <pre><%= job_invocation.targeting.search_query %></pre>
 
   <%= _('Evaluated at:') %> <%= job_invocation.targeting.resolved_at %><br>
-  <% if job_invocation.template_invocations.size > 1 %>
-    <% job_invocation.template_invocations.each do |template_invocation| %>
+  <% if job_invocation.pattern_template_invocations.size > 1 %>
+    <% job_invocation.pattern_template_invocations.each do |template_invocation| %>
       <%= host_counter template_invocation.template.provider.humanized_name, ForemanTasks::Task::DynflowTask.for_action(Actions::RemoteExecution::RunHostJob).for_resource(template_invocation).uniq.size %>
     <% end %>
   <% end %>
@@ -23,7 +23,7 @@
 
 <div class="col-md-6 infoblock">
   <h4><%= _('Providers and templates') %></h4>
-  <% job_invocation.template_invocations.each do |template_invocation| %>
+  <% job_invocation.pattern_template_invocations.each do |template_invocation| %>
     <h5>
       <b><%= template_invocation.template.name %></b> <%= 'through' %> <%= template_invocation.template.provider.humanized_name %>
     </h5>

--- a/app/views/job_invocations/show.js.erb
+++ b/app/views/job_invocations/show.js.erb
@@ -12,8 +12,11 @@ $('div#status').flot_pie();
   <% if params["host_ids_needing_#{attribute}_update"].present? %>
     var td_element;
     <% Host.authorized(:view_hosts, Host).where(:id => params["host_ids_needing_#{attribute}_update"]).each do |host| %>
+      <% template_invocation = @job_invocation.template_invocations.find { |template_invocation| template_invocation.host_id == host.id } %>
+      <% task = template_invocation.try(:run_host_job_task) %>
+      <% options = { :host => host, :task => task, :job_invocation => @job_invocation, :template_invocation => template_invocation } %>
       td_element= $('#<%= dom_id(host) %>-<%= attribute %>');
-      td_element.replaceWith('<%=j render("host_#{attribute}_td", :host => host, :task => @job_invocation.sub_task_for_host(host), :job_invocation => @job_invocation) %>');
+      td_element.replaceWith('<%=j render("host_#{attribute}_td", options) %>');
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/template_invocations/show.html.erb
+++ b/app/views/template_invocations/show.html.erb
@@ -19,7 +19,7 @@
   <%= preview_box(@template_invocation, @host) %>
 </div>
 
-<div class="terminal" data-refresh-url="<%= template_invocation_path(@template_invocation_task) %>">
+<div class="terminal" data-refresh-url="<%= template_invocation_path(@template_invocation) %>">
   <% if @error %>
     <div class="line error"><%= @error %></div>
   <% else %>

--- a/db/migrate/20160113161916_add_run_host_job_task_id_to_template_invocation.rb
+++ b/db/migrate/20160113161916_add_run_host_job_task_id_to_template_invocation.rb
@@ -1,0 +1,6 @@
+class AddRunHostJobTaskIdToTemplateInvocation < ActiveRecord::Migration
+  def change
+    add_column :template_invocations, :run_host_job_task_id, :string
+    add_index :template_invocations, [:run_host_job_task_id], :name => 'template_invocations_run_host_job_task_id'
+  end
+end

--- a/db/migrate/20160113162007_expand_all_template_invocations.rb
+++ b/db/migrate/20160113162007_expand_all_template_invocations.rb
@@ -1,0 +1,45 @@
+class ExpandAllTemplateInvocations < ActiveRecord::Migration
+  class FakeTemplateInvocation < ActiveRecord::Base
+    self.table_name = 'template_invocations'
+
+    has_many :input_values, :class_name => 'FakeInputValue', :foreign_key => 'template_invocation_id'
+  end
+
+  class FakeInputValue < ActiveRecord::Base
+    self.table_name = 'template_invocation_input_values'
+  end
+
+  def up
+    # make all template invocations pattern
+    FakeTemplateInvocation.update_all 'host_id = NULL'
+
+    # expand all pattern template invocations and link RunHostJob
+    JobInvocation.joins(:targeting).where("#{Targeting.table_name}.resolved_at IS NOT NULL").includes([ :pattern_template_invocations, :targeting, :sub_tasks => :locks ]).each do |job_invocation|
+      job_invocation.pattern_template_invocations.each do |pattern_template_invocation|
+        job_invocation.targeting.hosts.each do |host|
+          task = job_invocation.sub_tasks.find do |sub_task|
+            sub_task.locks.find { |lock| lock.resource_type == 'Host::Managed' && lock.resource_id == host.id && lock.name == 'link_resource'}.present?
+          end
+          next if task.nil? # job invocations with static targeting that failed too early
+
+          expanded_template_invocation = FakeTemplateInvocation.new
+          expanded_template_invocation.attributes = pattern_template_invocation.dup.attributes
+          pattern_template_invocation.input_values.each do |input_value|
+            input_value = input_value.dup
+            expanded_template_invocation.input_values.build(input_value.attributes.except('template_invocation_id'))
+          end
+          expanded_template_invocation.host_id = host.id
+          expanded_template_invocation.run_host_job_task_id = task.id
+          expanded_template_invocation.save!
+        end
+      end
+    end
+  end
+
+  def down
+    # we can't determine the last host for pattern, but keeping template invocations as pattern is safe
+    JobInvocation.joins(:targeting).where("#{Targeting.table_name}.resolved_at IS NOT NULL").includes(:template_invocations).each do |job_invocation|
+      job_invocation.template_invocations.delete_all
+    end
+  end
+end

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -34,7 +34,7 @@ FactoryGirl.define do
     f.description_format '%{job_category}'
     trait :with_template do
       after(:build) do |invocation, evaluator|
-        invocation.template_invocations << FactoryGirl.build(:template_invocation)
+        invocation.pattern_template_invocations << FactoryGirl.build(:template_invocation)
       end
 
     end

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -39,8 +39,7 @@ module ForemanRemoteExecution
     end
 
     it 'triggers the RunHostJob actions on the resolved hosts in run phase' do
-      template_invocation = job_invocation.template_invocation_for_host(host)
-      action.expects(:trigger).with(Actions::RemoteExecution::RunHostJob, job_invocation, host, template_invocation, proxy)
+      action.expects(:trigger).with() { |*args| args[0] == Actions::RemoteExecution::RunHostJob }
       action.create_sub_plans
     end
 

--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -205,7 +205,7 @@ describe JobInvocationComposer do
         end
       end
 
-      describe '#template_invocations' do
+      describe '#pattern template_invocations' do
         let(:ssh_params) do
           { :job_template_id => trying_job_template_1.id.to_s,
             :job_templates => {
@@ -216,9 +216,9 @@ describe JobInvocationComposer do
           }
         end
         let(:params) { { :job_invocation => { :providers => { :ssh => ssh_params } } }.with_indifferent_access }
-        let(:invocations) { composer.template_invocations }
+        let(:invocations) { composer.pattern_template_invocations }
 
-        it 'builds template invocations based on passed params and it filters out wrong inputs' do
+        it 'builds pattern template invocations based on passed params and it filters out wrong inputs' do
           invocations.size.must_equal 1
           invocations.first.input_values.size.must_equal 1
           invocations.first.input_values.first.value.must_equal 'value1'
@@ -238,7 +238,7 @@ describe JobInvocationComposer do
         let(:params) { { :job_invocation => { :providers => { :ssh => ssh_params } } }.with_indifferent_access }
         let(:template_invocation) do
           trying_job_template_1.effective_user.update_attributes(:overridable => overridable, :value => 'template user')
-          composer.template_invocations.first
+          composer.pattern_template_invocations.first
         end
 
         before do
@@ -424,7 +424,7 @@ describe JobInvocationComposer do
           composer
           composer.job_invocation.expects(:valid?).returns(false)
           composer.targeting.expects(:valid?).returns(false)
-          composer.template_invocations.each { |invocation| invocation.expects(:valid?).returns(false) }
+          composer.pattern_template_invocations.each { |invocation| invocation.expects(:valid?).returns(false) }
           refute composer.valid?
         end
       end
@@ -507,11 +507,11 @@ describe JobInvocationComposer do
         end
 
         it 'keeps job template ids' do
-          new_composer.job_template_ids.must_equal existing.template_invocations.map(&:template_id)
+          new_composer.job_template_ids.must_equal existing.pattern_template_invocations.map(&:template_id)
         end
 
         it 'keeps template invocations and their values' do
-          new_composer.template_invocations.size.must_equal existing.template_invocations.size
+          new_composer.pattern_template_invocations.size.must_equal existing.pattern_template_invocations.size
         end
 
       end
@@ -539,7 +539,7 @@ describe JobInvocationComposer do
         assert composer.save!
         assert_equal bookmark, composer.job_invocation.targeting.bookmark
         assert_equal composer.job_invocation.targeting.user, User.current
-        refute_empty composer.job_invocation.template_invocations
+        refute_empty composer.job_invocation.pattern_template_invocations
       end
     end
 
@@ -554,7 +554,7 @@ describe JobInvocationComposer do
       it 'creates invocation with a search query' do
         assert composer.save!
         assert_equal 'some hosts', composer.job_invocation.targeting.search_query
-        refute_empty composer.job_invocation.template_invocations
+        refute_empty composer.job_invocation.pattern_template_invocations
       end
     end
 
@@ -569,7 +569,7 @@ describe JobInvocationComposer do
 
       it 'finds the inputs by name' do
         assert composer.save!
-        assert_equal 1, composer.template_invocations.first.input_values.count
+        assert_equal 1, composer.pattern_template_invocations.first.input_values.count
       end
     end
 
@@ -583,7 +583,7 @@ describe JobInvocationComposer do
           :inputs => {input1.name => 'some_value'}}
       end
 
-      let(:template_invocation) { composer.job_invocation.template_invocations.first }
+      let(:template_invocation) { composer.job_invocation.pattern_template_invocations.first }
 
       it 'sets the effective user based on the input' do
         assert composer.save!

--- a/test/unit/job_invocation_test.rb
+++ b/test/unit/job_invocation_test.rb
@@ -30,16 +30,16 @@ describe JobInvocation do
     let(:job_invocation) { FactoryGirl.create(:job_invocation, :with_template) }
 
     before do
-      input = job_invocation.template_invocations.first.template.template_inputs.create!(:name => 'foo', :required => true, :input_type => 'user')
+      input = job_invocation.pattern_template_invocations.first.template.template_inputs.create!(:name => 'foo', :required => true, :input_type => 'user')
       @input_value = FactoryGirl.create(:template_invocation_input_value,
-                                        :template_invocation =>  job_invocation.template_invocations.first,
-                                        :template_input      => input)
+                                        :template_invocation => job_invocation.pattern_template_invocations.first,
+                                        :template_input => input)
       job_invocation.reload
-      job_invocation.template_invocations.first.reload
+      job_invocation.pattern_template_invocations.first.reload
     end
 
-    it { refute job_invocation.reload.template_invocations.empty? }
-    it { refute job_invocation.reload.template_invocations.first.input_values.empty? }
+    it { refute job_invocation.reload.pattern_template_invocations.empty? }
+    it { refute job_invocation.reload.pattern_template_invocations.first.input_values.empty? }
 
     it 'validates required inputs have values' do
       assert job_invocation.valid?

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -91,11 +91,11 @@ describe JobTemplate do
 
   context 'there is existing template invocation of a job template' do
     let(:job_invocation) { FactoryGirl.create(:job_invocation, :with_template) }
-    let(:job_template) { job_invocation.template_invocations.first.template }
+    let(:job_template) { job_invocation.pattern_template_invocations.first.template }
 
     describe 'job template deletion' do
       it 'succeeds' do
-        job_template.template_invocations.wont_be_empty
+        job_template.pattern_template_invocations.wont_be_empty
         assert job_template.destroy
       end
     end

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -55,7 +55,7 @@ describe RemoteExecutionProvider do
     end
 
     let(:job_invocation) { FactoryGirl.create(:job_invocation, :with_template) }
-    let(:template_invocation) { job_invocation.template_invocations.first }
+    let(:template_invocation) { job_invocation.pattern_template_invocations.first }
     let(:host) { FactoryGirl.create(:host) }
     let(:proxy_options) { SSHExecutionProvider.proxy_command_options(template_invocation, host) }
 


### PR DESCRIPTION
This commit introduces so called pattern template invocation which is
created by job composer as a pattern for real template invocation that
being created during dynflow action run. Pattern template invocation
holds all information from composer (e.g. input values) except target
host which is evaluated just during dynflow action run phase.