### PR TITLE
Fixes #17412 - Preview in job invocation works without refresh

### DIFF
--- a/app/assets/javascripts/template_invocation.js
+++ b/app/assets/javascripts/template_invocation.js
@@ -30,22 +30,17 @@ function refresh_search_query(value){
 }
 
 function show_preview_hosts_modal() {
-  var modal_window = $('#previewHostsModal');
-
   var form = $('form#job_invocation_form');
   var data = form.serializeArray();
-
   request = $.ajax({
     data: data,
     type: 'GET',
-    url: modal_window.attr('data-url'),
-    success: function(request) {
-      modal_window.find('.modal-body').html(request);
-    },
-    complete: function() {
-      modal_window.modal({'show': true});
-      modal_window.find('a[rel="popover-modal"]').popover();
-    }
+    url: $('#previewHostsModal').attr('data-url')
+  }).then(function(result){
+    var modal_window = $('#previewHostsModal');
+    modal_window.find('.modal-body').html(result);
+    modal_window.modal({'show': true});
+    modal_window.find('a[rel="popover-modal"]').popover();
   });
 }
 


### PR DESCRIPTION
The issue was `modal_window` was set to `$('#previewHostsModal')` and later when changed didn't actually change `$('#previewHostsModal')`.
I couldn't find out why clicking the refresh button fixed this but setting `modal_window` only before using it fixed the issue.
Also, @matanwerbner advised to change `success` to `then` as `success` is deprecated and combine the `success` and `complete` parts since we did not have a different behavior for error and always tried to show the modal.