### PR TITLE
Fixes #17456 - The register method will execute update only when ther…

### DIFF
--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -24,7 +24,7 @@ class RemoteExecutionFeature < ActiveRecord::Base
     feature = self.find_by_label(label)
     if feature.nil?
       feature = self.create!(:label => label, :name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
-    else
+    elsif feature.name != name || feature.description != options[:description] || feature.provided_input_names != options[:provided_inputs]
       feature.update_attributes!(:name => name, :provided_input_names => options[:provided_inputs], :description => options[:description])
     end
     return feature


### PR DESCRIPTION
Hi all, 
  I wrote small patch which prevents executing hooks each time the foreman / Passenger is being started. It is achieved by comparing the current feature in database with the feature which should be updated. There is compared each of the values which is being saved including the options[:description] which is array, but I believe the size of this array will not exceed 5, so it should be safe comparing the arrays like this.