### PR TITLE
Fixes #13689 - don't use authorized scope in provisioning template

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -38,7 +38,7 @@ module ForemanRemoteExecution
       get_interface_by_flag(:execution)
     end
 
-    def remote_execution_proxies(provider)
+    def remote_execution_proxies(provider, authorized = true)
       proxies = {}
       proxies[:subnet]   = execution_interface.subnet.remote_execution_proxies.with_features(provider) if execution_interface && execution_interface.subnet
       proxies[:fallback] = smart_proxies.with_features(provider) if Setting[:remote_execution_fallback_proxy]
@@ -50,14 +50,15 @@ module ForemanRemoteExecution
                         proxy_scope = ::SmartProxy
                       end
 
-        proxies[:global] = proxy_scope.authorized.with_features(provider)
+        proxy_scope = proxy_scope.authorized if authorized
+        proxies[:global] = proxy_scope.with_features(provider)
       end
 
       proxies
     end
 
     def remote_execution_ssh_keys
-      remote_execution_proxies('SSH').values.flatten.uniq.map { |proxy| proxy.pubkey }.compact.uniq
+      remote_execution_proxies('SSH', false).values.flatten.uniq.map { |proxy| proxy.pubkey }.compact.uniq
     end
 
     def drop_execution_interface_cache

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -40,6 +40,17 @@ describe ForemanRemoteExecution::HostExtensions do
     it 'has ssh keys in the parameters' do
       host.remote_execution_ssh_keys.must_include sshkey
     end
+
+    it 'has ssh keys in the parameters even when no user specified' do
+      # this is a case, when using the helper in provisioning templates
+      FactoryGirl.create(:smart_proxy, :ssh) do |proxy|
+        proxy.organizations << host.organization
+        proxy.locations << host.location
+      end
+      host.interfaces.first.subnet.remote_execution_proxies.clear
+      User.current = nil
+      host.remote_execution_ssh_keys.must_include sshkey
+    end
   end
 
   context 'host has multiple nics' do


### PR DESCRIPTION
The user is not set in context of provisioning, therefore the public
keys of the global proxies were not populated properly into the provisioned
hosts.