### PR TITLE
Fixes #19936 - Don't call Host::Base.authorized

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -97,7 +97,7 @@ module Api
       end
 
       def find_host
-        @host = Host::Base.authorized(:view_hosts).find(params['host_id'])
+        @host = Host.authorized(:view_hosts).find(params['host_id'])
       rescue ActiveRecord::RecordNotFound
         not_found({ :error => { :message => (_("Host with id '%{id}' was not found") % { :id => params['host_id'] }) } })
       end


### PR DESCRIPTION
It will fail if the user has filters defined in roles.