### PR TITLE
fixes #13922 - import/export job templates with metadata

### DIFF
--- a/app/assets/javascripts/job_templates.js
+++ b/app/assets/javascripts/job_templates.js
@@ -1,0 +1,10 @@
+function show_import_job_template_modal() {
+  var modal_window = $('#importJobTemplateModal');
+  modal_window.modal({'show': true});
+  modal_window.find('a[rel="popover-modal"]').popover();
+}
+
+function close_import_job_template_modal() {
+  var modal_window = $('#importJobTemplateModal');
+  modal_window.modal('hide');
+}

--- a/app/assets/stylesheets/modal_window.css.scss
+++ b/app/assets/stylesheets/modal_window.css.scss
@@ -1,0 +1,4 @@
+div.modal-body {
+  overflow-y: auto;
+  max-height: 500px;
+}

--- a/app/controllers/job_templates_controller.rb
+++ b/app/controllers/job_templates_controller.rb
@@ -25,7 +25,7 @@ class JobTemplatesController < ::TemplatesController
   end
 
   def import
-    contents = params[:imported_template][:template].respond_to?(:read) ? params[:imported_template][:template].read : nil
+    contents = params.fetch(:imported_template, {}).fetch(:template, nil).try(:read)
 
     @template = JobTemplate.import(contents, :update => Foreman::Cast.to_bool(params[:imported_template][:overwrite]))
     if @template && @template.save
@@ -56,9 +56,7 @@ class JobTemplatesController < ::TemplatesController
 
   def action_permission
     case params[:action]
-      when 'auto_complete_job_category'
-        :view_job_templates
-      when 'export'
+      when 'auto_complete_job_category', 'export'
         :view_job_templates
       else
         super

--- a/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
@@ -9,6 +9,8 @@ module ForemanRemoteExecution
     def permitted_actions_with_run_button(template)
       original = permitted_actions_without_run_button(template)
 
+      original.unshift(display_link_if_authorized(_('Export'), hash_for_export_job_template_path(:id => template.id), 'data-no-turbolink' => true))
+
       if template.is_a?(JobTemplate) && !template.snippet
         original.unshift(display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(:template_id => template.id)))
       end

--- a/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
@@ -9,10 +9,9 @@ module ForemanRemoteExecution
     def permitted_actions_with_run_button(template)
       original = permitted_actions_without_run_button(template)
 
-      original.unshift(display_link_if_authorized(_('Export'), hash_for_export_job_template_path(:id => template.id), 'data-no-turbolink' => true))
-
-      if template.is_a?(JobTemplate) && !template.snippet
-        original.unshift(display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(:template_id => template.id)))
+      if template.is_a?(JobTemplate)
+        original.unshift(display_link_if_authorized(_('Export'), hash_for_export_job_template_path(:id => template.id), 'data-no-turbolink' => true))
+        original.unshift(display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(:template_id => template.id))) unless template.snippet
       end
 
       original

--- a/app/models/concerns/foreman_remote_execution/exportable.rb
+++ b/app/models/concerns/foreman_remote_execution/exportable.rb
@@ -16,12 +16,11 @@ module ForemanRemoteExecution
       self.class.exportable_attributes.keys.inject({}) do |hash, attribute|
         value = export_attr(attribute, self.class.exportable_attributes[attribute], include_blank)
 
-        if include_blank
+        # Rails considers false blank, but if a boolean value is explicitly set false, we want to ensure we export it.
+        if include_blank || value.present? || value == false
           hash.update(attribute => value)
         else
-          # Rails considers false blank, but if a boolean value is explicitly
-          # set false, we want to ensure we export it.
-          (value.blank? && value != false) ? hash : hash.update(attribute => value)
+          hash
         end
       end.stringify_keys
     end

--- a/app/models/concerns/foreman_remote_execution/exportable.rb
+++ b/app/models/concerns/foreman_remote_execution/exportable.rb
@@ -1,0 +1,32 @@
+module ForemanRemoteExecution
+  module Exportable
+    extend ActiveSupport::Concern
+
+    def to_export
+      self.class.exportable_attributes.inject({}) do |hash, attribute|
+        value = self.send(attribute)
+        value = value.respond_to?(:to_export) ? value.to_export : value
+        value = value.respond_to?(:map) ? export_iterable(value) : value
+        value.blank? ? hash : hash.update(attribute => value)
+      end.stringify_keys
+    end
+
+    def export_iterable(items)
+      items.map do |item|
+        item.respond_to?(:to_export) ? item.to_export : item
+      end
+    end
+
+    module ClassMethods
+      def attr_exportable(*args)
+        @attr_exportable ||= []
+        @attr_exportable += args
+      end
+
+      def exportable_attributes
+        @attr_exportable.dup
+      end
+    end
+
+  end
+end

--- a/app/models/concerns/foreman_remote_execution/exportable.rb
+++ b/app/models/concerns/foreman_remote_execution/exportable.rb
@@ -11,42 +11,41 @@ module ForemanRemoteExecution
     extend ActiveSupport::Concern
 
     def to_export
-      self.class.exportable_attributes.inject({}) do |hash, attribute|
-        value = export_attr(attribute)
+      self.class.exportable_attributes.keys.inject({}) do |hash, attribute|
+        value = export_attr(attribute, self.class.exportable_attributes[attribute])
         value.blank? ? hash : hash.update(attribute => value)
       end.stringify_keys
     end
 
-    def export_attr(attribute)
-      value = self.send(attribute) if self.respond_to?(attribute)
+    def export_attr(attribute, exporter)
+      value = if exporter.respond_to?(:call)
+                exporter.call(self)
+              elsif self.respond_to?(exporter)
+                self.send(exporter)
+              end
 
-      if self.class.custom_exports.include?(attribute)
-        self.class.custom_exports[attribute].call(self)
-      elsif value.respond_to?(:to_export)
-        value.to_export
-      elsif value.respond_to?(:map)
-        export_iterable(value)
-      else
-        value
-      end
+      value.respond_to?(:map) ? export_iterable(value) : value
     end
 
     def export_iterable(items)
-      items.map do |item|
-        item.respond_to?(:to_export) ? item.to_export : item
-      end
+      items.map { |item| item.respond_to?(:to_export) ? item.to_export : item }
     end
 
     module ClassMethods
-      attr_reader :exportable_attributes, :custom_exports
+      attr_reader :exportable_attributes
 
       # Takes an array of exportable attributes, or a custom exports hash.  The
       # custom exports hash should be a key/proc pair used to export the
       # particular attribute.
       def attr_exportable(*args)
-        @custom_exports = args.last.is_a?(Hash) ? args.pop : {}
-        @exportable_attributes ||= []
-        @exportable_attributes += args + @custom_exports.keys
+        @exportable_attributes ||= {}
+        args.each do |arg|
+          if arg.is_a?(Hash)
+            @exportable_attributes.merge!(arg)
+          else
+            @exportable_attributes.merge!(arg => arg)
+          end
+        end
       end
     end
 

--- a/app/models/concerns/foreman_remote_execution/exportable.rb
+++ b/app/models/concerns/foreman_remote_execution/exportable.rb
@@ -1,14 +1,34 @@
+# This concern makes it easy to export an ActiveRecord object with specified
+# attributes and associations only.  If a specified assocation also includes
+# this concern, then it will likewise be exported. Custom attributes can be
+# specified as an options hast consisting of a custom export lambda.
+#
+# Example:
+#   attr_exportable :name, :address, :company => ->(user) { user.company.name }
+#
 module ForemanRemoteExecution
   module Exportable
     extend ActiveSupport::Concern
 
     def to_export
       self.class.exportable_attributes.inject({}) do |hash, attribute|
-        value = self.send(attribute)
-        value = value.respond_to?(:to_export) ? value.to_export : value
-        value = value.respond_to?(:map) ? export_iterable(value) : value
+        value = export_attr(attribute)
         value.blank? ? hash : hash.update(attribute => value)
       end.stringify_keys
+    end
+
+    def export_attr(attribute)
+      value = self.send(attribute) if self.respond_to?(attribute)
+
+      if self.class.custom_exports.include?(attribute)
+        self.class.custom_exports[attribute].call(self)
+      elsif value.respond_to?(:to_export)
+        value.to_export
+      elsif value.respond_to?(:map)
+        export_iterable(value)
+      else
+        value
+      end
     end
 
     def export_iterable(items)
@@ -18,13 +38,15 @@ module ForemanRemoteExecution
     end
 
     module ClassMethods
-      def attr_exportable(*args)
-        @attr_exportable ||= []
-        @attr_exportable += args
-      end
+      attr_reader :exportable_attributes, :custom_exports
 
-      def exportable_attributes
-        @attr_exportable.dup
+      # Takes an array of exportable attributes, or a custom exports hash.  The
+      # custom exports hash should be a key/proc pair used to export the
+      # particular attribute.
+      def attr_exportable(*args)
+        @custom_exports = args.last.is_a?(Hash) ? args.pop : {}
+        @exportable_attributes ||= []
+        @exportable_attributes += args + @custom_exports.keys
       end
     end
 

--- a/app/models/foreign_input_set.rb
+++ b/app/models/foreign_input_set.rb
@@ -5,7 +5,7 @@ class ForeignInputSet < ActiveRecord::Base
   end
 
   attr_accessible :template_id, :target_template_id, :include_all, :include, :exclude
-  attr_exportable :template_name, :exclude, :include, :include_all
+  attr_exportable :exclude, :include, :include_all, :template => ->(input_set) { input_set.template.name }
 
   belongs_to :template
   belongs_to :target_template, :class_name => 'Template'
@@ -14,11 +14,6 @@ class ForeignInputSet < ActiveRecord::Base
 
   validates :target_template, :presence => true
   validate :check_circular_dependency
-
-  def to_export
-    hash = super
-    hash.update('template' => hash.delete('template_name'))
-  end
 
   def inputs(templates_stack = [])
     return [] unless target_template

--- a/app/models/foreign_input_set.rb
+++ b/app/models/foreign_input_set.rb
@@ -1,8 +1,11 @@
 class ForeignInputSet < ActiveRecord::Base
+  include ForemanRemoteExecution::Exportable
+
   class CircularDependencyError < Foreman::Exception
   end
 
   attr_accessible :template_id, :target_template_id, :include_all, :include, :exclude
+  attr_exportable :template_name, :exclude, :include, :include_all
 
   belongs_to :template
   belongs_to :target_template, :class_name => 'Template'
@@ -11,6 +14,11 @@ class ForeignInputSet < ActiveRecord::Base
 
   validates :target_template, :presence => true
   validate :check_circular_dependency
+
+  def to_export
+    hash = super
+    hash.update('template' => hash.delete('template_name'))
+  end
 
   def inputs(templates_stack = [])
     return [] unless target_template

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -6,7 +6,7 @@ class JobTemplate < ::Template
 
   attr_accessible :job_category, :provider_type, :description_format, :effective_user_attributes
   attr_exportable :name, :job_category, :description_format, :snippet, :template_inputs,
-    :foreign_input_sets, :provider_type
+    :foreign_input_sets, :provider_type, :kind => ->(template) { template.class.name.underscore }
 
   include Authorizable
   extend FriendlyId
@@ -79,7 +79,7 @@ class JobTemplate < ::Template
       template.sync_inputs(metadata.delete('template_inputs'))
       template.sync_foreign_input_sets(metadata.delete('foreign_input_sets'))
       template.sync_feature(metadata.delete('feature'))
-      template.assign_attributes(metadata.merge(:template => contents.gsub(/<%\#.+?.-?%>\n?/m, '')).merge(options))
+      template.assign_attributes(metadata.merge(:template => contents.gsub(/<%\#.+?.-?%>\n?/m, '').strip).merge(options))
       template.assign_taxonomies if template.new_record?
 
       template
@@ -93,8 +93,7 @@ class JobTemplate < ::Template
   end
 
   def metadata
-    metadata = to_export.merge('kind' => 'job_template')
-    "<%#\n#{metadata.to_yaml.gsub(/\A---$/, '').strip}\n%>\n\n"
+    "<%#\n#{to_export.to_yaml.sub(/\A---$/, '').strip}\n%>\n\n"
   end
 
   # 'Package Action - SSH Default' => 'package_action_ssh_default.erb'

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -93,7 +93,7 @@ class JobTemplate < ::Template
   end
 
   def metadata
-    "<%#\n#{to_export.to_yaml.sub(/\A---$/, '').strip}\n%>\n\n"
+    "<%#\n#{to_export(false).to_yaml.sub(/\A---$/, '').strip}\n%>\n\n"
   end
 
   # 'Package Action - SSH Default' => 'package_action_ssh_default.erb'

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -1,4 +1,6 @@
 class TemplateInput < ActiveRecord::Base
+  include ForemanRemoteExecution::Exportable
+
   class ValueNotReady < ::Foreman::Exception
   end
   class UnsatisfiedRequiredInput < ::Foreman::Exception
@@ -10,6 +12,8 @@ class TemplateInput < ActiveRecord::Base
   attr_accessible :name, :required, :input_type, :fact_name, :variable_name,
                   :puppet_class_name, :puppet_parameter_name, :description, :template_id,
                   :options, :advanced
+
+  attr_exportable(*self.accessible_attributes - %w(template_id))
 
   belongs_to :template
   has_many :template_invocation_input_values, :dependent => :destroy

--- a/app/views/job_invocations/_preview_hosts_modal.html.erb
+++ b/app/views/job_invocations/_preview_hosts_modal.html.erb
@@ -1,3 +1,5 @@
+<% stylesheet 'modal_window' %>
+
 <!-- modal window -->
 <div class="modal fade" id="previewHostsModal" role="dialog" aria-hidden="true" data-url="<%= preview_hosts_job_invocations_path %>">
   <div class="modal-dialog">
@@ -6,7 +8,7 @@
         <button type="button" class="close" onclick="close_preview_hosts_modal(); return false;"><span aria-hidden="true">&times;</span><span class="sr-only"><%= _('Close') %></span></button>
         <h4 class="modal-title">Preview Hosts</h4>
       </div>
-      <div class="modal-body" style="overflow-y: auto; max-height: 500px;">
+      <div class="modal-body">
       </div>
     </div>
   </div>

--- a/app/views/job_templates/_import_job_template_modal.html.erb
+++ b/app/views/job_templates/_import_job_template_modal.html.erb
@@ -1,3 +1,5 @@
+<% stylesheet 'modal_window' %>
+
 <!-- modal window -->
 <div class="modal fade" id="importJobTemplateModal" role="dialog" aria-hidden="true">
   <div class="modal-dialog">
@@ -6,7 +8,7 @@
         <button type="button" class="close" onclick="close_import_job_template_modal(); return false;"><span aria-hidden="true">&times;</span><span class="sr-only"><%= _('Close') %></span></button>
         <h4 class="modal-title">Import Job Template</h4>
       </div>
-      <div class="modal-body" style="overflow-y: auto; max-height: 500px;">
+      <div class="modal-body">
         <%= form_for :imported_template, :url => import_job_templates_path do |f| %>
           <%= file_field_f f, :template, :size => "col-md-10", :help_block  => _("Select an ERB file to upload in order to import a job template.  The template must contain metadata in the first ERB comment.") %>
           <%= checkbox_f(f, :overwrite, :label => _('Overwrite'), :help_block => _("Whether to overwrite the template if it already exists")) %>

--- a/app/views/job_templates/_import_job_template_modal.html.erb
+++ b/app/views/job_templates/_import_job_template_modal.html.erb
@@ -1,0 +1,18 @@
+<!-- modal window -->
+<div class="modal fade" id="importJobTemplateModal" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" onclick="close_import_job_template_modal(); return false;"><span aria-hidden="true">&times;</span><span class="sr-only"><%= _('Close') %></span></button>
+        <h4 class="modal-title">Import Job Template</h4>
+      </div>
+      <div class="modal-body" style="overflow-y: auto; max-height: 500px;">
+        <%= form_for :imported_template, :url => import_job_templates_path do |f| %>
+          <%= file_field_f f, :template, :size => "col-md-10", :help_block  => _("Select an ERB file to upload in order to import a job template.  The template must contain metadata in the first ERB comment.") %>
+          <%= checkbox_f(f, :overwrite, :label => _('Overwrite'), :help_block => _("Whether to overwrite the template if it already exists")) %>
+          <%= submit_or_cancel f, false, :cancel_path => 'javascript:close_import_job_template_modal();' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/job_templates/index.html.erb
+++ b/app/views/job_templates/index.html.erb
@@ -6,7 +6,8 @@
 <% title _("Job Templates") %>
 <% title_actions(documentation_button_rex('3.1JobTemplates'),
                  link_to_function(_('Import'), 'show_import_job_template_modal();', :class => 'btn btn-default'),
-                 new_link(_('New Job Template'), hash_for_new_job_template_path)) %>
+                 display_link_if_authorized(_("New Job Template"),
+                                            hash_for_new_job_template_path)) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>

--- a/app/views/job_templates/index.html.erb
+++ b/app/views/job_templates/index.html.erb
@@ -5,8 +5,8 @@
 
 <% title _("Job Templates") %>
 <% title_actions(documentation_button_rex('3.1JobTemplates'),
-                 link_to_function(_('Import'), 'show_import_job_template_modal();'),
-                 display_link_if_authorized(_('New Job Template'), hash_for_new_job_template_path)) %>
+                 link_to_function(_('Import'), 'show_import_job_template_modal();', :class => 'btn btn-default'),
+                 new_link(_('New Job Template'), hash_for_new_job_template_path)) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>

--- a/app/views/job_templates/index.html.erb
+++ b/app/views/job_templates/index.html.erb
@@ -1,11 +1,12 @@
 <%= include_javascript if SETTINGS[:version].short == '1.9' %>
+<%= javascript 'job_templates' %>
 <%= javascript 'lookup_keys' %>
 <%= javascript 'template_input' %>
 
 <% title _("Job Templates") %>
 <% title_actions(documentation_button_rex('3.1JobTemplates'),
-                 display_link_if_authorized(_("New Job Template"),
-                                            hash_for_new_job_template_path)) %>
+                 link_to_function(_('Import'), 'show_import_job_template_modal();'),
+                 display_link_if_authorized(_('New Job Template'), hash_for_new_job_template_path)) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>
@@ -33,3 +34,5 @@
   </tbody>
 </table>
 <%= will_paginate_with_info @templates %>
+
+<%= render :partial => 'import_job_template_modal' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,13 @@ Rails.application.routes.draw do
     member do
       get 'clone_template'
       get 'lock'
+      get 'export'
       get 'unlock'
       post 'preview'
     end
     collection do
       post 'preview'
+      post 'import'
       get 'revision'
       get 'auto_complete_search'
       get 'auto_complete_job_category'
@@ -45,9 +47,11 @@ Rails.application.routes.draw do
       resources :job_templates, :except => [:new, :edit] do
         (resources :locations, :only => [:index, :show]) if SETTINGS[:locations_enabled]
         (resources :organizations, :only => [:index, :show]) if SETTINGS[:organizations_enabled]
+        get :export, :on => :member
         post :clone, :on => :member
         collection do
           get 'revision'
+          post 'import'
         end
       end
 

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -35,12 +35,12 @@ module ForemanRemoteExecution
 
         # Add permissions
         security_block :foreman_remote_execution do
-          permission :view_job_templates, { :job_templates => [:index, :show, :revision, :auto_complete_search, :auto_complete_job_category, :preview],
-                                            :'api/v2/job_templates' => [:index, :show, :revision],
+          permission :view_job_templates, { :job_templates => [:index, :show, :revision, :auto_complete_search, :auto_complete_job_category, :preview, :export],
+                                            :'api/v2/job_templates' => [:index, :show, :revision, :export],
                                             :'api/v2/template_inputs' => [:index, :show],
                                             :'api/v2/foreign_input_sets' => [:index, :show]}, :resource_type => 'JobTemplate'
-          permission :create_job_templates, { :job_templates => [:new, :create, :clone_template],
-                                              :'api/v2/job_templates' => [:create, :clone] }, :resource_type => 'JobTemplate'
+          permission :create_job_templates, { :job_templates => [:new, :create, :clone_template, :import],
+                                              :'api/v2/job_templates' => [:create, :clone, :import] }, :resource_type => 'JobTemplate'
           permission :edit_job_templates, { :job_templates => [:edit, :update],
                                             :'api/v2/job_templates' => [:update],
                                             :'api/v2/template_inputs' => [:create, :update, :destroy],

--- a/test/functional/api/v2/job_templates_controller_test.rb
+++ b/test/functional/api/v2/job_templates_controller_test.rb
@@ -69,6 +69,21 @@ module Api
                      :job_template => {:name => ''}
         assert_response :unprocessable_entity
       end
+
+      test 'should export template' do
+        get :export, :id => @template.to_param
+        assert_equal @response.body, @template.to_erb
+        assert_response :success
+      end
+
+      test 'should import template' do
+        new_name = @template.name = "#{@template.name}_renamed"
+        erb_data = @template.to_erb
+        post :import, :template => erb_data
+        assert_response :success
+        assert JobTemplate.find_by_name(new_name)
+      end
     end
+
   end
 end

--- a/test/unit/concerns/exportable_test.rb
+++ b/test/unit/concerns/exportable_test.rb
@@ -1,0 +1,88 @@
+require 'test_plugin_helper'
+
+module ForemanRemoteExecution
+  class ExportableTest < ActiveSupport::TestCase
+    class SampleModel
+      include ::ForemanRemoteExecution::Exportable
+
+      attr_accessor :name, :attrs, :subnet, :mac, :password, :subnet
+      attr_exportable :name, :attrs, :mac, :subnet, :mac => ->(m) { m.mac.upcase if m.mac },
+        :custom_attr => ->(m) { "hello world" }
+
+      def attributes
+        {
+          'name' => name,
+          'attrs' => attrs,
+          'mac' => mac,
+          'password' => password,
+          'subnet' => subnet
+        }
+      end
+    end
+
+    class SampleSubnet
+      include ::ForemanRemoteExecution::Exportable
+
+      attr_accessor :name, :network
+      attr_exportable :name, :network
+
+      def attributes
+        {
+          'name' => name,
+          'network' => network
+        }
+      end
+    end
+
+    def setup
+      @subnet = SampleSubnet.new
+      @subnet.name = 'pxe'
+      @subnet.network = '192.168.122.0'
+
+      @sample = SampleModel.new
+      @sample.name = 'name'
+      @sample.attrs = {'nested' => 'hash'}
+      @sample.subnet = @subnet
+      @sample.mac = 'aa:bb:cc:dd:ee:ff'
+      @sample.password = 'password'
+    end
+
+    test '#to_export includes all specified attributes' do
+      assert_equal %w(name attrs mac subnet custom_attr), @sample.to_export.keys
+    end
+
+    test '#to_export does not include all attributes' do
+      assert_not_include @sample.to_export.keys, 'password'
+    end
+
+    test "#to_export calls the lambda" do
+      export = @sample.to_export
+      assert_equal('AA:BB:CC:DD:EE:FF', export['mac'])
+      assert_equal(export['custom_attr'], "hello world")
+    end
+
+    test '#to_export values are exported recursively' do
+      export = @sample.to_export
+      assert_equal('pxe', export['subnet']['name'])
+      assert_equal('192.168.122.0', export['subnet']['network'])
+    end
+
+    test '#to_export nested hashes are primitive' do
+      @sample.attrs = {:foo => 'bar', :baz => 'qux'}.with_indifferent_access
+      export = @sample.to_export
+      assert_instance_of Hash, export['attrs']
+    end
+
+    test '#to_export includes blank values' do
+      @sample.attrs = {}
+      export = @sample.to_export
+      assert_instance_of Hash, export['attrs']
+    end
+
+    test '#to_export(false) does not include blank values' do
+      @sample.attrs = {}
+      export = @sample.to_export(false)
+      assert_nil export['attrs']
+    end
+  end
+end

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -226,6 +226,38 @@ describe JobTemplate do
     end
   end
 
+  context 'template export' do
+    let(:exportable_template) do
+      FactoryGirl.create(:job_template, :with_input)
+    end
+
+    let(:erb) do
+      exportable_template.to_erb
+    end
+
+    it 'exports name' do
+      erb.must_match(/^name: #{exportable_template.name}$/)
+    end
+
+    it 'includes template inputs' do
+      erb.must_match(/^template_inputs:$/)
+    end
+
+    it 'includes template contents' do
+      erb.must_include exportable_template.template
+    end
+
+    it 'is importable' do
+      erb
+      old_name = exportable_template.name
+      exportable_template.update_attributes(:name => "#{old_name}_renamed")
+
+      imported = JobTemplate.import!(erb)
+      imported.name.must_equal old_name
+      imported.template_inputs.first.to_export.must_equal exportable_template.template_inputs.first.to_export
+    end
+  end
+
   context 'there is existing template invocation of a job template' do
     let(:job_invocation) { FactoryGirl.create(:job_invocation, :with_template) }
     let(:job_template) { job_invocation.pattern_template_invocations.first.template }

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -217,7 +217,7 @@ describe JobTemplate do
     end
 
     it 'syncs content' do
-      synced_template.template.must_match(/\s+ping -c <%= input\('count'\) %> <%= input\('hostname'\) %>\s+/m)
+      synced_template.template.must_match(/ping -c <%= input\('count'\) %> <%= input\('hostname'\) %>/m)
     end
 
     it 'syncs input sets' do

--- a/test/unit/template_input_test.rb
+++ b/test/unit/template_input_test.rb
@@ -3,6 +3,21 @@ require 'test_plugin_helper'
 describe TemplateInput do
   let(:template_input) { FactoryGirl.build(:template_input) }
 
+  context 'export' do
+    before do
+      template_input.input_type = 'user'
+      template_input.options = "foo\nbar\nbaz"
+    end
+
+    it 'exports type' do
+      template_input.to_export['input_type'].must_equal template_input.input_type
+    end
+
+    it 'exports options' do
+      template_input.to_export['options'].must_equal template_input.options
+    end
+  end
+
   context 'user input' do
     before { template_input.input_type = 'user' }
     it { assert template_input.user_template_input? }


### PR DESCRIPTION
This lets you export the template in our import format (metadata in a YAML comment).  The idea here is to facilitate easier sharing / creation of new templates, moving us a step closer to creating a vibrant community of job templates in the community-templates repo.