### PR TITLE
Fixes #13786 - Distinguish between planned and running

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -62,6 +62,10 @@ module RemoteExecutionHelper
   def template_invocation_status(task)
     if task.nil?
       icon_text('question', 'N/A', :kind => 'fa')
+    elsif task.state == 'running'
+      icon_text('running', _('running'), :kind => 'pficon')
+    elsif task.state == 'planned'
+      icon_text('build', _('planned'), :kind => 'pficon')
     else
       case task.result
         when 'warning', 'error'
@@ -72,8 +76,6 @@ module RemoteExecutionHelper
           end
         when 'success'
           icon_text('ok', _('success'), :kind => 'pficon')
-        when 'pending'
-          icon_text('question', _('pending'), :kind => 'fa')
         else
           task.result
       end


### PR DESCRIPTION
Old: can't figure out how many tasks are actually running when using concurrency control
![old](https://i.imgur.com/XwzqAjp.png)

New:
![new](https://i.imgur.com/WejLjW2.png)