### PR TITLE
Fixes #16107 - Allow user to set own keys parameter

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -26,8 +26,9 @@ module ForemanRemoteExecution
 
     def params_with_remote_execution
       params = params_without_remote_execution
-      keys = remote_execution_ssh_keys
-      params['remote_execution_ssh_keys'] = keys unless keys.blank?
+      if (keys = remote_execution_ssh_keys).present?
+        params['remote_execution_ssh_keys'] = params['remote_execution_ssh_keys'].to_s + keys.join('\n')
+      end
       [:remote_execution_ssh_user, :remote_execution_effective_user_method].each do |key|
         params[key.to_s] = Setting[key] unless params.key?(key.to_s)
       end


### PR DESCRIPTION
Currently Foreman is failing to render the REX snippet with this error:
"The snippet 'remote_execution_ssh_keys' threw an error: undefined
method `join' for #String:0x007f4775c597e8"

From what I see, the parameter is expected to be an array or similar.
The docs say nothing about it -
https://theforeman.org/plugins/foreman_remote_execution/0.3/index.html -
and there's no way for the user to set the parameter as Array as a
global param or a host param.

The 'expected' Array comes from the plugin itself who queries all
proxies for the parameter, but it doesn't respect if there's a parameter
that already exists.

I propose making the method in REX return a string so that we can:
- remove the `join` call from the template
- allow people to set their own SSH keys via global params/host params
