### PR TITLE
Fixes #13342 - Align Remote execution checkbox in NICs modal

### DIFF
--- a/app/overrides/foreman/nics/_execution_interface.html.erb
+++ b/app/overrides/foreman/nics/_execution_interface.html.erb
@@ -1,1 +1,9 @@
-<%= checkbox_f f, :execution, :help_inline => _("The execution interface is used for remote execution"), :class => :interface_execution %>
+<%= checkbox_f(
+  f,
+  :execution,
+  :help_inline => popover(
+    '', _("The execution interface is used for remote execution"),
+    :rel => 'popover-modal'),
+  :label_size => 'col-md-3',
+  :label => _('Remote execution'),
+  :class => :interface_execution) %>


### PR DESCRIPTION
Notice the label change to 'Remote execution', which I think it's more
clear. I also changed the help inline to a popover as per Patternfly
guidelines https://www.patternfly.org/patterns/field-level-help/

before: ![](http://i.imgur.com/pzoelrF.png)
after: ![](http://i.imgur.com/IDZiBk5.png)