### PR TITLE
Fixes #16067 - state the API key for dynflow_task explicitly

### DIFF
--- a/app/views/api/v2/job_invocations/base.json.rabl
+++ b/app/views/api/v2/job_invocations/base.json.rabl
@@ -11,6 +11,6 @@ node do |invocation|
   }
 end
 
-child :task do
+child :task => :dynflow_task do
   attributes :id, :state
 end


### PR DESCRIPTION
This fixes the regression introduce by
 http://projects.theforeman.org/issues/15778, as the output
 of the API for job-invocation show changed.