### PR TITLE
Fixes #13312 - enable filtering on template name

### DIFF
--- a/app/models/template_invocation.rb
+++ b/app/models/template_invocation.rb
@@ -23,6 +23,7 @@ class TemplateInvocation < ActiveRecord::Base
   scoped_search :in => :host, :on => :name, :rename => 'host.name', :complete_value => true
   scoped_search :in => :host_group, :on => :name, :rename => 'host_group.name', :complete_value => true
   scoped_search :in => :template, :on => :job_category, :complete_value => true
+  scoped_search :in => :template, :on => :name, :complete_value => true
 
   def to_action_input
     { :id => id, :name => template.name }


### PR DESCRIPTION
this is needed for execute permission filters, we used to use job_name for that