### PR TITLE
Fixes #17953 - extend core roles with permissions

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -84,6 +84,8 @@ module ForemanRemoteExecution
         role 'Remote Execution User', USER_PERMISSIONS
         role 'Remote Execution Manager', MANAGER_PERMISSIONS
 
+        add_all_permissions_to_default_roles
+
         # add menu entry
         menu :top_menu, :job_templates,
              url_hash: { controller: :job_templates, action: :index },


### PR DESCRIPTION
Please consider merging this before another release. This is new plugin DSL introduced in 1.15 that adds all permissions to Manager role and all view_* permissions to Viewer core roles.