### PR TITLE
Fixes #20101 - update input template renderer for Foreman 1.16

### DIFF
--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -173,11 +173,11 @@ class TemplateInput < ActiveRecord::Base
     private
 
     def get_enc
-      if SETTINGS[:version].short <= '1.15'
-        @enc ||= Classification::ClassParam.new(:host => @renderer.host).enc
-      else
-        @enc ||= HostInfoProviders::PuppetInfo.new(@renderer.host).puppetclass_parameters
-      end
+      @enc ||= if SETTINGS[:version].short <= '1.15'
+                 Classification::ClassParam.new(:host => @renderer.host).enc
+               else
+                 HostInfoProviders::PuppetInfo.new(@renderer.host).puppetclass_parameters
+               end
     end
   end
 end

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -173,7 +173,11 @@ class TemplateInput < ActiveRecord::Base
     private
 
     def get_enc
-      @enc ||= Classification::ClassParam.new(:host => @renderer.host).enc
+      if SETTINGS[:version].short <= '1.15'
+        @enc ||= Classification::ClassParam.new(:host => @renderer.host).enc
+      else
+        @enc ||= HostInfoProviders::PuppetInfo.new(@renderer.host).puppetclass_parameters
+      end
     end
   end
 end

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -464,8 +464,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
               puppetclass
             end
             let(:lookup_key) do
-              lookup_key_factory = :variable_lookup_key
-              FactoryGirl.create(lookup_key_factory,
+              FactoryGirl.create(:variable_lookup_key,
                                  :key => 'client_key',
                                  :puppetclass => puppet_class,
                                  :overrides => {"fqdn=#{renderer.host.fqdn}" => 'RSA KEY'})
@@ -550,8 +549,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
               puppetclass
             end
             let(:lookup_key) do
-              lookup_key_factory = :puppetclass_lookup_key
-              FactoryGirl.create(lookup_key_factory, :as_smart_class_param,
+              FactoryGirl.create(:puppetclass_lookup_key, :as_smart_class_param,
                                  :key => 'version',
                                  :puppetclass => puppet_class,
                                  :path => 'fqdn',

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -464,7 +464,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
               puppetclass
             end
             let(:lookup_key) do
-              lookup_key_factory = SETTINGS[:version].short == '1.9' ? :lookup_key : :variable_lookup_key
+              lookup_key_factory = :variable_lookup_key
               FactoryGirl.create(lookup_key_factory,
                                  :key => 'client_key',
                                  :puppetclass => puppet_class,
@@ -550,7 +550,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
               puppetclass
             end
             let(:lookup_key) do
-              lookup_key_factory = SETTINGS[:version].short == '1.9' ? :lookup_key : :puppetclass_lookup_key
+              lookup_key_factory = :puppetclass_lookup_key
               FactoryGirl.create(lookup_key_factory, :as_smart_class_param,
                                  :key => 'version',
                                  :puppetclass => puppet_class,


### PR DESCRIPTION
It keeps backward compatibility with Foreman 1.15.

While searching for older version compatibility checks, I've removed
really old ones.