### PR TITLE
Fixes #18356 - Ensure UTF-8 encoding

### DIFF
--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -28,6 +28,7 @@ module ForemanRemoteExecutionCore
       # pipe the output to tee while capturing the exit code in a file
       script = <<-SCRIPT.gsub(/^\s+\| /, '')
       | sh <<WRAPPER
+      | LC_ALL=C.UTF-8
       | (#{su_prefix}#{remote_script} < /dev/null; echo \\$?>#{exit_code_path}) | /usr/bin/tee #{output_path}
       | exit \\$(cat #{exit_code_path})
       | WRAPPER

--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -94,6 +94,10 @@ module ForemanRemoteExecutionCore
       @session.close if @session && !@session.closed?
     end
 
+    def publish_data(data, type)
+      super(data.force_encoding('UTF-8'), type)
+    end
+
     private
 
     def session

--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -28,7 +28,6 @@ module ForemanRemoteExecutionCore
       # pipe the output to tee while capturing the exit code in a file
       script = <<-SCRIPT.gsub(/^\s+\| /, '')
       | sh <<WRAPPER
-      | LC_ALL=C.UTF-8
       | (#{su_prefix}#{remote_script} < /dev/null; echo \\$?>#{exit_code_path}) | /usr/bin/tee #{output_path}
       | exit \\$(cat #{exit_code_path})
       | WRAPPER


### PR DESCRIPTION
Let's override the default locale with `C.UTF-8`. Users wanting to use their own locales can set them in their scripts, as long as the encoding is `UTF-8`.

Requires https://github.com/theforeman/foreman-tasks/pull/254