### PR TITLE
Fixes #18298 - fix description generation

### DIFF
--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -160,9 +160,8 @@ class JobInvocation < ActiveRecord::Base
   def generate_description
     key_re = /%\{([^\}]+)\}/
     template_invocation = pattern_template_invocations.first
-    input_names = template_invocation.template.template_inputs_with_foreign(&:name)
     hash_base = Hash.new { |hash, key| hash[key] = "%{#{key}}" }
-    input_hash = hash_base.merge Hash[input_names.zip(template_invocation.input_values.map(&:value))]
+    input_hash = template_invocation.input_values.reduce(hash_base) { |h, v| h.update(v.template_input.name => v.value) }
     input_hash.update(:job_category => job_category)
     input_hash.update(:template_name => template_invocation.template.name)
     description_format.scan(key_re) { |key| input_hash[key.first] }

--- a/test/unit/job_invocation_test.rb
+++ b/test/unit/job_invocation_test.rb
@@ -45,6 +45,10 @@ describe JobInvocation do
 
     before do
       input = job_invocation.pattern_template_invocations.first.template.template_inputs.create!(:name => 'foo', :required => true, :input_type => 'user')
+      input2 = job_invocation.pattern_template_invocations.first.template.template_inputs.create!(:name => 'bar', :required => true, :input_type => 'user')
+      FactoryGirl.create(:template_invocation_input_value,
+                         :template_invocation => job_invocation.pattern_template_invocations.first,
+                         :template_input => input2)
       @input_value = FactoryGirl.create(:template_invocation_input_value,
                                         :template_invocation => job_invocation.pattern_template_invocations.first,
                                         :template_input => input)


### PR DESCRIPTION
Previous algorithm failed, when the order of inputs was different than
the order of values in the invocation - the new test were extended with
and example that failed before this patch