### PR TITLE
Fixes #16426 - Add JobTemplateImporter shim class for foreman_templates

### DIFF
--- a/app/models/job_template_importer.rb
+++ b/app/models/job_template_importer.rb
@@ -1,0 +1,24 @@
+# This class is a shim to handle the importing of templates via the
+# foreman_templates plugin. It expects a method like
+#     def import(name, text, metadata)
+# but REx already has an import! method, so this class provides the
+# translation layer.
+
+class JobTemplateImporter
+  def self.import!(name, text, _metadata)
+    template = JobTemplate.import(
+      text.sub(/^name: .*$/, "name: #{name}").sub(/^model: .*$/, ''),
+      :update => true
+    )
+
+    c_or_u = template.new_record? ? 'Created' : 'Updated'
+    id_string = ('id' + template.id) rescue ''
+
+    result = "  #{c_or_u} Template #{id_string}:#{name}"
+    { :old => template.template_was,
+      :new => template.template,
+      :status => template.save,
+      :result => result
+    }
+  end
+end

--- a/test/unit/job_template_importer_test.rb
+++ b/test/unit/job_template_importer_test.rb
@@ -1,0 +1,48 @@
+require 'test_plugin_helper'
+
+describe JobTemplateImporter do
+  context 'importing a new template' do
+    # JobTemplate tests handle most of this, we just check that the shim
+    # correctly loads a template returns a hash
+    let(:remote_execution_feature) do
+      FactoryGirl.create(:remote_execution_feature)
+    end
+
+    let(:result) do
+      name = "Community Service Restart"
+      text = <<-END_TEMPLATE
+<%#
+model: JobTemplateImporter
+kind: job_template
+name: Service Restart
+job_category: Service Restart
+provider_type: SSH
+feature: #{remote_execution_feature.label}
+template_inputs:
+- name: service_name
+  input_type: user
+  required: true
+- name: verbose
+  input_type: user
+%>
+
+service <%= input("service_name") %> restart
+END_TEMPLATE
+
+      # This parameter is unused but foreman_templates will supply it
+      # so we test it's accepted
+      metadata = "unused"
+
+      JobTemplateImporter.import!(name, text, metadata)
+    end
+
+    let(:template) { JobTemplate.find_by_name 'Community Service Restart' }
+
+    it 'returns a valid foreman_templates hash' do
+      result[:status].must_equal true
+      result[:result].must_equal '  Created Template :Community Service Restart'
+      result[:old].must_equal nil
+      result[:new].must_equal template.template.squish
+    end
+  end
+end


### PR DESCRIPTION
This is pretty much verbatim copy from the `update_job_template` method already present in foreman_templates itself. The only difference is that it deletes `model` from the metadata before passing it on to the real import call.

Not quite sure if tests are wanted / best place to implement them, guidance welcome.