### PR TITLE
Fixes #13439 - authorized_files is created at the user directory but owner is root

### DIFF
--- a/app/views/unattended/snippets/_remote_execution_ssh_keys.erb
+++ b/app/views/unattended/snippets/_remote_execution_ssh_keys.erb
@@ -15,4 +15,5 @@ EOF
 
 chmod 700 <%= ssh_path %>
 chmod 600 <%= ssh_path %>/authorized_keys
+chown -R <%= "#{ssh_user}:#{ssh_user}" %> <%= ssh_path %>
 <% end %>


### PR DESCRIPTION
As noticed by ewoud on
https://github.com/theforeman/community-templates/pull/233 , during
provision the authorized_keys file is created under the 'ssh_user'
directory but the user may not be able to read or write it after that,
since it was created by root.

Fix is simple, just chown the directory and file as 'ssh_user'.