### PR TITLE
fixes #14506 - use new_link helpers, and use button css

### DIFF
--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -12,7 +12,7 @@ module ForemanRemoteExecution
     end
 
     def host_title_actions_with_run_button(*args)
-      title_actions(button_group(link_to(_('Run Job'), new_job_invocation_path(:host_ids => [args.first.id]), :id => :run_button)))
+      title_actions(button_group(link_to(_('Run Job'), new_job_invocation_path(:host_ids => [args.first.id]), :id => :run_button, :class => 'btn btn-default')))
       host_title_actions_without_run_button(*args)
     end
   end

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -96,7 +96,7 @@ module RemoteExecutionHelper
   def job_invocations_buttons
     [
       documentation_button_rex('3.2ExecutingaJob'),
-      display_link_if_authorized(_('Run Job'), hash_for_new_job_invocation_path)
+      new_link(_('Run Job'))
     ]
   end
 

--- a/app/views/job_templates/index.html.erb
+++ b/app/views/job_templates/index.html.erb
@@ -6,8 +6,7 @@
 <% title _("Job Templates") %>
 <% title_actions(documentation_button_rex('3.1JobTemplates'),
                  link_to_function(_('Import'), 'show_import_job_template_modal();', :class => 'btn btn-default'),
-                 display_link_if_authorized(_("New Job Template"),
-                                            hash_for_new_job_template_path)) %>
+                 new_link(_("New Job Template"))) %>
 
 <table class="table table-bordered table-striped table-two-pane table-fixed">
   <thead>


### PR DESCRIPTION
Button links are broken in a few places due to https://groups.google.com/forum/#!topic/foreman-dev/QB9ZeK_m0Qw.

Foreman now provides a new_link helper for creating new objects. We need to use
that on the Job Templates and Invocations pages.  Additionally, other places
like Host "Run Job", we need to explicitly set the btn btn-default CSS.