### PR TITLE
 Fixes #17315 - Handle output coming from .bashrc, v2

### DIFF
--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -152,7 +152,7 @@ module ForemanRemoteExecutionCore
       output = ""
       exit_status = nil
       channel = session.open_channel do |ch|
-        ch.on_data { |data| output.concat(data) }
+        ch.on_data { |_, data| output.concat(data) }
         ch.on_extended_data { |_, _, data| output.concat(data) }
         ch.on_request("exit-status") { |_, data| exit_status = data.read_long }
         # on signal: sending the signal value (such as 'TERM')


### PR DESCRIPTION
Alternative to #216

Instead of using SCP to copy the script we open an ssh connection and write the script into its stdin. On the other side of the tunnel we use `tee` to read from the stdin and write it to a file and `chmod` to set the permissions on the script.