### PR TITLE
Fixes #19575 - don't use sudo prefix for script preparation

### DIFF
--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -231,7 +231,7 @@ module ForemanRemoteExecutionCore
       # We use tee here to pipe stdin coming from ssh to a file at $path, while silencing its output
       # This is used to write to $path with elevated permissions, solutions using cat and output redirection
       # would not work, because the redirection would happen in the non-elevated shell.
-      command = "#{su_prefix} tee '#{path}' >/dev/null && #{su_prefix} chmod '#{permissions}' '#{path}'"
+      command = "tee '#{path}' >/dev/null && chmod '#{permissions}' '#{path}'"
 
       @logger.debug("Sending data to #{path} on remote host:\n#{data}")
       status, _out, err = run_sync(command, data)


### PR DESCRIPTION
For the infrastructure files, we use the remote user: the effective
user is for the scope of the actual script