### PR TITLE
Fixes #17315 - Handle output coming from .bashrc

### DIFF
--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -152,7 +152,7 @@ module ForemanRemoteExecutionCore
       output = ""
       exit_status = nil
       channel = session.open_channel do |ch|
-        ch.on_data { |data| output.concat(data) }
+        ch.on_data { |_, data| output.concat(data) }
         ch.on_extended_data { |_, _, data| output.concat(data) }
         ch.on_request("exit-status") { |_, data| exit_status = data.read_long }
         # on signal: sending the signal value (such as 'TERM')


### PR DESCRIPTION
This fix contains a not-so-pretty monkey patch for how Net::SCP's state machine handles the communication. Probably needs some discussion