### PR TITLE
Fixes #11936 - Allow authenticating with kerberos

### DIFF
--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -41,6 +41,9 @@ class Setting::RemoteExecution < Setting
                  N_('Should the ip addresses on host interfaces be preferred over the fqdn? '\
                  'It is useful, when DNS not resolving the fqdns properly. You may override this per host by setting a parameter called remote_execution_connect_by_ip.'),
                  false),
+        self.set('remote_execution_kerberos_auth',
+                 N_('Should SSH try to authenticate using kerberos?'),
+                 false)
       ].each { |s| self.create! s.update(:category => 'Setting::RemoteExecution') }
     end
 

--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -40,9 +40,6 @@ class Setting::RemoteExecution < Setting
         self.set('remote_execution_connect_by_ip',
                  N_('Should the ip addresses on host interfaces be preferred over the fqdn? '\
                  'It is useful, when DNS not resolving the fqdns properly. You may override this per host by setting a parameter called remote_execution_connect_by_ip.'),
-                 false),
-        self.set('remote_execution_kerberos_auth',
-                 N_('Should SSH try to authenticate using kerberos?'),
                  false)
       ].each { |s| self.create! s.update(:category => 'Setting::RemoteExecution') }
     end

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -7,7 +7,8 @@ class SSHExecutionProvider < RemoteExecutionProvider
       super.merge(:ssh_user => ssh_user(host),
                   :effective_user => effective_user(template_invocation),
                   :effective_user_method => effective_user_method(host),
-                  :ssh_port => ssh_port(host))
+                  :ssh_port => ssh_port(host),
+                  :authentication_methods => authentication_methods(host))
     end
 
     def humanized_name
@@ -68,6 +69,13 @@ class SSHExecutionProvider < RemoteExecutionProvider
 
     def host_setting(host, setting)
       host.params[setting.to_s] || Setting[setting]
+    end
+
+    def authentication_methods(host)
+      arr = []
+      arr << 'gssapi-with-mic' if host_setting(host, :remote_execution_kerberos_auth)
+      arr << 'pubkey'
+      arr
     end
   end
 end

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -7,8 +7,7 @@ class SSHExecutionProvider < RemoteExecutionProvider
       super.merge(:ssh_user => ssh_user(host),
                   :effective_user => effective_user(template_invocation),
                   :effective_user_method => effective_user_method(host),
-                  :ssh_port => ssh_port(host),
-                  :authentication_methods => authentication_methods(host))
+                  :ssh_port => ssh_port(host))
     end
 
     def humanized_name
@@ -69,13 +68,6 @@ class SSHExecutionProvider < RemoteExecutionProvider
 
     def host_setting(host, setting)
       host.params[setting.to_s] || Setting[setting]
-    end
-
-    def authentication_methods(host)
-      arr = []
-      arr << 'gssapi-with-mic' if host_setting(host, :remote_execution_kerberos_auth)
-      arr << 'pubkey'
-      arr
     end
   end
 end

--- a/foreman_remote_execution_core.gemspec
+++ b/foreman_remote_execution_core.gemspec
@@ -19,5 +19,4 @@ DESC
 
   s.add_runtime_dependency('foreman-tasks-core', '~> 0.1.0')
   s.add_runtime_dependency('net-ssh')
-  s.add_runtime_dependency('net-scp')
 end

--- a/lib/foreman_remote_execution_core.rb
+++ b/lib/foreman_remote_execution_core.rb
@@ -6,7 +6,8 @@ module ForemanRemoteExecutionCore
                     :ssh_identity_key_file => '~/.ssh/id_rsa_foreman_proxy',
                     :ssh_user              => 'root',
                     :remote_working_dir    => '/var/tmp',
-                    :local_working_dir     => '/var/tmp')
+                    :local_working_dir     => '/var/tmp',
+                    :kerberos_auth         => false)
 
   def self.simulate?
     %w(yes true 1).include? ENV.fetch('REX_SIMULATE', '').downcase

--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -285,7 +285,7 @@ module ForemanRemoteExecutionCore
 
     def available_authentication_methods
       methods = %w(pubkey) # Always use pubkey auth as fallback
-      if settings.kerberos_auth
+      if settings[:kerberos_auth]
         if defined? Net::SSH::Kerberos
           methods.unshift('gssapi-with-mic')
         else

--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -2,6 +2,7 @@ require 'net/ssh'
 begin
   require 'net/ssh/krb'
 rescue LoadError
+  $stderr.puts 'Failed to load net/ssh/krb, kerberos authentication won\'t be available'
 end
 
 module ForemanRemoteExecutionCore
@@ -284,10 +285,10 @@ module ForemanRemoteExecutionCore
     end
 
     def available_authentication_methods
-      methods = %w(pubkey) # Always use pubkey auth as fallback
+      methods = %w(publickey) # Always use pubkey auth as fallback
       if settings[:kerberos_auth]
         if defined? Net::SSH::Kerberos
-          methods.unshift('gssapi-with-mic')
+          methods << 'gssapi-with-mic'
         else
           @logger.warn('Kerberos authentication requested but not available')
         end

--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -1,9 +1,10 @@
 require 'net/ssh'
+
+# rubocop:disable Lint/HandleExceptions
 begin
   require 'net/ssh/krb'
-rescue LoadError
-  $stderr.puts 'Failed to load net/ssh/krb, kerberos authentication won\'t be available'
-end
+rescue LoadError; end
+# rubocop:enable Lint/HandleExceptions:
 
 module ForemanRemoteExecutionCore
   class ScriptRunner < ForemanTasksCore::Runner::Base


### PR DESCRIPTION
For now it requires `net-ssh-krb` to be required into the `smart-proxy` or `smart_proxy_dynflow_core`

Packaging PRs:
- [DEB](https://github.com/theforeman/foreman-packaging/pull/1664)
- [RPM](https://github.com/theforeman/foreman-packaging/pull/1665)