### PR TITLE
fixes #13500 - Pxe-less reprovision with remote execution

### DIFF
--- a/app/controllers/concerns/foreman_remote_execution/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_remote_execution/hosts_controller_extensions.rb
@@ -1,0 +1,36 @@
+module ForemanRemoteExecution
+  module HostsControllerExtensions
+    extend ActiveSupport::Concern
+    include Foreman::Renderer
+
+    included do
+      alias_method_chain(:action_permission, :remote_execution)
+    end
+
+    def reprovision
+      find_resource
+      script_template = @host.provisioning_template(:kind => 'script')
+      if script_template.nil?
+        process_error :redirect => :back, :error_msg => _("No script provisioning template available")
+        return
+      end
+      @host.setBuild
+      script = unattended_render(script_template.template, @template_name)
+      composer = JobInvocationComposer.for_feature(:reprovision, @host, :script => script)
+      composer.save!
+      composer.trigger
+      process_success :success_msg => _("Reprovision job started. The host should reboot soon."), :success_redirect => :back
+    end
+
+    private
+
+    def action_permission_with_remote_execution
+      case params[:action]
+      when 'reprovision'
+        :edit_host
+      else
+        action_permission_without_remote_execution
+      end
+    end
+  end
+end

--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -11,9 +11,13 @@ module ForemanRemoteExecution
       multiple_actions_without_remote_execution + [[_('Run Job'), new_job_invocation_path, false]]
     end
 
-    def host_title_actions_with_run_button(*args)
-      title_actions(button_group(link_to(_('Run Job'), new_job_invocation_path(:host_ids => [args.first.id]), :id => :run_button)))
-      host_title_actions_without_run_button(*args)
+    def host_title_actions_with_run_button(host)
+      links = [link_to(_('Run Job'), new_job_invocation_path(:host_ids => [host.id]), :id => :run_button)]
+      if RemoteExecutionFeature.feature(:reprovision).job_template && @host.provisioning_template(:kind => 'script')
+        links << link_to(_('Reprovision'), reprovision_host_path(host.id), { :method => :post, :disabled =>  @host.build })
+      end
+      title_actions(button_group(*links))
+      host_title_actions_without_run_button(host)
     end
   end
 end

--- a/app/views/templates/reprovision.erb
+++ b/app/views/templates/reprovision.erb
@@ -1,0 +1,16 @@
+<%#
+kind: job_template
+name: Reprovision - SSH Default
+job_category: Power
+description_format: 'Reprovision host'
+feature: reprovision
+provider_type: SSH
+template_inputs:
+- name: script
+  description: script to configure the bootloader to provision on next boot
+  input_type: user
+  required: true
+%>
+
+<%= input('script') %>
+<%= render_template("Power Action - SSH Default", :action => "restart") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  resources :hosts, :only => [] do
+    member do
+      post 'reprovision', :method => :post
+    end
+  end
+
   resources :job_templates, :except => [:show] do
     member do
       get 'clone_template'

--- a/db/migrate/20160201154900_change_template_invocation_input_values_value.rb
+++ b/db/migrate/20160201154900_change_template_invocation_input_values_value.rb
@@ -1,0 +1,5 @@
+class ChangeTemplateInvocationInputValuesValue < ActiveRecord::Migration
+  def change
+    change_column :template_invocation_input_values, :value, :text
+  end
+end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -103,6 +103,10 @@ module ForemanRemoteExecution
         register_custom_status HostStatus::ExecutionStatus
         # add dashboard widget
         # widget 'foreman_remote_execution_widget', name: N_('Foreman plugin template widget'), sizex: 4, sizey: 1
+
+        RemoteExecutionFeature.register(:reprovision, N_("Reprovision"),
+                                        :description => "Reprovision the host via a script",
+                                        :provided_inputs => ['script'])
       end
     end
 
@@ -133,6 +137,9 @@ module ForemanRemoteExecution
       #   Template.reflect_on_association :template_inputs # => <#Association...
       #   ProvisioningTemplate.reflect_on_association :template_inputs # => nil
       require_dependency 'job_template'
+
+      HostsController.send(:include, ForemanRemoteExecution::HostsControllerExtensions)
+
       (Template.descendants + [Template]).each { |klass| klass.send(:include, ForemanRemoteExecution::TemplateExtensions) }
 
       (Taxonomy.descendants + [Taxonomy]).each { |klass| klass.send(:include, ForemanRemoteExecution::TaxonomyExtensions) }


### PR DESCRIPTION
This commit adds ability to run the script provision template
via remote execution and reboot the host, which effectively
brings PXEless provisioning into Foreman.