### PR TITLE
Cherry-picks for 0.3.2

### DIFF
--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -1,7 +1,7 @@
 class RemoteExecutionFeature < ActiveRecord::Base
   attr_accessible :label, :name, :provided_input_names, :description, :job_template_id
 
-  validate :label, :name, :presence => true, :unique => true
+  validates :label, :name, :presence => true, :uniqueness => true
 
   belongs_to :job_template
 

--- a/db/migrate/20150612121541_add_job_template_to_template.rb
+++ b/db/migrate/20150612121541_add_job_template_to_template.rb
@@ -1,6 +1,6 @@
 class AddJobTemplateToTemplate < ActiveRecord::Migration
   def change
-    add_column :templates, :job_name, :string
-    add_column :templates, :provider_type, :string
+    add_column :templates, :job_name, :string, :limit => 255
+    add_column :templates, :provider_type, :string, :limit => 255
   end
 end

--- a/db/migrate/20150616080015_create_template_input.rb
+++ b/db/migrate/20150616080015_create_template_input.rb
@@ -1,13 +1,13 @@
 class CreateTemplateInput < ActiveRecord::Migration
   def change
     create_table :template_inputs do |t|
-      t.string :name, :null => false
+      t.string :name, :null => false, :limit => 255
       t.boolean :required, :null => false, :default => false
-      t.string :input_type, :null => false
-      t.string :fact_name
-      t.string :variable_name
-      t.string :puppet_class_name
-      t.string :puppet_parameter_name
+      t.string :input_type, :null => false, :limit => 255
+      t.string :fact_name, :limit => 255
+      t.string :variable_name, :limit => 255
+      t.string :puppet_class_name, :limit => 255
+      t.string :puppet_parameter_name, :limit => 255
       t.text :description
       t.integer :template_id
 

--- a/db/migrate/20150708133241_add_targeting.rb
+++ b/db/migrate/20150708133241_add_targeting.rb
@@ -1,10 +1,10 @@
 class AddTargeting < ActiveRecord::Migration
   def change
     create_table :targetings do |t|
-      t.string :search_query
+      t.string :search_query, :limit => 255
       t.references :bookmark
       t.references :user
-      t.string :targeting_type, :null => false
+      t.string :targeting_type, :null => false, :limit => 255
       t.timestamps
     end
 

--- a/db/migrate/20150708133242_add_invocation.rb
+++ b/db/migrate/20150708133242_add_invocation.rb
@@ -2,7 +2,7 @@ class AddInvocation< ActiveRecord::Migration
   def change
     create_table :job_invocations do |t|
       t.references :targeting, :null => false
-      t.string :job_name, :null => false
+      t.string :job_name, :null => false, :limit => 255
     end
 
     add_index :job_invocations, [:targeting_id], :name => 'job_invocations_targeting_id'

--- a/db/migrate/20150708133305_add_template_invocation.rb
+++ b/db/migrate/20150708133305_add_template_invocation.rb
@@ -12,7 +12,7 @@ class AddTemplateInvocation < ActiveRecord::Migration
     create_table :template_invocation_input_values do |t|
       t.references :template_invocation, :null => false
       t.references :template_input, :null => false
-      t.string :value, :null => false
+      t.string :value, :null => false, :limit => 255
     end
 
     add_index :template_invocation_input_values, [:template_invocation_id, :template_input_id], :name => 'template_invocation_input_values_ti_ti_ids'

--- a/db/migrate/20150812145900_add_last_task_id_to_job_invocation.rb
+++ b/db/migrate/20150812145900_add_last_task_id_to_job_invocation.rb
@@ -1,6 +1,6 @@
 class AddLastTaskIdToJobInvocation < ActiveRecord::Migration
   def change
-    add_column :job_invocations, :last_task_id, :string
+    add_column :job_invocations, :last_task_id, :string, :limit => 255
     add_index :job_invocations, [:last_task_id], :name => 'job_invocations_last_task_id'
   end
 end

--- a/db/migrate/20150826191632_create_target_remote_execution_proxies.rb
+++ b/db/migrate/20150826191632_create_target_remote_execution_proxies.rb
@@ -3,7 +3,7 @@ class CreateTargetRemoteExecutionProxies < ActiveRecord::Migration
     create_table :target_remote_execution_proxies do |t|
       t.integer :remote_execution_proxy_id
       t.integer :target_id
-      t.string :target_type
+      t.string :target_type, :limit => 255
 
       t.timestamps
     end

--- a/db/migrate/20151120171100_add_effective_user_to_template_invocation.rb
+++ b/db/migrate/20151120171100_add_effective_user_to_template_invocation.rb
@@ -1,5 +1,5 @@
 class AddEffectiveUserToTemplateInvocation < ActiveRecord::Migration
   def change
-    add_column :template_invocations, :effective_user, :string
+    add_column :template_invocations, :effective_user, :string, :limit => 255
   end
 end

--- a/db/migrate/20151124162300_create_job_template_effective_users.rb
+++ b/db/migrate/20151124162300_create_job_template_effective_users.rb
@@ -2,7 +2,7 @@ class CreateJobTemplateEffectiveUsers < ActiveRecord::Migration
   def change
     create_table :job_template_effective_users do |t|
       t.integer :job_template_id
-      t.string :value
+      t.string :value, :limit => 255
       t.boolean :overridable
       t.boolean :current_user
     end

--- a/db/migrate/20151203100824_add_description_to_job_invocation.rb
+++ b/db/migrate/20151203100824_add_description_to_job_invocation.rb
@@ -1,7 +1,7 @@
 class AddDescriptionToJobInvocation < ActiveRecord::Migration
   def up
-    add_column :job_invocations, :description, :string
-    add_column :templates, :description_format, :string
+    add_column :job_invocations, :description, :string, :limit => 255
+    add_column :templates, :description_format, :string, :limit => 255
   end
 
   def down

--- a/db/migrate/20160108141144_make_job_name_default_to_something.rb
+++ b/db/migrate/20160108141144_make_job_name_default_to_something.rb
@@ -1,9 +1,9 @@
 class MakeJobNameDefaultToSomething < ActiveRecord::Migration
   def up
-    change_column :templates, :job_name, :string, :default => 'Miscellaneous'
+    change_column :templates, :job_name, :string, :default => 'Miscellaneous', :limit => 255
   end
 
   def down
-    change_column :templates, :job_name, :string, :default => nil
+    change_column :templates, :job_name, :string, :default => nil, :limit => 255
   end
 end

--- a/db/migrate/20160113161916_add_run_host_job_task_id_to_template_invocation.rb
+++ b/db/migrate/20160113161916_add_run_host_job_task_id_to_template_invocation.rb
@@ -1,6 +1,6 @@
 class AddRunHostJobTaskIdToTemplateInvocation < ActiveRecord::Migration
   def change
-    add_column :template_invocations, :run_host_job_task_id, :string
+    add_column :template_invocations, :run_host_job_task_id, :string, :limit => 255
     add_index :template_invocations, [:run_host_job_task_id], :name => 'template_invocations_run_host_job_task_id'
   end
 end

--- a/db/migrate/20160118124600_create_remote_execution_features.rb
+++ b/db/migrate/20160118124600_create_remote_execution_features.rb
@@ -5,10 +5,8 @@ class CreateRemoteExecutionFeatures < ActiveRecord::Migration
       t.string :name, :null => false
       t.string :description
       t.text :provided_inputs
-      t.integer :job_template_id
+      t.integer :job_template_id, :index => true
     end
-    add_index :remote_execution_features, :label
-    add_index :remote_execution_features, :job_template_id
     add_foreign_key :remote_execution_features, :templates, :column => :job_template_id
   end
 end

--- a/db/migrate/20160118124600_create_remote_execution_features.rb
+++ b/db/migrate/20160118124600_create_remote_execution_features.rb
@@ -1,9 +1,9 @@
 class CreateRemoteExecutionFeatures < ActiveRecord::Migration
   def change
     create_table :remote_execution_features do |t|
-      t.string :label, :index => true, :null => false
-      t.string :name, :null => false
-      t.string :description
+      t.string :label, :index => true, :null => false, :limit => 255
+      t.string :name, :null => false, :limit => 255
+      t.string :description, :limit => 255
       t.text :provided_inputs
       t.integer :job_template_id, :index => true
     end

--- a/lib/tasks/foreman_remote_execution_tasks.rake
+++ b/lib/tasks/foreman_remote_execution_tasks.rake
@@ -36,14 +36,9 @@ namespace :foreman_remote_execution do
   end
 end
 
-Rake::Task[:test].enhance do
-  Rake::Task['test:foreman_remote_execution'].invoke
-end
+Rake::Task[:test].enhance ['test:foreman_remote_execution']
 
 load 'tasks/jenkins.rake'
 if Rake::Task.task_defined?(:'jenkins:unit')
-  Rake::Task['jenkins:unit'].enhance do
-    Rake::Task['test:foreman_remote_execution'].invoke
-    Rake::Task['foreman_remote_execution:rubocop'].invoke
-  end
+  Rake::Task['jenkins:unit'].enhance ['test:foreman_remote_execution', 'foreman_remote_execution:rubocop']
 end

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -89,7 +89,7 @@ FactoryGirl.modify do
         overrides[:organizations] = [organization] unless organization.nil?
 
         FactoryGirl.create(
-          :subnet_ipv4,
+          :subnet,
           overrides
         )
       end

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -66,6 +66,7 @@ FactoryGirl.modify do
   factory :smart_proxy do
     trait :ssh do
       features { [FactoryGirl.build(:feature, :ssh)] }
+      pubkey 'ssh-rsa AAAAB3N...'
     end
   end
 
@@ -88,7 +89,7 @@ FactoryGirl.modify do
         overrides[:organizations] = [organization] unless organization.nil?
 
         FactoryGirl.create(
-          :subnet,
+          :subnet_ipv4,
           overrides
         )
       end

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,6 +1,6 @@
 # This calls the main test_helper in Foreman-core
 require 'test_helper'
-
+require 'database_cleaner'
 require 'dynflow/testing'
 
 # Add plugin to FactoryGirl's paths

--- a/test/unit/execution_task_status_mapper_test.rb
+++ b/test/unit/execution_task_status_mapper_test.rb
@@ -3,7 +3,7 @@ require 'test_plugin_helper'
 describe HostStatus::ExecutionStatus::ExecutionTaskStatusMapper do
 
   describe '.sql_conditions_for(status)' do
-    subject { HostStatus::ExecutionStatus::ExecutionTaskStatusMapper }
+    let(:subject) { HostStatus::ExecutionStatus::ExecutionTaskStatusMapper }
 
     it 'accepts status number as well as string representation' do
       subject.sql_conditions_for(HostStatus::ExecutionStatus::ERROR).must_equal subject.sql_conditions_for('failed')
@@ -18,7 +18,7 @@ describe HostStatus::ExecutionStatus::ExecutionTaskStatusMapper do
   let(:mapper) { HostStatus::ExecutionStatus::ExecutionTaskStatusMapper.new(task) }
 
   describe '#status' do
-    subject { mapper }
+    let(:subject) { mapper }
 
     describe 'is queued' do
       context 'when there is no task' do
@@ -65,7 +65,7 @@ describe HostStatus::ExecutionStatus::ExecutionTaskStatusMapper do
   end
 
   describe '#status_label' do
-    subject { mapper.status_label }
+    let(:subject) { mapper.status_label }
 
     context 'status is OK' do
       before do


### PR DESCRIPTION
Looks like we actually need the rails 4.2 fixes in 0.3-stable branch, because it fixed some other bugs (validates vs. validate, duplicate indexes, etc).  But not all of them, this excludes the `:subnet_v4` change since it doesn't exist in 1.10.