### PR TITLE
fixes #13133, #13632 - improve package action template

### DIFF
--- a/app/models/input_template_renderer.rb
+++ b/app/models/input_template_renderer.rb
@@ -2,6 +2,9 @@ class InputTemplateRenderer
   class UndefinedInput < ::Foreman::Exception
   end
 
+  class RenderError < ::Foreman::Exception
+  end
+
   include UnattendedHelper
 
   attr_accessor :template, :host, :invocation, :input_values, :error_message
@@ -22,7 +25,7 @@ class InputTemplateRenderer
 
   def render
     @template.validate_unique_inputs!
-    render_safe(@template.template, ::Foreman::Renderer::ALLOWED_HELPERS + [ :input, :render_template, :preview? ], :host => @host)
+    render_safe(@template.template, ::Foreman::Renderer::ALLOWED_HELPERS + [ :input, :render_template, :preview?, :render_error ], :host => @host)
   rescue => e
     self.error_message ||= _('error during rendering: %s') % e.message
     Rails.logger.debug e.to_s + "\n" + e.backtrace.join("\n")
@@ -46,6 +49,10 @@ class InputTemplateRenderer
       self.error_message = _('input macro with name \'%s\' used, but no input with such name defined for this template') % name
       raise UndefinedInput, "Rendering failed, no input with name #{name} for input macro found"
     end
+  end
+
+  def render_error(message)
+    raise RenderError.new(message)
   end
 
   def render_template(template_name, input_values = {}, options = {})

--- a/app/views/templates/package_action.erb
+++ b/app/views/templates/package_action.erb
@@ -26,7 +26,17 @@ template_inputs:
   advanced: true
 %>
 
-die() {
+<%
+  supported_families = ['Redhat', 'Debian']
+  render_error(N_('Unsupported or no operating system found for this host.')) unless @host.operatingsystem && supported_families.include?(@host.operatingsystem.family)
+%>
+
+# Helper function that exits with a particular message and code.
+#
+# Usage:
+#   exit_with_message "Could not do a thing" 2
+#
+function exit_with_message() {
   echo "${1}, exiting..."
   exit $2
 }
@@ -35,7 +45,7 @@ die() {
   # Pre Script
   <%= input("pre_script") %>
   RETVAL=$?
-  [ $RETVAL -eq 0 ] || die "Pre script failed" $RETVAL
+  [ $RETVAL -eq 0 ] || exit_with_message "Pre script failed" $RETVAL
 <% end -%>
 
 # Action
@@ -45,11 +55,11 @@ die() {
   apt-get -y <%= input("action") %> <%= input("package") %>
 <% end -%>
 RETVAL=$?
-[ $RETVAL -eq 0 ] || die "Package action failed" $RETVAL
+[ $RETVAL -eq 0 ] || exit_with_message "Package action failed" $RETVAL
 
 <% unless input("post_script").blank? -%>
   # Post Script
   <%= input("post_script") %>
   RETVAL=$?
-  [ $RETVAL -eq 0 ] || die "Post script failed" $RETVAL
+  [ $RETVAL -eq 0 ] || exit_with_message "Post script failed" $RETVAL
 <% end -%>


### PR DESCRIPTION
This change renames the 'die' function to 'exit_with_message' as some
users found it particularly terrifying to see this as the first line in
the template preview. It also adds documentation to the function.

We can extract this to a helper snippet later if we have more or it
becomes useful elsewhere.

Secondly, it causes the package action template to fail more gracefully
when a host has no operating system, or an unsupported one.