### PR TITLE
Fixes #20466 - Use polling in RunHostsJob

### DIFF
--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -3,6 +3,7 @@ module Actions
     class RunHostsJob < Actions::ActionWithSubPlans
 
       include Dynflow::Action::WithBulkSubPlans
+      include Dynflow::Action::WithPollingSubPlans
 
       middleware.use Actions::Middleware::BindJobInvocation
       middleware.use Actions::Middleware::RecurringLogic

--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = `git ls-files doc`.split("\n") + Dir['README*', 'LICENSE']
 
   s.add_dependency 'deface'
-  s.add_dependency 'dynflow', '~> 0.8.10'
+  s.add_dependency 'dynflow', '~> 0.8.26'
   s.add_dependency 'foreman_remote_execution_core'
   s.add_dependency 'foreman-tasks', '>= 0.9'
 


### PR DESCRIPTION
The default poll interval set in Dynflow is 10 seconds. This might cause a slight responsiveness drop for smaller jobs, but is probably way too frequent for jobs running on thousands of hosts. Maybe computing the value from the number of hosts (which we know before we start polling) would be the way to go.