### PR TITLE
Fixes #15311 free form job command cannot exceed 255 chars

### DIFF
--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -170,7 +170,6 @@ class JobInvocation < ActiveRecord::Base
     input_hash.each do |k, v|
       self.description.gsub!(Regexp.new("%\{#{k}\}"), v || '')
     end
-    self.description = self.description[0..(JobInvocation.columns_hash['description'].limit - 1)]
   end
 
   private

--- a/db/migrate/20160909090711_remove_char_limit_for_remote_job_invocation.rb
+++ b/db/migrate/20160909090711_remove_char_limit_for_remote_job_invocation.rb
@@ -1,0 +1,10 @@
+class RemoveCharLimitForRemoteJobInvocation < ActiveRecord::Migration
+  def up
+    change_column :template_invocation_input_values, :value, :string, :null => false, :limit => nil
+    change_column :job_invocations, :description, :string, :limit => nil
+  end
+  def down
+    change_column :template_invocation_input_values, :value, :string, :null => false, :limit => 255
+    change_column :job_invocations, :description, :string, :limit => 255
+  end
+end

--- a/test/unit/job_invocation_test.rb
+++ b/test/unit/job_invocation_test.rb
@@ -1,7 +1,6 @@
 require 'test_plugin_helper'
 
 describe JobInvocation do
-
   let(:job_invocation) { FactoryGirl.build(:job_invocation) }
   let(:template) { FactoryGirl.create(:job_template, :with_input) }
 
@@ -74,14 +73,11 @@ describe JobInvocation do
         job_invocation.description.must_equal "#{job_invocation.job_category} - %{missing_key}"
       end
 
-      it 'truncates generated description to 255 characters' do
-        column_limit = 255
-        expected_result = 'a' * column_limit
-        JobInvocation.columns_hash['description'].expects(:limit).returns(column_limit)
+      it 'accepts description greater than 255 characters' do
         job_invocation.description_format = '%{job_category}'
         job_invocation.job_category = 'a' * 1000
         job_invocation.generate_description
-        job_invocation.description.must_equal expected_result
+        assert job_invocation.description.length > 255
       end
     end
   end


### PR DESCRIPTION
remote execution is unable to handle commands longer than 255 chars. In a normal scenario executed command could exceed 255 chars. 

Added a migration to remove the limit for command length.