### PR TITLE
Fixes #21168 - Workaround for rails5 callbacks 

### DIFF
--- a/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
@@ -4,6 +4,14 @@ module ForemanRemoteExecution
 
     included do
       has_many :job_templates, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'JobTemplate'
+
+      # TODO: on foreman_version_bump
+      # workaround for #11805 - use before_create for setting
+      # the default templates, remove after it's fixed in upstream
+      # (https://github.com/theforeman/foreman/pull/4890) and gets
+      # into a 1.17 release
+      skip_callback :create, :after, :assign_default_templates, :raise => false
+      before_create :assign_default_templates
     end
   end
 end


### PR DESCRIPTION
This reverts commit 82627b3c731aab3c79c4d95974325e2188903ac4.

Just to see what's actually broken with this.

We want to get a release that is compatible with 1.15 and 
it seems the original solution was not actually merged yet.