### PR TITLE
Fixes #10751 - Support for concurrency control

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -45,6 +45,11 @@ module Api
             param :start_before, DateTime, :required => false, :desc => N_('Indicates that the action should be cancelled if it cannot be started before this time.')
           end
 
+          param :concurrency_control, Hash, :desc => N_('Control concurrency level and distribution over time') do
+            param :time_span, Integer, :desc => N_('Distribute tasks over N seconds')
+            param :concurrency_level, Integer, :desc => N_('Run at most N tasks at a time')
+          end
+
           param :bookmark_id, Integer, :required => false
           param :search_query, Integer, :required => false
           param :description_format, String, :required => false, :desc => N_('Override the description format from the template for this invocation only')

--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -27,7 +27,6 @@ class JobInvocationsController < ApplicationController
   def rerun
     job_invocation = resource_base.find(params[:id])
     @composer = JobInvocationComposer.from_job_invocation(job_invocation)
-
     if params[:failed_only]
       host_ids = job_invocation.failed_host_ids
       @composer.search_query = @composer.targeting.build_query_from_hosts(host_ids)

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -85,6 +85,11 @@
       </fieldset>
     <% end %>
 
+    <div class="advanced hidden">
+      <%= number_f f, :concurrency_level, :label => _('Concurrency level'), :placeholder => 'N', :min => 1, :help_inline => N_("Run at most N tasks at a time") %>
+      <%= number_f f, :time_span, :label => _('Time span'), :placeholder => 'N', :min => 1, :help_inline => N_("Distribute execution over N seconds")  %>
+    </div>
+
     <div class="form-group advanced hidden">
       <label class="col-md-2 control-label"><%= _('Type of query') %></label>
 
@@ -93,16 +98,15 @@
         <%= radio_button_f targeting_fields, :targeting_type, :value => Targeting::DYNAMIC_TYPE, :text => _(Targeting::TYPES[Targeting::DYNAMIC_TYPE]) %>
       </div>
 
-                        <span class="help-inline"><%= popover(_('Explanation'),
-                                                              _("Type has impact on when is the query evaulated to hosts.<br><ul><li><b>Static</b> - evaluates just after you submit this form</li><li><b>Dynamic</b> - evaluates just before the execution is started, so if it's planed in future, targeted hosts set may change before it</li></ul>")) %>
-                        </span>
+      <span class="help-inline"><%= popover(_('Explanation'),
+                                            _("Type has impact on when is the query evaulated to hosts.<br><ul><li><b>Static</b> - evaluates just after you submit this form</li><li><b>Dynamic</b> - evaluates just before the execution is started, so if it's planed in future, targeted hosts set may change before it</li></ul>")) %>
+      </span>
     </div>
   <% end %>
 
-
   <%= trigger_selector f, @composer.triggering %>
-  <%= render :partial => 'preview_hosts_modal' %>
 
+  <%= render :partial => 'preview_hosts_modal' %>
 
   <%= submit_or_cancel f %>
 <% end %>

--- a/db/migrate/20160203104056_add_concurrency_options_to_job_invocation.rb
+++ b/db/migrate/20160203104056_add_concurrency_options_to_job_invocation.rb
@@ -1,0 +1,6 @@
+class AddConcurrencyOptionsToJobInvocation < ActiveRecord::Migration
+  def change
+    add_column :job_invocations, :concurrency_level, :integer, :null => true
+    add_column :job_invocations, :time_span, :integer, :null => true
+  end
+end

--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = `git ls-files doc`.split("\n") + Dir['README*', 'LICENSE']
 
   s.add_dependency 'deface'
-  s.add_dependency 'dynflow', '~> 0.8.8'
+  s.add_dependency 'dynflow', '~> 0.8.10'
   s.add_dependency 'foreman-tasks', '~> 0.7.11'
 
   s.add_development_dependency 'rubocop'


### PR DESCRIPTION
Allows to limit concurrency level or distribute sub tasks over the provided time window (or both).

Quick overview:
- all sub plans get planned immediately, their `run` phases get held back until it is possible to start them without breaking the limits
- sub plans which are not started within the time window are cancelled
- sub plans which fail in the plan phase ignore the limits and are finished immediately

Requires Dynflow/dynflow/pull/179