### PR TITLE
Fixes #13839 - Show provider humanized name on job templates form

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/ModuleLength
 module RemoteExecutionHelper
   def providers_options
-    RemoteExecutionProvider.providers.map { |key, provider| [ key, _(provider) ] }
+    RemoteExecutionProvider.providers.map { |key, provider| [ key, _(provider.humanized_name) ] }
   end
 
   def template_input_types_options


### PR DESCRIPTION
Currently it shows the provider class name, which the user doesn't need
to know about.

Before:
![screenshot from 2016-02-22 21-26-14](https://cloud.githubusercontent.com/assets/598891/13231634/1c10356e-d9ab-11e5-9bb1-46d91f8a46ed.png)

After:
![screenshot from 2016-02-22 21-25-40](https://cloud.githubusercontent.com/assets/598891/13231633/1be06316-d9ab-11e5-946e-9ef4dd2bdd24.png)
