### PR TITLE
Fixes #19525 - fix user reparation in tests

### DIFF
--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -4,22 +4,9 @@ RemoteExecutionProvider.register(:Mcollective, OpenStruct)
 
 class JobInvocationComposerTest < ActiveSupport::TestCase
   before do
-    permission1 = Permission.find_by(name: 'view_job_templates')
-    permission2 = Permission.find_by(name: 'view_bookmarks')
-    permission3 = Permission.find_by(name: 'view_hosts')
-    filter1 = FactoryGirl.build(:filter, :permissions => [permission1], :search => 'name ~ trying*')
-    filter2 = FactoryGirl.build(:filter, :permissions => [permission2])
-    filter3 = FactoryGirl.build(:filter, :permissions => [permission3])
-    filter1.save
-    filter2.save
-    filter3.save
-    role = FactoryGirl.build(:role)
-    role.filters = filter1, filter2, filter3
-    role.save
-    User.current = FactoryGirl.build(:user)
-    User.current.current_password = User.current.password
-    User.current.roles << role
-    User.current.save
+    setup_user('view', 'job_templates', 'name ~ trying*')
+    setup_user('view', 'bookmarks')
+    setup_user('view', 'hosts')
   end
 
   let(:trying_job_template_1) { FactoryGirl.create(:job_template, :job_category => 'trying_job_template_1', :name => 'trying1', :provider_type => 'SSH') }

--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -491,10 +491,8 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           {
             :job_invocation => {
               :providers => { :ssh => ssh_params },
-              :concurrency_control => {
-                :level => 5,
-                :time_span => 60
-              }
+              :concurrency_level => 5,
+              :time_span => 60,
             },
             :targeting => {
               :search_query => "name = #{host.name}",

--- a/test/unit/job_template_importer_test.rb
+++ b/test/unit/job_template_importer_test.rb
@@ -41,7 +41,7 @@ END_TEMPLATE
     it 'returns a valid foreman_templates hash' do
       result[:status].must_equal true
       result[:result].must_equal '  Created Template :Community Service Restart'
-      result[:old].must_equal nil
+      result[:old].must_be_nil
       result[:new].must_equal template.template.squish
     end
   end


### PR DESCRIPTION
A change in Foreman's #19463 revealed an issue in remote execution
where we were not saving the user properly when testing permissions.
When auditing was present, it ensured the user was saved, while without
it, the saving of test user fails on password validation.

This commit uses Foreman's helper method to prepare the test user
which has the user preparation set properly.