### PR TITLE
Fixes #18651 - Provide a way to test REX at scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ management functionality with remote management functionality.
 
 Check the Foreman manual [remote execution section](http://theforeman.org/plugins/foreman_remote_execution/)
 
+## Simulated runs
+There is an option to use an alternative `ScriptRunner` implementation. Instead of doing ssh connections it discards any input its given and gives back fake output.
+
+It is controlled by setting the following environment variables
+`REX_SIMULATE` - setting to 1, yes or true enables the use of the fake runner
+`REX_SIMULATE_PATH` - full path to a file which should be given back as output by the runner, currently one line per runner's refresh
+`REX_SIMULATE_FAIL_CHANCE` - number from 0 to 100, each host has a `REX_SIMULATE_FAIL_CHANCE` of exiting with `REX_SIMULATE_EXIT`, useful for simulating random failures
+`REX_SIMULATE_EXIT` - see the previous
+
+Because it doesn't really open the outgoing connections, it doesn't need hosts with valid IP addresses as targets.
+
 ## Links
 
 * [Design document](http://theforeman.github.io/foreman_remote_execution/design/)

--- a/lib/foreman_remote_execution_core.rb
+++ b/lib/foreman_remote_execution_core.rb
@@ -12,6 +12,10 @@ module ForemanRemoteExecutionCore
     %w(yes true 1).include? ENV.fetch('REX_SIMULATE', '').downcase
   end
 
+  def self.runner_class
+    @runner_class ||= simulate? ? FakeScriptRunner : ScriptRunner
+  end
+
   if ForemanTasksCore.dynflow_present?
     require 'foreman_tasks_core/runner'
     if simulate?

--- a/lib/foreman_remote_execution_core.rb
+++ b/lib/foreman_remote_execution_core.rb
@@ -8,9 +8,18 @@ module ForemanRemoteExecutionCore
                     :remote_working_dir    => '/var/tmp',
                     :local_working_dir     => '/var/tmp')
 
+  def self.debug?
+    %w(yes true 1).include? ENV.fetch('REX_DEBUG', '')
+  end
+
   if ForemanTasksCore.dynflow_present?
     require 'foreman_tasks_core/runner'
-    require 'foreman_remote_execution_core/script_runner'
+    if debug?
+      # Load the fake implementation of the script runner if debug is enabled
+      require 'foreman_remote_execution_core/fake_script_runner'
+    else
+      require 'foreman_remote_execution_core/script_runner'
+    end
     require 'foreman_remote_execution_core/actions'
   end
 

--- a/lib/foreman_remote_execution_core.rb
+++ b/lib/foreman_remote_execution_core.rb
@@ -8,13 +8,13 @@ module ForemanRemoteExecutionCore
                     :remote_working_dir    => '/var/tmp',
                     :local_working_dir     => '/var/tmp')
 
-  def self.debug?
-    %w(yes true 1).include? ENV.fetch('REX_DEBUG', '')
+  def self.simulate?
+    %w(yes true 1).include? ENV.fetch('REX_SIMULATE', '').downcase
   end
 
   if ForemanTasksCore.dynflow_present?
     require 'foreman_tasks_core/runner'
-    if debug?
+    if simulate?
       # Load the fake implementation of the script runner if debug is enabled
       require 'foreman_remote_execution_core/fake_script_runner'
     else

--- a/lib/foreman_remote_execution_core/actions.rb
+++ b/lib/foreman_remote_execution_core/actions.rb
@@ -4,7 +4,7 @@ module ForemanRemoteExecutionCore
   module Actions
     class RunScript < ForemanTasksCore::Runner::Action
       def initiate_runner
-        ScriptRunner.new(input)
+        ForemanRemoteExecutionCore.runner_class.new(input)
       end
     end
   end

--- a/lib/foreman_remote_execution_core/fake_script_runner.rb
+++ b/lib/foreman_remote_execution_core/fake_script_runner.rb
@@ -1,5 +1,5 @@
 module ForemanRemoteExecutionCore
-  class ScriptRunner < ForemanTasksCore::Runner::Base
+  class FakeScriptRunner < ForemanTasksCore::Runner::Base
 
     @data = []
 

--- a/lib/foreman_remote_execution_core/fake_script_runner.rb
+++ b/lib/foreman_remote_execution_core/fake_script_runner.rb
@@ -1,17 +1,21 @@
 module ForemanRemoteExecutionCore
   class ScriptRunner < ForemanTasksCore::Runner::Base
 
-    @@data = []
+    @data = []
+
+    class << self
+      attr_accessor :data
+    end
 
     def initialize(*args)
       super
       # Load the fake output the first time its needed
-      unless @@data.frozen?
+      unless self.class.data.frozen?
         logger.debug("Loading fake output file #{configuration_path}")
         File.open(configuration_path, 'r') do |f|
-          @@data = f.readlines.map(&:chomp)
+          self.class.data = f.readlines.map(&:chomp)
         end
-        @@data.freeze
+        self.class.data.freeze
       end
       @position = 0
     end
@@ -44,11 +48,11 @@ module ForemanRemoteExecutionCore
     end
 
     def done?
-      @position == @@data.count
+      @position == self.class.data.count
     end
 
     def next_chunk
-      output = @@data[@position]
+      output = self.class.data[@position]
       @position += 1
       output
     end

--- a/lib/foreman_remote_execution_core/fake_script_runner.rb
+++ b/lib/foreman_remote_execution_core/fake_script_runner.rb
@@ -1,0 +1,73 @@
+module ForemanRemoteExecutionCore
+  class ScriptRunner < ForemanTasksCore::Runner::Base
+
+    @@data = []
+
+    def initialize(*args)
+      super
+      # Load the fake output the first time its needed
+      unless @@data.frozen?
+        logger.debug("Loading fake output file #{configuration_path}")
+        File.open(configuration_path, 'r') do |f|
+          @@data = f.readlines.map(&:chomp)
+        end
+        @@data.freeze
+      end
+      @position = 0
+    end
+
+    def start
+      refresh
+    end
+
+    # Do one step
+    def refresh
+      if done?
+        finish
+      else
+        step
+      end
+    end
+
+    def kill
+      finish
+    end
+
+    private
+
+    def finish
+      publish_exit_status exit_code
+    end
+
+    def step
+      publish_data(next_chunk, 'stdout')
+    end
+
+    def done?
+      @position == @@data.count
+    end
+
+    def next_chunk
+      output = @@data[@position]
+      @position += 1
+      output
+    end
+
+    # Decide if the execution should fail or not
+    def exit_code
+      fail_chance   = ENV.fetch('REX_DEBUG_FAIL_CHANCE', 0).to_i
+      fail_exitcode = ENV['REX_DEBUG_EXIT'] || 0
+      if fail_exitcode == 0 || fail_chance < (Random.rand * 100).round
+        0
+      else
+        fail_exitcode
+      end
+    end
+
+    def configuration_path
+      path = ENV['REX_DEBUG_PATH'] || '/dev/null'
+      File.expand_path(path)
+    end
+
+  end
+end


### PR DESCRIPTION
This commit adds an alternative implementation for the ScriptRunner
class. Instead of doing ssh connections it discards any input its
given and gives back fake output.

It is controlled by setting the following environment variables
- ~~`REX_DEBUG`~~ `REX_SIMULATE` - setting to `1`, `yes` or `true` enables the use of the fake runner
- ~~`REX_DEBUG_PATH`~~ `REX_SIMULATE_PATH` - full path to a file which should be given back as output by the runner, currently one line per runner's refresh
- ~~`REX_DEBUG_FAIL_CHANCE`~~ `REX_SIMULATE_FAIL_CHANCE` - number from 0 to 100, each host has a ~~`REX_DEBUG_FAIL_CHANCE`~~ `REX_SIMULATE_FAIL_CHANCE` of exiting with ~~`REX_DEBUG_EXIT`~~ `REX_SIMULATE_EXIT`, useful for simulating random failures
- ~~`REX_DEBUG_EXIT`~~ `REX_SIMULATE_EXIT` - see the previous

Because it doesn't really open the outgoing connections, it doesn't need hosts with valid IP addresses.  This means one can spin up arbitrary number of hosts for testing purposes with the following snippet
```shell
bundle exec rails console <<-END
group = Hostgroup.find_or_create_by(:name => 'fakes')
group.save
300.times do
  h = Host.new
  h.hostgroup_id = group.id
  h.save!
end
END
```

All that is left to do is run the `smart_proxy_dynflow_core` (or `smart-proxy` or even `foreman`, depending on configuration) with properly set environment variables and use targeting `hostgroup = fakes`