### PR TITLE
fixes #13579 - sync templates during seed

### DIFF
--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -22,7 +22,10 @@ class Setting::RemoteExecution < Setting
                  'root'),
         self.set('remote_execution_effective_user_method',
                  N_('What command should be used to switch to the effective user. One of %s') % SSHExecutionProvider::EFFECTIVE_USER_METHODS.inspect,
-                 'sudo')
+                 'sudo'),
+        self.set('remote_execution_sync_templates',
+                 N_('Whether we should sync templates from disk when running db:seed.'),
+                 true)
       ].each { |s| self.create! s.update(:category => 'Setting::RemoteExecution') }
     end
 

--- a/db/seeds.d/70-job_templates.rb
+++ b/db/seeds.d/70-job_templates.rb
@@ -1,7 +1,8 @@
 User.as_anonymous_admin do
   JobTemplate.without_auditing do
     Dir[File.join("#{ForemanRemoteExecution::Engine.root}/app/views/templates/**/*.erb")].each do |template|
-      JobTemplate.import(File.read(template), :default => true, :locked => true)
+      sync = !Rails.env.test? && Setting[:remote_execution_sync_templates]
+      JobTemplate.import!(File.read(template), :default => true, :locked => true, :update => sync)
     end
   end
 end


### PR DESCRIPTION
This syncs job templates during `db:seed` (and bypasses the foreman idempotency check here only), so they're always up to date without needing to create individual migrations.

These sync methods will also be able to be used to add support for syncing job templates from git using the foreman_templates plugin.