### PR TITLE
Fixes #15667 - Passing nested array in smart-proxy scope is deprecated

### DIFF
--- a/app/views/overrides/subnets/_rex_tab_pane.html.erb
+++ b/app/views/overrides/subnets/_rex_tab_pane.html.erb
@@ -1,5 +1,5 @@
 <div class="tab-pane" id="rex_proxies">
   <%= fields_for :subnet do |f| %>
-    <%= multiple_selects f, :remote_execution_proxies, SmartProxy.authorized.with_features(RemoteExecutionProvider.provider_names), @subnet.remote_execution_proxy_ids, {:label => _("Proxies"), :help_inline => _("Select as many remote execution proxies as applicable for this subnet.  When multiple proxies with the same provider are added, actions will be load balanced among them.")} %>
+    <%= multiple_selects f, :remote_execution_proxies, SmartProxy.authorized.with_features(*RemoteExecutionProvider.provider_names), @subnet.remote_execution_proxy_ids, {:label => _("Proxies"), :help_inline => _("Select as many remote execution proxies as applicable for this subnet.  When multiple proxies with the same provider are added, actions will be load balanced among them.")} %>
   <% end %>
 </div>


### PR DESCRIPTION
Rails 5 will remove the option of passing nested arrays that are used in SQL 'IN' conditions. You can see several warnings running test/functional/subnets_controller.rb