### PR TITLE
fixes #14847 - attr_accessible on effective user

### DIFF
--- a/app/models/job_template_effective_user.rb
+++ b/app/models/job_template_effective_user.rb
@@ -1,5 +1,7 @@
 class JobTemplateEffectiveUser < ActiveRecord::Base
 
+  attr_accessible :value, :current_user, :overridable
+
   belongs_to :job_template
 
   before_validation :set_defaults


### PR DESCRIPTION
Otherwise creating a new template fails with a
ForbiddenAttributesError.  Rails 4.2 must go
deeper in verifying attribute accessibility.