### PR TITLE
Refs #14842 - 'validate' should be 'validates'

### DIFF
--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -1,6 +1,10 @@
 require 'test_plugin_helper'
 
 describe RemoteExecutionFeature do
+  should validate_presence_of(:name)
+  should validate_presence_of(:label)
+  should validate_uniqueness_of(:name)
+  should validate_uniqueness_of(:label)
 
   let(:install_feature) do
     RemoteExecutionFeature.register(:katello_install_package, N_('Katello: Install package'),


### PR DESCRIPTION
On remote_execution_feature, there's a line calling `validate` and then
calls some Rails validations. It has a typo and should say `validates`.
Passenger does not start because of this, with an error

' Message from application: Unknown key: :presence. Valid keys are: :on,
  :if, :unless, :prepend. Perhaps you meant to call `validates` instead
  of `validate`? (ArgumentError) '

Fix is as simple as correcting the typo.