### PR TITLE
Fixes #21178 - correct strong parameters on Nic::Interface

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -109,7 +109,9 @@ module ForemanRemoteExecution
         # widget 'foreman_remote_execution_widget', name: N_('Foreman plugin template widget'), sizex: 4, sizey: 1
 
         parameter_filter Subnet, :remote_execution_proxies, :remote_execution_proxy_ids => []
-        parameter_filter Nic, :execution
+        parameter_filter Nic::Interface do |ctx|
+          ctx.permit :execution
+        end
       end
     end
 


### PR DESCRIPTION
The current setting of the `parameter_filter` was not allowing the
:execution parameter on the interface correctly.