### PR TITLE
Fixes #10757 - preparation for Katello remote actions integration

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -60,10 +60,8 @@ module Api
       param_group :job_invocation, :as => :create
       def create
         composer = JobInvocationComposer.from_api_params(job_invocation_params)
-        composer.save!
+        composer.trigger!
         @job_invocation = composer.job_invocation
-        @job_invocation.generate_description! if @job_invocation.description.blank?
-        composer.triggering.trigger(::Actions::RemoteExecution::RunHostsJob, @job_invocation)
         process_response @job_invocation
       end
 

--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -1,0 +1,38 @@
+module Api
+  module V2
+    class RemoteExecutionFeaturesController < ::Api::V2::BaseController
+      include ::Api::Version2
+
+      before_filter :find_resource, :only => %w{show update}
+
+      api :GET, '/remote_execution_features/', N_('List remote execution features')
+      def index
+        @remote_execution_features = RemoteExecutionFeature.all
+      end
+
+      api :GET, '/remote_execution_features/:id', N_('Show remote execution feature')
+      param :id, :identifier, :required => true
+      def show
+      end
+
+      def_param_group :remote_execution_feature do
+        param :remote_execution_feature, Hash, :required => true, :action_aware => true do
+          param :job_template_id, :identifier, :required => true, :desc => N_('Job template id to be used for the feature')
+        end
+      end
+
+      api :PUT, '/remote_execution_features/:id', N_('Update a job template')
+      param :id, :identifier, :required => true
+      param_group :remote_execution_feature
+      def update
+        process_response @remote_execution_feature.update_attributes(params[:remote_execution_feature])
+      end
+
+      private
+
+      def parent_scope
+        resource_class.where(nil)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       api :GET, '/remote_execution_features/', N_('List remote execution features')
       def index
-        @remote_execution_features = RemoteExecutionFeature.all
+        @remote_execution_features = resource_scope
       end
 
       api :GET, '/remote_execution_features/:id', N_('Show remote execution feature')
@@ -17,7 +17,7 @@ module Api
 
       def_param_group :remote_execution_feature do
         param :remote_execution_feature, Hash, :required => true, :action_aware => true do
-          param :job_template_id, :identifier, :required => true, :desc => N_('Job template id to be used for the feature')
+          param :job_template_id, :identifier, :required => true, :desc => N_('Job template ID to be used for the feature')
         end
       end
 

--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -1,8 +1,6 @@
 class JobInvocationsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
-  before_filter :find_or_create_triggering, :only => [:create, :refresh]
-
   def new
     ui_params = {
       :host_ids => params[:host_ids],
@@ -74,10 +72,6 @@ class JobInvocationsController < ApplicationController
   end
 
   private
-
-  def find_or_create_triggering
-    @triggering ||= ::ForemanTasks::Triggering.new_from_params(params[:triggering])
-  end
 
   def action_permission
     case params[:action]

--- a/app/controllers/remote_execution_features_controller.rb
+++ b/app/controllers/remote_execution_features_controller.rb
@@ -1,0 +1,19 @@
+class RemoteExecutionFeaturesController < ::ApplicationController
+  before_filter :find_resource, :only => [:show, :update]
+
+  def index
+    @remote_execution_features = resource_base.all
+  end
+
+  def show
+  end
+
+  def update
+    if @remote_execution_feature.update_attributes(params[:remote_execution_feature])
+      process_success :object => @remote_execution_feature
+    else
+      process_error :object => @remote_execution_feature
+    end
+  end
+
+end

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -167,7 +167,7 @@ module RemoteExecutionHelper
 
   def invocation_result(invocation, key)
     unknown = '&mdash;'
-    result = invocation_count(invocation, :output_key => key, :unknown_string => unknown.html_safe )
+    result = invocation_count(invocation, :output_key => key, :unknown_string => unknown.html_safe)
     label = key == :failed_count ? 'danger' : 'info'
     result == unknown ? result : report_event_column(result, "label-#{label}")
   end

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -43,7 +43,7 @@ module Actions
         host = Host.find(input[:host][:id])
         host.refresh_statuses
       rescue => e
-        Foreman::Logging.exception "Could not update execution status for #{input[:host][:name]}", e
+        ::Foreman::Logging.exception "Could not update execution status for #{input[:host][:name]}", e
       end
 
       def humanized_output

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -156,7 +156,7 @@ class JobInvocation < ActiveRecord::Base
     template_invocation = pattern_template_invocations.first
     input_names = template_invocation.template.template_inputs_with_foreign(&:name)
     hash_base = Hash.new { |hash, key| hash[key] = "%{#{key}}" }
-    input_hash = hash_base.merge Hash[input_names.zip(template_invocation.input_values.pluck(:value))]
+    input_hash = hash_base.merge Hash[input_names.zip(template_invocation.input_values.map(&:value))]
     input_hash.update(:job_category => job_category)
     input_hash.update(:template_name => template_invocation.template.name)
     description_format.scan(key_re) { |key| input_hash[key.first] }

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -177,6 +177,66 @@ class JobInvocationComposer
     end
   end
 
+  class ParamsForFeature
+    attr_reader :feature_label, :feature, :provided_inputs
+
+    def initialize(feature_label, hosts, provided_inputs = {})
+      @feature = RemoteExecutionFeature.feature(feature_label)
+      @provided_inputs = provided_inputs
+      if hosts.is_a? Bookmark
+        @host_bookmark = hosts
+      elsif hosts.is_a? Host::Base
+        @host_objects = [hosts]
+      elsif hosts.is_a? String
+        @host_scoped_search = hosts
+      else
+        @host_objects = hosts
+      end
+    end
+
+    def params
+      { :job_category => job_template.job_category,
+        :targeting => targeting_params,
+        :triggering => {},
+        :template_invocations => template_invocations_params,
+        :description_format => job_template.generate_description_format }.with_indifferent_access
+    end
+
+    private
+
+    def targeting_params
+      ret = {}
+      ret['targeting_type'] = Targeting::STATIC_TYPE
+      ret['search_query'] = @host_scoped_search if @host_scoped_search
+      ret['search_query'] = Targeting.build_query_from_hosts(@host_objects) if @host_objects
+      ret['bookmark_id'] = @host_bookmark.id if @host_bookmark
+      ret['user_id'] = User.current.id
+      ret
+    end
+
+    def template_invocations_params
+      [ { 'template_id' => job_template.id,
+          'input_values' => input_values_params } ]
+    end
+
+    def input_values_params
+      @provided_inputs.map do |key, value|
+        input = job_template.template_inputs.find_by_name!(key)
+        { 'template_input_id' => input.id, 'value' => value }
+      end
+    end
+
+    def job_template
+      template = JobTemplate.authorized(:view_job_templates).find_by_id(feature.job_template_id)
+      unless template
+        raise Foreman::Exception.new(N_('The template %{template_name} mapped to feature %{feature_name} is not accessible by the user'),
+                                     :template_name => mapping.template.name,
+                                     :feature_name => feature.name)
+      end
+      template
+    end
+  end
+
   attr_accessor :params, :job_invocation, :host_ids, :search_query
   delegate :job_category, :pattern_template_invocations, :template_invocations, :targeting, :triggering, :to => :job_invocation
 
@@ -203,6 +263,10 @@ class JobInvocationComposer
     self.new(ApiParams.new(api_params).params)
   end
 
+  def self.for_feature(feature_label, hosts, provided_inputs = {})
+    self.new(ParamsForFeature.new(feature_label, hosts, provided_inputs).params)
+  end
+
   def compose
     job_invocation.job_category = validate_job_category(params[:job_category])
     job_invocation.job_category ||= available_job_categories.first if @set_defaults
@@ -214,6 +278,20 @@ class JobInvocationComposer
     job_invocation.concurrency_level = params[:concurrency_control][:level].to_i unless params[:concurrency_control][:level].blank?
 
     self
+  end
+
+  def trigger(raise_on_error = false)
+    if raise_on_error
+      save!
+    else
+      return false unless save
+    end
+    job_invocation.generate_description! if job_invocation.description.blank?
+    triggering.trigger(::Actions::RemoteExecution::RunHostsJob, job_invocation)
+  end
+
+  def trigger!
+    trigger(true)
   end
 
   def valid?
@@ -277,7 +355,7 @@ class JobInvocationComposer
     if @search_query.present?
       @search_query
     elsif host_ids.present?
-      targeting.build_query_from_hosts(host_ids)
+      Targeting.build_query_from_hosts(host_ids)
     elsif targeting.bookmark_id
       if (bookmark = available_bookmarks.find_by(:id => targeting.bookmark_id))
         bookmark.query

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -70,7 +70,7 @@ class JobInvocationComposer
       { :job_category => template.job_category,
         :targeting => targeting_params,
         :triggering => triggering_params,
-        :description_format => api_params[:description_format] || template.generate_description_format,
+        :description_format => api_params[:description_format],
         :concurrency_control => concurrency_control_params,
         :template_invocations => template_invocations_params }.with_indifferent_access
     end
@@ -198,8 +198,8 @@ class JobInvocationComposer
       { :job_category => job_template.job_category,
         :targeting => targeting_params,
         :triggering => {},
-        :template_invocations => template_invocations_params,
-        :description_format => job_template.generate_description_format }.with_indifferent_access
+        :concurrency_control => {},
+        :template_invocations => template_invocations_params }.with_indifferent_access
     end
 
     private
@@ -221,16 +221,25 @@ class JobInvocationComposer
 
     def input_values_params
       @provided_inputs.map do |key, value|
-        input = job_template.template_inputs.find_by_name!(key)
+        input = job_template.template_inputs_with_foreign.find { |i| i.name == key.to_s }
+        unless input
+          raise Foreman::Exception.new(N_('Feature input %{input_name} not defined in template %{template_name}'),
+                                       :input_name => key, :template_name => job_template.name)
+        end
         { 'template_input_id' => input.id, 'value' => value }
       end
     end
 
     def job_template
+      unless feature.job_template
+        raise Foreman::Exception.new(N_('No template mapped to feature %{feature_name}'),
+                                     :feature_name => feature.name)
+      end
       template = JobTemplate.authorized(:view_job_templates).find_by_id(feature.job_template_id)
+
       unless template
         raise Foreman::Exception.new(N_('The template %{template_name} mapped to feature %{feature_name} is not accessible by the user'),
-                                     :template_name => mapping.template.name,
+                                     :template_name => template.name,
                                      :feature_name => feature.name)
       end
       template
@@ -281,12 +290,12 @@ class JobInvocationComposer
   end
 
   def trigger(raise_on_error = false)
+    generate_description
     if raise_on_error
       save!
     else
       return false unless save
     end
-    job_invocation.generate_description! if job_invocation.description.blank?
     triggering.trigger(::Actions::RemoteExecution::RunHostsJob, job_invocation)
   end
 
@@ -452,6 +461,14 @@ class JobInvocationComposer
       build_input_values_for(template_invocation, template_invocation_params)
       template_invocation
     end
+  end
+
+  def generate_description
+    unless job_invocation.description_format
+      template = job_invocation.pattern_template_invocations.first.try(:template)
+      job_invocation.description_format = template.generate_description_format if template
+    end
+    job_invocation.generate_description! if job_invocation.description.blank?
   end
 
   def build_effective_user(template_invocation_params)

--- a/app/models/job_template_effective_user.rb
+++ b/app/models/job_template_effective_user.rb
@@ -4,8 +4,6 @@ class JobTemplateEffectiveUser < ActiveRecord::Base
 
   before_validation :set_defaults
 
-  belongs_to :job_template
-
   def set_defaults
     self.overridable = true if self.overridable.nil?
     self.current_user = false if self.current_user.nil?

--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -1,0 +1,36 @@
+class RemoteExecutionFeature < ActiveRecord::Base
+  attr_accessible :label, :name, :provided_input_names, :description, :job_template_id
+
+  validate :label, :name, :presence => true, :unique => true
+
+  belongs_to :job_template
+
+  extend FriendlyId
+  friendly_id :label
+
+  def provided_input_names
+    self.provided_inputs.to_s.split(',').map(&:chomp)
+  end
+
+  def provided_input_names=(values)
+    self.provided_inputs = Array(values).join(',')
+  end
+
+  class << self
+    def feature(label)
+      self.find_by_label(label) || raise(::Foreman::Exception.new(N_('Unknown remote execution feature %s'), label))
+    end
+
+    def register(label, name, options = {})
+      return false unless RemoteExecutionFeature.table_exists?
+      options.assert_valid_keys(:provided_inputs, :description)
+      feature = self.find_by_label(label)
+      if feature.nil?
+        feature = self.create!(:label => label, :name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
+      else
+        feature.update_attributes!(:name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
+      end
+      return feature
+    end
+  end
+end

--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -9,28 +9,26 @@ class RemoteExecutionFeature < ActiveRecord::Base
   friendly_id :label
 
   def provided_input_names
-    self.provided_inputs.to_s.split(',').map(&:chomp)
+    self.provided_inputs.to_s.split(',').map(&:strip)
   end
 
   def provided_input_names=(values)
     self.provided_inputs = Array(values).join(',')
   end
 
-  class << self
-    def feature(label)
-      self.find_by_label(label) || raise(::Foreman::Exception.new(N_('Unknown remote execution feature %s'), label))
-    end
+  def self.feature(label)
+    self.find_by_label(label) || raise(::Foreman::Exception.new(N_('Unknown remote execution feature %s'), label))
+  end
 
-    def register(label, name, options = {})
-      return false unless RemoteExecutionFeature.table_exists?
-      options.assert_valid_keys(:provided_inputs, :description)
-      feature = self.find_by_label(label)
-      if feature.nil?
-        feature = self.create!(:label => label, :name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
-      else
-        feature.update_attributes!(:name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
-      end
-      return feature
+  def self.register(label, name, options = {})
+    return false unless RemoteExecutionFeature.table_exists?
+    options.assert_valid_keys(:provided_inputs, :description)
+    feature = self.find_by_label(label)
+    if feature.nil?
+      feature = self.create!(:label => label, :name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
+    else
+      feature.update_attributes!(:name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
     end
+    return feature
   end
 end

--- a/app/models/targeting.rb
+++ b/app/models/targeting.rb
@@ -51,9 +51,9 @@ class Targeting < ActiveRecord::Base
     targeting_type == STATIC_TYPE
   end
 
-  def build_query_from_hosts(ids)
+  def self.build_query_from_hosts(ids)
     hosts = Host.where(:id => ids).all.group_by(&:id)
-    ids.map { |id| "name = #{hosts[id].first.name}" }.join(' or ')
+    hosts.map { |id, h| "name = #{h.first.name}" }.join(' or ')
   end
 
   def resolved?

--- a/app/views/api/v2/remote_execution_features/base.json.rabl
+++ b/app/views/api/v2/remote_execution_features/base.json.rabl
@@ -1,0 +1,3 @@
+object @remote_execution_feature
+
+attributes :id, :label, :name, :description, :job_template_id, :job_template_name

--- a/app/views/api/v2/remote_execution_features/index.json.rabl
+++ b/app/views/api/v2/remote_execution_features/index.json.rabl
@@ -1,0 +1,3 @@
+collection @remote_execution_features
+
+extends "api/v2/remote_execution_features/main"

--- a/app/views/api/v2/remote_execution_features/main.json.rabl
+++ b/app/views/api/v2/remote_execution_features/main.json.rabl
@@ -1,0 +1,3 @@
+object @remote_execution_feature
+
+extends "api/v2/remote_execution_features/base"

--- a/app/views/api/v2/remote_execution_features/show.json.rabl
+++ b/app/views/api/v2/remote_execution_features/show.json.rabl
@@ -1,0 +1,3 @@
+object @remote_execution_feature
+
+extends "api/v2/remote_execution_features/main"

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -108,5 +108,5 @@
 
   <%= render :partial => 'preview_hosts_modal' %>
 
-  <%= submit_or_cancel f %>
+  <%= submit_or_cancel f, false, :cancel_path => job_invocations_path %>
 <% end %>

--- a/app/views/remote_execution_features/_form.html.erb
+++ b/app/views/remote_execution_features/_form.html.erb
@@ -12,7 +12,13 @@
     <%= field(f, :provided_inputs) { @remote_execution_feature.provided_inputs } %>
   </div>
   <div class="row">
-    <%= selectable_f f, :job_template_id, JobTemplate.all.map { |t| [ t.name, t.id ] }, { :include_blank => true }, :class => 'input_type_selector' %>
+    <% job_templates = JobTemplate.authorized(:view_job_templates) %>
+    <% if @remote_execution_feature.job_template_id.present? && job_templates.where(:id => @remote_execution_feature.job_template_id).empty? %>
+      <div class="alert alert-warning" role="alert">
+        <%= _("You are not allowed to see the currently assigned template. Saving the form now would unassign the template.") %>
+      </div>
+    <% end %>
+    <%= selectable_f f, :job_template_id, job_templates.map { |t| [ t.name, t.id ] }, { :include_blank => true }, :class => 'input_type_selector' %>
   </div>
 <%= submit_or_cancel f %>
 <% end %>

--- a/app/views/remote_execution_features/_form.html.erb
+++ b/app/views/remote_execution_features/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_for @remote_execution_feature do |f| %>
+  <div class="row">
+    <%= field(f, :name) { @remote_execution_feature.name } %>
+  </div>
+  <div class="row">
+    <%= field(f, :label) { @remote_execution_feature.label } %>
+  </div>
+  <div class="row">
+    <%= field(f, :description) { @remote_execution_feature.description } %>
+  </div>
+  <div class="row">
+    <%= field(f, :provided_inputs) { @remote_execution_feature.provided_inputs } %>
+  </div>
+  <div class="row">
+    <%= selectable_f f, :job_template_id, JobTemplate.all.map { |t| [ t.name, t.id ] }, { :include_blank => true }, :class => 'input_type_selector' %>
+  </div>
+<%= submit_or_cancel f %>
+<% end %>

--- a/app/views/remote_execution_features/index.html.erb
+++ b/app/views/remote_execution_features/index.html.erb
@@ -1,0 +1,21 @@
+<% title _('Remote Execution Features') %>
+
+<table class="table table-bordered table-striped table-condensed">
+  <thead>
+    <tr>
+      <th><%= sort :label, :as => _('Label') %></th>
+      <th><%= sort :name, :as => _('Name') %></th>
+      <th><%= sort :description, :as => _('Description') %></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @remote_execution_features.each do |feature| %>
+      <tr>
+        <td><%= link_to_if_authorized feature.label, hash_for_remote_execution_feature_path(feature).merge(:auth_object => feature, :permission => :view_remote_execution_feature) %></td>
+        <td><%= feature.name %></td>
+        <td><%= feature.description %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/remote_execution_features/index.html.erb
+++ b/app/views/remote_execution_features/index.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% @remote_execution_features.each do |feature| %>
       <tr>
-        <td><%= link_to_if_authorized feature.label, hash_for_remote_execution_feature_path(feature).merge(:auth_object => feature, :permission => :view_remote_execution_feature) %></td>
+        <td><%= link_to_if_authorized feature.label, hash_for_remote_execution_feature_path(feature).merge(:auth_object => feature, :permission => :edit_remote_execution_features) %></td>
         <td><%= feature.name %></td>
         <td><%= feature.description %></td>
       </tr>

--- a/app/views/remote_execution_features/show.html.erb
+++ b/app/views/remote_execution_features/show.html.erb
@@ -1,0 +1,3 @@
+<% title _("Edit Remote Execution Feature") %>
+
+<%= render :partial => 'form' %>

--- a/app/views/templates/package_action.erb
+++ b/app/views/templates/package_action.erb
@@ -14,7 +14,7 @@ template_inputs:
   description: 'The package action: install, update, or remove'
   input_type: user
   required: true
-  options: "install\nupdate\nremove"
+  options: "install\nupdate\nremove\ngroup install\ngroup remove"
 - name: package
   description: The name of the package, if any
   input_type: user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :remote_execution_features, :only => [:show, :index, :update]
+
   # index is needed so the auto_complete_search can be constructed, otherwise autocompletion in filter does not work
   resources :template_invocations, :only => [:show, :index] do
     collection do
@@ -53,6 +55,8 @@ Rails.application.routes.draw do
         resources :template_inputs, :only => [:index, :show, :create, :destroy, :update]
         resources :foreign_input_sets, :only => [:index, :show, :create, :destroy, :update]
       end
+
+      resources :remote_execution_features, :only => [:show, :index, :update]
     end
   end
 end

--- a/db/migrate/20160118124600_create_remote_execution_features.rb
+++ b/db/migrate/20160118124600_create_remote_execution_features.rb
@@ -2,10 +2,10 @@ class CreateRemoteExecutionFeatures < ActiveRecord::Migration
   def change
     create_table :remote_execution_features do |t|
       t.string :label, :index => true, :null => false
-      t.string :name
+      t.string :name, :null => false
       t.string :description
-      t.text :provided_inputs, :null => true
-      t.integer :job_template_id, :null => true
+      t.text :provided_inputs
+      t.integer :job_template_id
     end
     add_index :remote_execution_features, :label
     add_index :remote_execution_features, :job_template_id

--- a/db/migrate/20160118124600_create_remote_execution_features.rb
+++ b/db/migrate/20160118124600_create_remote_execution_features.rb
@@ -1,0 +1,14 @@
+class CreateRemoteExecutionFeatures < ActiveRecord::Migration
+  def change
+    create_table :remote_execution_features do |t|
+      t.string :label, :index => true, :null => false
+      t.string :name
+      t.string :description
+      t.text :provided_inputs, :null => true
+      t.integer :job_template_id, :null => true
+    end
+    add_index :remote_execution_features, :label
+    add_index :remote_execution_features, :job_template_id
+    add_foreign_key :remote_execution_features, :templates, :column => :job_template_id
+  end
+end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -45,6 +45,8 @@ module ForemanRemoteExecution
                                             :'api/v2/job_templates' => [:update],
                                             :'api/v2/template_inputs' => [:create, :update, :destroy],
                                             :'api/v2/foreign_input_sets' => [:create, :update, :destroy]}, :resource_type => 'JobTemplate'
+          permission :edit_remote_execution_features, { :remote_execution_features => [:index, :show, :update],
+                                                        :'api/v2/remote_execution_features' => [:index, :show, :update]}, :resource_type => 'RemoteExecutionFeature'
           permission :destroy_job_templates, { :job_templates => [:destroy],
                                                :'api/v2/job_templates' => [:destroy] }, :resource_type => 'JobTemplate'
           permission :lock_job_templates, { :job_templates => [:lock, :unlock] }, :resource_type => 'JobTemplate'
@@ -72,7 +74,8 @@ module ForemanRemoteExecution
           :create_job_templates,
           :lock_job_templates,
           :view_audit_logs,
-          :filter_autocompletion_for_template_invocation
+          :filter_autocompletion_for_template_invocation,
+          :edit_remote_execution_features
         ]
 
         # Add a new role called 'Remote Execution User ' if it doesn't exist
@@ -85,6 +88,11 @@ module ForemanRemoteExecution
              caption: N_('Job templates'),
              parent: :hosts_menu,
              after: :provisioning_templates
+        menu :admin_menu, :remote_execution_features,
+             url_hash: { controller: :remote_execution_features, action: :index },
+             caption: N_('Remote Execution Features'),
+             parent: :administer_menu,
+             after: :bookmarks
 
         menu :top_menu, :job_invocations,
              url_hash: { controller: :job_invocations, action: :index },

--- a/test/functional/api/v2/remote_execution_features_controller_test.rb
+++ b/test/functional/api/v2/remote_execution_features_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    class RemoteExecutionFeaturesControllerTest < ActionController::TestCase
+      setup do
+        @remote_execution_feature = RemoteExecutionFeature.register(:my_awesome_feature, 'My awesome feature',
+                                                                    :description => 'You will not believe what it does',
+                                                                    :provided_inputs => ['awesomeness_level'])
+        @template = FactoryGirl.create(:job_template, :with_input)
+      end
+
+      test 'should get index' do
+        get :index
+        remote_execution_features = ActiveSupport::JSON.decode(@response.body)
+        refute remote_execution_features.empty?, 'Should respond with input sets'
+        assert_response :success
+      end
+
+      test 'should get input set detail' do
+        get :show, :id => @remote_execution_feature.to_param
+        assert_response :success
+        remote_execution_feature = ActiveSupport::JSON.decode(@response.body)
+        refute remote_execution_feature.empty?
+        assert_equal remote_execution_feature['name'], @remote_execution_feature.name
+      end
+
+      test 'should update valid' do
+        put :update, :id => @remote_execution_feature.to_param,
+                     :job_template_id => @template.id
+        assert_response :ok
+      end
+    end
+  end
+end

--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -1,0 +1,42 @@
+require 'test_plugin_helper'
+
+describe RemoteExecutionFeature do
+
+  let(:install_feature) do
+    RemoteExecutionFeature.register(:katello_install_package, N_('Katello: Install package'),
+                                    :description => 'Install package via Katello user interface',
+                                    :provided_inputs => ['package'])
+  end
+
+  let(:package_template) do
+    FactoryGirl.create(:job_template).tap do |job_template|
+      job_template.job_category = 'Package Action'
+      job_template.name = 'Package Action - SSH Default'
+      job_template.template_inputs.create(:name => 'package', :input_type => 'user')
+    end
+  end
+
+  let(:host) { FactoryGirl.create(:host) }
+
+  before do
+    User.current = users :admin
+    install_feature.update_attributes!(:job_template_id => package_template.id)
+  end
+
+  describe 'composer' do
+    it 'prepares composer for given feature based on the mapping' do
+      composer = JobInvocationComposer.for_feature(:katello_install_package, host, :package => 'zsh')
+      assert composer.valid?
+      composer.pattern_template_invocations.size.must_equal 1
+      template_invocation = composer.pattern_template_invocations.first
+      template_invocation.template.must_equal package_template
+      template_invocation.input_values.size.must_equal 1
+
+      input_value = template_invocation.input_values.first
+      input_value.value.must_equal 'zsh'
+      input_value.template_input.name.must_equal 'package'
+
+      composer.targeting.search_query.must_equal "name = #{host.name}"
+    end
+  end
+end

--- a/test/unit/targeting_test.rb
+++ b/test/unit/targeting_test.rb
@@ -86,7 +86,7 @@ describe Targeting do
     end
 
     context 'for two hosts' do
-      let(:query) { targeting.build_query_from_hosts([ host.id, second_host.id ]) }
+      let(:query) { Targeting.build_query_from_hosts([ host.id, second_host.id ]) }
 
       it 'builds query using host names joining with or' do
         query.must_include "name = #{host.name}"
@@ -99,7 +99,7 @@ describe Targeting do
     end
 
     context 'for one host' do
-      let(:query) { targeting.build_query_from_hosts([ host.id ]) }
+      let(:query) { Targeting.build_query_from_hosts([ host.id ]) }
 
       it 'builds query using host name' do
         query.must_equal "name = #{host.name}"
@@ -109,7 +109,7 @@ describe Targeting do
     end
 
     context 'for no id' do
-      let(:query) { targeting.build_query_from_hosts([]) }
+      let(:query) { Targeting.build_query_from_hosts([]) }
 
       it 'builds query to find all hosts' do
         Host.search_for(query).must_include host


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman_remote_execution/pull/148
opening separate PR for discussing the katello-related issues. The general developer API comments should go to https://github.com/theforeman/foreman_remote_execution/pull/148.

- [x] - errata support
- [x] - tests for input sets import