### PR TITLE
fixes #10756 - developer api for registering features and templates

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -56,9 +56,8 @@ module Api
       def create
         composer = JobInvocationComposer.from_api_params(job_invocation_params)
         composer.save!
+        composer.trigger
         @job_invocation = composer.job_invocation
-        @job_invocation.generate_description! if @job_invocation.description.blank?
-        composer.triggering.trigger(::Actions::RemoteExecution::RunHostsJob, @job_invocation)
         process_response @job_invocation
       end
 

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -55,8 +55,7 @@ module Api
       param_group :job_invocation, :as => :create
       def create
         composer = JobInvocationComposer.from_api_params(job_invocation_params)
-        composer.save!
-        composer.trigger
+        composer.trigger!
         @job_invocation = composer.job_invocation
         process_response @job_invocation
       end

--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module V2
+    class RemoteExecutionFeaturesController < ::Api::V2::BaseController
+      include ::Api::Version2
+
+      before_filter :find_resource, :only => %w{show update}
+
+      api :GET, '/remote_execution_features/', N_('List remote execution features')
+      def index
+        @remote_execution_features = RemoteExecutionFeature.all
+      end
+
+      api :GET, '/remote_execution_features/:id', N_('Show remote execution feature')
+      param :id, :identifier, :required => true
+      def show
+      end
+
+      def_param_group :remote_execution_feature do
+        param :remote_execution_feature, Hash, :required => true, :action_aware => true do
+          param :job_template_id, :identifier, :required => true, :desc => N_('Job template id to be used for the feature')
+        end
+      end
+
+      api :PUT, '/remote_execution_features/:id', N_('Update a job template')
+      param :id, :identifier, :required => true
+      param_group :remote_execution_feature
+      def update
+        process_response @remote_execution_feature.update_attributes(params[:remote_execution_feature])
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -27,6 +27,12 @@ module Api
       def update
         process_response @remote_execution_feature.update_attributes(params[:remote_execution_feature])
       end
+
+      private
+
+      def parent_scope
+        resource_class.where(nil)
+      end
     end
   end
 end

--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -38,8 +38,7 @@ class JobInvocationsController < ApplicationController
 
   def create
     @composer = JobInvocationComposer.from_ui_params(params)
-    if @composer.save
-      @composer.trigger
+    if @composer.trigger
       redirect_to job_invocation_path(@composer.job_invocation)
     else
       @composer.job_invocation.description_format = nil if params[:job_invocation].key?(:description_override)

--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -30,7 +30,7 @@ class JobInvocationsController < ApplicationController
 
     if params[:failed_only]
       host_ids = job_invocation.failed_host_ids
-      @composer.search_query = @composer.targeting.build_query_from_hosts(host_ids)
+      @composer.search_query = Targeting.build_query_from_hosts(host_ids)
     end
 
     render :action => 'new'
@@ -39,10 +39,8 @@ class JobInvocationsController < ApplicationController
   def create
     @composer = JobInvocationComposer.from_ui_params(params)
     if @composer.save
-      job_invocation = @composer.job_invocation
-      job_invocation.generate_description! if job_invocation.description.blank?
-      @composer.triggering.trigger(::Actions::RemoteExecution::RunHostsJob, job_invocation)
-      redirect_to job_invocation_path(job_invocation)
+      @composer.trigger
+      redirect_to job_invocation_path(@composer.job_invocation)
     else
       @composer.job_invocation.description_format = nil if params[:job_invocation].key?(:description_override)
       render :action => 'new'

--- a/app/controllers/remote_execution_features_controller.rb
+++ b/app/controllers/remote_execution_features_controller.rb
@@ -1,0 +1,19 @@
+class RemoteExecutionFeaturesController < ::ApplicationController
+  before_filter :find_resource, :only => [:show, :update]
+
+  def index
+    @remote_execution_features = resource_base.all
+  end
+
+  def show
+  end
+
+  def update
+    if @remote_execution_feature.update_attributes(params[:remote_execution_feature])
+      process_success :object => @remote_execution_feature
+    else
+      process_error :object => @remote_execution_feature
+    end
+  end
+
+end

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -167,7 +167,7 @@ module RemoteExecutionHelper
 
   def invocation_result(invocation, key)
     unknown = '&mdash;'
-    result = invocation_count(invocation, :output_key => key, :unknown_string => unknown.html_safe )
+    result = invocation_count(invocation, :output_key => key, :unknown_string => unknown.html_safe)
     label = key == :failed_count ? 'danger' : 'info'
     result == unknown ? result : report_event_column(result, "label-#{label}")
   end

--- a/app/models/input_template_renderer.rb
+++ b/app/models/input_template_renderer.rb
@@ -4,7 +4,7 @@ class InputTemplateRenderer
 
   class RenderError < ::Foreman::Exception
   end
-
+  include Rails.application.routes.url_helpers
   include UnattendedHelper
 
   attr_accessor :template, :host, :invocation, :input_values, :error_message

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -172,11 +172,11 @@ class JobInvocationComposer
     end
 
     def params
-      { :job_category => template.job_category,
+      { :job_category => job_template.job_category,
         :targeting => targeting_params,
         :triggering => {},
         :template_invocations => template_invocations_params,
-        :description_format => template.generate_description_format }.with_indifferent_access
+        :description_format => job_template.generate_description_format }.with_indifferent_access
     end
 
     private
@@ -192,19 +192,19 @@ class JobInvocationComposer
     end
 
     def template_invocations_params
-      [ { 'template_id' => template.id,
+      [ { 'template_id' => job_template.id,
           'input_values' => input_values_params } ]
     end
 
     def input_values_params
       @provided_inputs.map do |key, value|
-        input = template.template_inputs.find_by_name!(key)
+        input = job_template.template_inputs.find_by_name!(key)
         { 'template_input_id' => input.id, 'value' => value }
       end
     end
 
-    def template
-      template = JobTemplate.authorized(:view_job_templates).find_by_id(feature.template_id)
+    def job_template
+      template = JobTemplate.authorized(:view_job_templates).find_by_id(feature.job_template_id)
       unless template
         raise Foreman::Exception.new(N_('The template %{template_name} mapped to feature %{feature_name} is not accessible by the user'),
                                      :template_name => mapping.template.name,

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -255,9 +255,18 @@ class JobInvocationComposer
     self
   end
 
-  def trigger
+  def trigger(raise_on_error = false)
+    if raise_on_error
+      save!
+    else
+      return false unless save
+    end
     job_invocation.generate_description! if job_invocation.description.blank?
     triggering.trigger(::Actions::RemoteExecution::RunHostsJob, job_invocation)
+  end
+
+  def trigger!
+    trigger(true)
   end
 
   def valid?

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -16,7 +16,7 @@ class JobTemplate < ::Template
   has_many :template_invocations, -> { where('host_id IS NOT NULL') }, :foreign_key => 'template_id'
   has_many :pattern_template_invocations, -> { where('host_id IS NULL') }, :foreign_key => 'template_id', :class_name => 'TemplateInvocation'
 
-  has_many :remote_execution_features, :dependent => :nullify, :foreign_key => 'template_id'
+  has_many :remote_execution_features, :dependent => :nullify
 
   # these can't be shared in parent class, scoped search can't handle STI properly
   # tested with scoped_search 3.2.0
@@ -76,7 +76,7 @@ class JobTemplate < ::Template
     end
 
     if metadata['feature'] && (feature = RemoteExecutionFeature.feature(metadata['feature']))
-      feature.template_id ||= template.id
+      feature.job_template_id ||= template.id
       feature.save!
     end
 

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -16,6 +16,8 @@ class JobTemplate < ::Template
   has_many :template_invocations, -> { where('host_id IS NOT NULL') }, :foreign_key => 'template_id'
   has_many :pattern_template_invocations, -> { where('host_id IS NULL') }, :foreign_key => 'template_id', :class_name => 'TemplateInvocation'
 
+  has_many :remote_execution_features, :dependent => :nullify, :foreign_key => 'template_id'
+
   # these can't be shared in parent class, scoped search can't handle STI properly
   # tested with scoped_search 3.2.0
   include Taxonomix
@@ -66,11 +68,16 @@ class JobTemplate < ::Template
 
     inputs = metadata.delete('template_inputs')
 
-    template = self.create(metadata.merge(:template => template.gsub(/<%\#.+?.-?%>\n?/m, '')).merge(options))
+    template = self.create(metadata.merge(:template => template.gsub(/<%\#.+?.-?%>\n?/m, '')).except('feature').merge(options))
     template.assign_taxonomies
 
     inputs.each do |input|
       template.template_inputs << TemplateInput.create(input)
+    end
+
+    if metadata['feature'] && (feature = RemoteExecutionFeature.feature(metadata['feature']))
+      feature.template_id ||= template.id
+      feature.save!
     end
 
     template

--- a/app/models/job_template_effective_user.rb
+++ b/app/models/job_template_effective_user.rb
@@ -4,8 +4,6 @@ class JobTemplateEffectiveUser < ActiveRecord::Base
 
   before_validation :set_defaults
 
-  belongs_to :job_template
-
   def set_defaults
     self.overridable = true if self.overridable.nil?
     self.current_user = false if self.current_user.nil?

--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -1,0 +1,36 @@
+class RemoteExecutionFeature < ActiveRecord::Base
+  attr_accessible :label, :name, :provided_input_names, :description, :template_id
+
+  validate :label, :name, :presence => true, :unique => true
+
+  belongs_to :template
+
+  extend FriendlyId
+  friendly_id :label
+
+  def provided_input_names
+    self.provided_inputs.to_s.split(',').map(&:chomp)
+  end
+
+  def provided_input_names=(values)
+    self.provided_inputs = Array(values).join(',')
+  end
+
+  class << self
+    def feature(label)
+      self.find_by_label(label) || raise(::Foreman::Exception.new(N_("Unknown remote execution feature %s"), label))
+    end
+
+    def register(label, name, options = {})
+      return false unless RemoteExecutionFeature.table_exists?
+      options.assert_valid_keys(:provided_inputs, :description)
+      feature = self.find_by_label(label)
+      if feature.nil?
+        feature = self.create!(:label => label, :name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
+      else
+        feature.update_attributes!(:name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
+      end
+      return feature
+    end
+  end
+end

--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -1,9 +1,9 @@
 class RemoteExecutionFeature < ActiveRecord::Base
-  attr_accessible :label, :name, :provided_input_names, :description, :template_id
+  attr_accessible :label, :name, :provided_input_names, :description, :job_template_id
 
   validate :label, :name, :presence => true, :unique => true
 
-  belongs_to :template
+  belongs_to :job_template
 
   extend FriendlyId
   friendly_id :label

--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -18,7 +18,7 @@ class RemoteExecutionFeature < ActiveRecord::Base
 
   class << self
     def feature(label)
-      self.find_by_label(label) || raise(::Foreman::Exception.new(N_("Unknown remote execution feature %s"), label))
+      self.find_by_label(label) || raise(::Foreman::Exception.new(N_('Unknown remote execution feature %s'), label))
     end
 
     def register(label, name, options = {})

--- a/app/models/targeting.rb
+++ b/app/models/targeting.rb
@@ -51,9 +51,9 @@ class Targeting < ActiveRecord::Base
     targeting_type == STATIC_TYPE
   end
 
-  def build_query_from_hosts(ids)
+  def self.build_query_from_hosts(ids)
     hosts = Host.where(:id => ids).all.group_by(&:id)
-    ids.map { |id| "name = #{hosts[id].first.name}" }.join(' or ')
+    hosts.map { |id, h| "name = #{h.first.name}" }.join(' or ')
   end
 
   def resolved?

--- a/app/views/api/v2/remote_execution_features/base.json.rabl
+++ b/app/views/api/v2/remote_execution_features/base.json.rabl
@@ -1,0 +1,3 @@
+object @remote_execution_feature
+
+attributes :id, :label, :name, :description, :job_template_id, :job_template_name

--- a/app/views/api/v2/remote_execution_features/index.json.rabl
+++ b/app/views/api/v2/remote_execution_features/index.json.rabl
@@ -1,0 +1,3 @@
+collection @remote_execution_features
+
+extends "api/v2/remote_execution_features/main"

--- a/app/views/api/v2/remote_execution_features/main.json.rabl
+++ b/app/views/api/v2/remote_execution_features/main.json.rabl
@@ -1,0 +1,3 @@
+object @remote_execution_feature
+
+extends "api/v2/remote_execution_features/base"

--- a/app/views/api/v2/remote_execution_features/show.json.rabl
+++ b/app/views/api/v2/remote_execution_features/show.json.rabl
@@ -1,0 +1,3 @@
+object @remote_execution_feature
+
+extends "api/v2/remote_execution_features/main"

--- a/app/views/remote_execution_features/_form.html.erb
+++ b/app/views/remote_execution_features/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_for @remote_execution_feature do |f| %>
+  <div class="row">
+    <%= field(f, :name) { @remote_execution_feature.name } %>
+  </div>
+  <div class="row">
+    <%= field(f, :label) { @remote_execution_feature.label } %>
+  </div>
+  <div class="row">
+    <%= field(f, :description) { @remote_execution_feature.description } %>
+  </div>
+  <div class="row">
+    <%= field(f, :provided_inputs) { @remote_execution_feature.provided_inputs } %>
+  </div>
+  <div class="row">
+    <%= selectable_f f, :template_id, JobTemplate.all.map { |t| [ t.name, t.id ] }, { :include_blank => true }, :class => 'input_type_selector' %>
+  </div>
+<%= submit_or_cancel f %>
+<% end %>

--- a/app/views/remote_execution_features/_form.html.erb
+++ b/app/views/remote_execution_features/_form.html.erb
@@ -12,7 +12,7 @@
     <%= field(f, :provided_inputs) { @remote_execution_feature.provided_inputs } %>
   </div>
   <div class="row">
-    <%= selectable_f f, :template_id, JobTemplate.all.map { |t| [ t.name, t.id ] }, { :include_blank => true }, :class => 'input_type_selector' %>
+    <%= selectable_f f, :job_template_id, JobTemplate.all.map { |t| [ t.name, t.id ] }, { :include_blank => true }, :class => 'input_type_selector' %>
   </div>
 <%= submit_or_cancel f %>
 <% end %>

--- a/app/views/remote_execution_features/index.html.erb
+++ b/app/views/remote_execution_features/index.html.erb
@@ -1,0 +1,21 @@
+<% title _('Remote Execution Features') %>
+
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th><%= sort :label, :as => _('Label') %></th>
+      <th><%= sort :name, :as => _('Name') %></th>
+      <th><%= sort :description, :as => _('Description') %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @remote_execution_features.each do |feature| %>
+      <tr>
+        <td><%= link_to_if_authorized feature.label, hash_for_remote_execution_feature_path(feature).merge(:auth_object => feature, :permission => :view_remote_execution_feature) %></td>
+        <td><%= feature.name %></td>
+        <td><%= feature.description %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/remote_execution_features/show.html.erb
+++ b/app/views/remote_execution_features/show.html.erb
@@ -1,0 +1,3 @@
+<% title _("Edit Remote Execution Feature") %>
+
+<%= render :partial => 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :remote_execution_features, :only => [:show, :index, :update]
+
   # index is needed so the auto_complete_search can be constructed, otherwise autocompletion in filter does not work
   resources :template_invocations, :only => [:show, :index] do
     collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
         resources :template_inputs, :only => [:index, :show, :create, :destroy, :update]
         resources :foreign_input_sets, :only => [:index, :show, :create, :destroy, :update]
       end
+
+      resources :remote_execution_features, :only => [:show, :index, :update]
     end
   end
 end

--- a/db/migrate/20160118124600_create_remote_execution_features.rb
+++ b/db/migrate/20160118124600_create_remote_execution_features.rb
@@ -5,10 +5,10 @@ class CreateRemoteExecutionFeatures < ActiveRecord::Migration
       t.string :name
       t.string :description
       t.text :provided_inputs, :null => true
-      t.integer :template_id, :null => true
+      t.integer :job_template_id, :null => true
     end
     add_index :remote_execution_features, :label
-    add_index :remote_execution_features, :template_id
-    add_foreign_key :remote_execution_features, :templates
+    add_index :remote_execution_features, :job_template_id
+    add_foreign_key :remote_execution_features, :templates, :column => :job_template_id
   end
 end

--- a/db/migrate/20160118124600_create_remote_execution_features.rb
+++ b/db/migrate/20160118124600_create_remote_execution_features.rb
@@ -1,0 +1,14 @@
+class CreateRemoteExecutionFeatures < ActiveRecord::Migration
+  def change
+    create_table :remote_execution_features do |t|
+      t.string :label, :index => true, :null => false
+      t.string :name
+      t.string :description
+      t.text :provided_inputs, :null => true
+      t.integer :template_id, :null => true
+    end
+    add_index :remote_execution_features, :label
+    add_index :remote_execution_features, :template_id
+    add_foreign_key :remote_execution_features, :templates
+  end
+end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -46,7 +46,7 @@ module ForemanRemoteExecution
                                             :'api/v2/template_inputs' => [:create, :update, :destroy],
                                             :'api/v2/foreign_input_sets' => [:create, :update, :destroy]}, :resource_type => 'JobTemplate'
           permission :edit_remote_execution_features, { :remote_execution_features => [:index, :show, :update],
-                                            :'api/v2/remote_execution_features' => [:index, :show, :update]}, :resource_type => 'RemoteExecutionFeature'
+                                                        :'api/v2/remote_execution_features' => [:index, :show, :update]}, :resource_type => 'RemoteExecutionFeature'
           permission :destroy_job_templates, { :job_templates => [:destroy],
                                                :'api/v2/job_templates' => [:destroy] }, :resource_type => 'JobTemplate'
           permission :lock_job_templates, { :job_templates => [:lock, :unlock] }, :resource_type => 'JobTemplate'

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -45,6 +45,8 @@ module ForemanRemoteExecution
                                             :'api/v2/job_templates' => [:update],
                                             :'api/v2/template_inputs' => [:create, :update, :destroy],
                                             :'api/v2/foreign_input_sets' => [:create, :update, :destroy]}, :resource_type => 'JobTemplate'
+          permission :edit_remote_execution_features, { :remote_execution_features => [:index, :show, :update],
+                                            :'api/v2/remote_execution_features' => [:index, :show, :update]}, :resource_type => 'RemoteExecutionFeature'
           permission :destroy_job_templates, { :job_templates => [:destroy],
                                                :'api/v2/job_templates' => [:destroy] }, :resource_type => 'JobTemplate'
           permission :lock_job_templates, { :job_templates => [:lock, :unlock] }, :resource_type => 'JobTemplate'
@@ -72,7 +74,8 @@ module ForemanRemoteExecution
           :create_job_templates,
           :lock_job_templates,
           :view_audit_logs,
-          :filter_autocompletion_for_template_invocation
+          :filter_autocompletion_for_template_invocation,
+          :edit_remote_execution_features
         ]
 
         # Add a new role called 'Remote Execution User ' if it doesn't exist
@@ -85,6 +88,11 @@ module ForemanRemoteExecution
              caption: N_('Job templates'),
              parent: :hosts_menu,
              after: :provisioning_templates
+        menu :admin_menu, :remote_execution_features,
+             url_hash: { controller: :remote_execution_features, action: :index },
+             caption: N_('Remote Execution Features'),
+             parent: :administer_menu,
+             after: :bookmarks
 
         menu :top_menu, :job_invocations,
              url_hash: { controller: :job_invocations, action: :index },

--- a/test/functional/api/v2/remote_execution_features_controller_test.rb
+++ b/test/functional/api/v2/remote_execution_features_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    class RemoteExecutionFeaturesControllerTest < ActionController::TestCase
+      setup do
+        @remote_execution_feature = RemoteExecutionFeature.register(:my_awesome_feature, 'My awesome feature',
+                                                                    :description => 'You will not believe what it does',
+                                                                    :provided_inputs => ['awesomeness_level'])
+        @template = FactoryGirl.create(:job_template, :with_input)
+      end
+
+      test 'should get index' do
+        get :index
+        remote_execution_features = ActiveSupport::JSON.decode(@response.body)
+        refute remote_execution_features.empty?, 'Should respond with input sets'
+        assert_response :success
+      end
+
+      test 'should get input set detail' do
+        get :show, :id => @remote_execution_feature.to_param
+        assert_response :success
+        remote_execution_feature = ActiveSupport::JSON.decode(@response.body)
+        refute remote_execution_feature.empty?
+        assert_equal remote_execution_feature['name'], @remote_execution_feature.name
+      end
+
+      test 'should update valid' do
+        put :update, :id => @remote_execution_feature.to_param,
+                     :job_template_id => @template.id
+        assert_response :ok
+      end
+    end
+  end
+end

--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -20,7 +20,7 @@ describe RemoteExecutionFeature do
 
   before do
     User.current = users :admin
-    install_feature.update_attributes!(:template_id => package_template.id)
+    install_feature.update_attributes!(:job_template_id => package_template.id)
   end
 
   describe 'composer' do

--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -1,0 +1,42 @@
+require 'test_plugin_helper'
+
+describe RemoteExecutionFeature do
+
+  let(:install_feature) do
+    RemoteExecutionFeature.register(:katello_install_package, N_("Katello: Install package"),
+                                    :description => "Install package via Katello user interface",
+                                    :provided_inputs => ["package"])
+  end
+
+  let(:package_template) do
+    FactoryGirl.create(:job_template).tap do |job_template|
+      job_template.job_category = 'Package Action'
+      job_template.name = 'Package Action - SSH Default'
+      job_template.template_inputs.create(:name => "package", :input_type => "user")
+    end
+  end
+
+  let(:host) { FactoryGirl.create(:host) }
+
+  before do
+    User.current = users :admin
+    install_feature.update_attributes!(:template_id => package_template.id)
+  end
+
+  describe 'composer' do
+    it 'prepares composer for given feature based on the mapping' do
+      composer = JobInvocationComposer.for_feature(:katello_install_package, host, :package => "zsh")
+      assert composer.valid?
+      composer.pattern_template_invocations.size.must_equal 1
+      template_invocation = composer.pattern_template_invocations.first
+      template_invocation.template.must_equal package_template
+      template_invocation.input_values.size.must_equal 1
+
+      input_value = template_invocation.input_values.first
+      input_value.value.must_equal 'zsh'
+      input_value.template_input.name.must_equal 'package'
+
+      composer.targeting.search_query.must_equal "name = #{host.name}"
+    end
+  end
+end

--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -3,16 +3,16 @@ require 'test_plugin_helper'
 describe RemoteExecutionFeature do
 
   let(:install_feature) do
-    RemoteExecutionFeature.register(:katello_install_package, N_("Katello: Install package"),
-                                    :description => "Install package via Katello user interface",
-                                    :provided_inputs => ["package"])
+    RemoteExecutionFeature.register(:katello_install_package, N_('Katello: Install package'),
+                                    :description => 'Install package via Katello user interface',
+                                    :provided_inputs => ['package'])
   end
 
   let(:package_template) do
     FactoryGirl.create(:job_template).tap do |job_template|
       job_template.job_category = 'Package Action'
       job_template.name = 'Package Action - SSH Default'
-      job_template.template_inputs.create(:name => "package", :input_type => "user")
+      job_template.template_inputs.create(:name => 'package', :input_type => 'user')
     end
   end
 
@@ -25,7 +25,7 @@ describe RemoteExecutionFeature do
 
   describe 'composer' do
     it 'prepares composer for given feature based on the mapping' do
-      composer = JobInvocationComposer.for_feature(:katello_install_package, host, :package => "zsh")
+      composer = JobInvocationComposer.for_feature(:katello_install_package, host, :package => 'zsh')
       assert composer.valid?
       composer.pattern_template_invocations.size.must_equal 1
       template_invocation = composer.pattern_template_invocations.first

--- a/test/unit/targeting_test.rb
+++ b/test/unit/targeting_test.rb
@@ -86,7 +86,7 @@ describe Targeting do
     end
 
     context 'for two hosts' do
-      let(:query) { targeting.build_query_from_hosts([ host.id, second_host.id ]) }
+      let(:query) { Targeting.build_query_from_hosts([ host.id, second_host.id ]) }
 
       it 'builds query using host names joining with or' do
         query.must_include "name = #{host.name}"
@@ -99,7 +99,7 @@ describe Targeting do
     end
 
     context 'for one host' do
-      let(:query) { targeting.build_query_from_hosts([ host.id ]) }
+      let(:query) { Targeting.build_query_from_hosts([ host.id ]) }
 
       it 'builds query using host name' do
         query.must_equal "name = #{host.name}"
@@ -109,7 +109,7 @@ describe Targeting do
     end
 
     context 'for no id' do
-      let(:query) { targeting.build_query_from_hosts([]) }
+      let(:query) { Targeting.build_query_from_hosts([]) }
 
       it 'builds query to find all hosts' do
         Host.search_for(query).must_include host


### PR DESCRIPTION
Any plugin (or core) and define a feature at initialization:

```
RemoteExecutionFeature.register(:reprovision, N_("Reprovision"),
                                :description => "Reprovision the host via script",
                                :provided_inputs => ["script"])
```

The mapping between the feature and templates can be made via
'Administer -> Remote Execution Features'.

```
composer = JobInvocationComposer.for_feature(:reprovision, host, :script => "grubby...")
composer.save!
composer.trigger
```

When seeding a template, there is a new meta `feature`, which allows
to assign some template as default to the specified feature.

The template mapping is now limited to just one template, but in future,
we can extend that to allow different mappings through organizations,
but lets keep it simple first.

- [x] - API/cli for feature mapping setting
- [x] -tests for API/CLI