### PR TITLE
Fixes #18316 - Changed scoped_search query to :in for hosts enum

### DIFF
--- a/app/models/targeting.rb
+++ b/app/models/targeting.rb
@@ -54,8 +54,9 @@ class Targeting < ActiveRecord::Base
   end
 
   def self.build_query_from_hosts(ids)
-    hosts = Host.where(:id => ids).all.group_by(&:id)
-    hosts.map { |id, h| "name = #{h.first.name}" }.join(' or ')
+    return '' if ids.empty?
+    hosts = Host.where(:id => ids).distinct.pluck(:name)
+    "name ^ (#{hosts.join(', ')})"
   end
 
   def resolved?

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -5,6 +5,8 @@ require 'dynflow/testing'
 
 # Add plugin to FactoryGirl's paths
 FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
+# Add foreman tasks factories too
+FactoryGirl.definition_file_paths << "#{ForemanTasks::Engine.root}/test/factories"
 FactoryGirl.reload
 
 # Foreman's setup doesn't handle cleaning up for Minitest::Spec

--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -40,7 +40,7 @@ describe RemoteExecutionFeature do
       input_value.value.must_equal 'zsh'
       input_value.template_input.name.must_equal 'package'
 
-      composer.targeting.search_query.must_equal "name = #{host.name}"
+      composer.targeting.search_query.must_equal "name ^ (#{host.name})"
     end
 
     it "updates the feature when attributes change" do

--- a/test/unit/targeting_test.rb
+++ b/test/unit/targeting_test.rb
@@ -88,10 +88,10 @@ describe Targeting do
     context 'for two hosts' do
       let(:query) { Targeting.build_query_from_hosts([ host.id, second_host.id ]) }
 
-      it 'builds query using host names joining with or' do
-        query.must_include "name = #{host.name}"
-        query.must_include "name = #{second_host.name}"
-        query.must_include ' or '
+      it 'builds query using host names joining inside ^' do
+        query.must_include host.name
+        query.must_include second_host.name
+        query.must_include 'name ^'
 
         Host.search_for(query).must_include host
         Host.search_for(query).must_include second_host
@@ -102,7 +102,7 @@ describe Targeting do
       let(:query) { Targeting.build_query_from_hosts([ host.id ]) }
 
       it 'builds query using host name' do
-        query.must_equal "name = #{host.name}"
+        query.must_equal "name ^ (#{host.name})"
         Host.search_for(query).must_include host
         Host.search_for(query).wont_include second_host
       end


### PR DESCRIPTION
When asking to target a specific set of hosts (like in case of failed hosts), a `name = X or name = Y...` query was generated. This query caused a very deep stack recursion in scoped_search AST. This commit changes the query to `name ^ (X, Y...)` that will not require the same treatment in AST.
