### PR TITLE
Fixes #12105 - Parse ANSI terminal codes into colorful HTML

### DIFF
--- a/app/helpers/job_invocation_output_helper.rb
+++ b/app/helpers/job_invocation_output_helper.rb
@@ -1,0 +1,42 @@
+module JobInvocationOutputHelper
+  CONSOLE_COLOR = {
+      '31' => 'red',
+      '32' => 'lightgreen',
+      '33' => 'orange',
+      '34' => 'deepskyblue',
+      '35' => 'mediumpurple',
+      '36' => 'cyan',
+      '37' => 'grey',
+      '91' => 'red',
+      '92' => 'lightgreen',
+      '93' => 'yellow',
+      '94' => 'lightblue',
+      '95' => 'violet',
+      '96' => 'turquoise',
+      '0'  => 'default',
+    }
+  CONSOLE_COLOR.default = 'default'
+
+  def colorize_line(line)
+    line = line.gsub(/\e\[.*?m/) do |seq|
+      color = seq[/(\d+)m/,1]
+      "{{{format color:#{color}}}}"
+    end
+
+    current_color = 'default'
+    out = %{<span style="color: #{@current_color}">}
+    parts = line.split(/({{{format.*?}}})/)
+    parts.each do |console_line|
+      if console_line.include?('{{{format')
+        if (color_index = console_line[/color:(\d+)/, 1]).present?
+          current_color = CONSOLE_COLOR[color_index]
+          out << %{</span><span style="color: #{current_color}">}
+        end
+      else
+        out << h(console_line)
+      end
+    end
+    out << %{</span>}
+    out
+  end
+end

--- a/app/views/template_invocations/_output_line_set.html.erb
+++ b/app/views/template_invocations/_output_line_set.html.erb
@@ -2,6 +2,6 @@
   <%= content_tag :div, :class => 'line ' + output_line_set['output_type'], :data => { :timestamp => output_line_set['timestamp'] } do %>
 
     <%= content_tag(:span, (@line_counter += 1).to_s.rjust(4).gsub(' ', '&nbsp;').html_safe + ':', :class => 'counter', :title => (output_line_set['timestamp'] && Time.at(output_line_set['timestamp']))) %>
-    <%= content_tag(:div, (line.empty? ? '&nbsp;' : h(line)).html_safe, :class => 'content') %>
+    <%= content_tag(:div, (line.empty? ? '&nbsp;' : colorize_line(line)).html_safe, :class => 'content') %>
   <% end %>
 <% end %>


### PR DESCRIPTION
There are client-side libraries that can do this, and I'd argue that's
the way it should be done. However, given the state of affairs with
gemified assets (we don't know if we're going to move to npm or
something like that) and the fact I already had this code ready, this
could be a temporary solution to display nicer console output.

Taken from https://github.com/theforeman/foreman_remote_execution/pull/134/files
