### PR TITLE
Fixes #17976 - Fix tests for CVE 2016-7078

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -44,10 +44,10 @@ module ForemanRemoteExecution
       proxies[:fallback] = smart_proxies.with_features(provider) if Setting[:remote_execution_fallback_proxy]
 
       if Setting[:remote_execution_global_proxy]
-        proxy_scope = if Taxonomy.enabled_taxonomies.any?
+        proxy_scope = if Taxonomy.enabled_taxonomies.any? && User.current.present?
                         ::SmartProxy.with_taxonomy_scope_override(location, organization)
                       else
-                        proxy_scope = ::SmartProxy
+                        proxy_scope = ::SmartProxy.unscoped
                       end
 
         proxy_scope = proxy_scope.authorized if authorized

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -5,6 +5,9 @@ FactoryGirl.define do
     sequence(:job_category) { |n| "job name #{n}" }
     f.template 'id'
     f.provider_type 'SSH'
+    organizations { [Organization.find_by_name('Organization 1')] } if SETTINGS[:organizations_enabled]
+    locations { [Location.find_by_name('Location 1')] } if SETTINGS[:locations_enabled]
+
 
     trait :with_input do
       after(:build) do |template, evaluator|

--- a/test/functional/api/v2/job_templates_controller_test.rb
+++ b/test/functional/api/v2/job_templates_controller_test.rb
@@ -91,7 +91,7 @@ module Api
         erb_data = @template.to_erb
         post :import, :template => erb_data
         assert_response :success
-        assert JobTemplate.find_by_name(new_name)
+        assert JobTemplate.unscoped.find_by_name(new_name)
       end
     end
 

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -40,10 +40,7 @@ describe ForemanRemoteExecution::HostExtensions do
 
     it 'has ssh keys in the parameters even when no user specified' do
       # this is a case, when using the helper in provisioning templates
-      FactoryGirl.create(:smart_proxy, :ssh) do |proxy|
-        proxy.organizations << host.organization
-        proxy.locations << host.location
-      end
+      FactoryGirl.create(:smart_proxy, :ssh)
       host.interfaces.first.subnet.remote_execution_proxies.clear
       User.current = nil
       host.remote_execution_ssh_keys.must_include sshkey


### PR DESCRIPTION
After the patch for the CVE in #16982, some tests fail in REX. This
fixes parts of REX where 'no taxonomies' implied 'all taxonomies'