### PR TITLE
Fixes #21242 - revert using prepend instaed of alias_method_chain

### DIFF
--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -1,7 +1,14 @@
 module ForemanRemoteExecution
   module HostsHelperExtensions
-    def multiple_actions
-      super + [ [_('Schedule Remote Job'), new_job_invocation_path, false] ]
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain(:host_title_actions, :run_button)
+      alias_method_chain :multiple_actions, :remote_execution
+    end
+
+    def multiple_actions_with_remote_execution
+      multiple_actions_without_remote_execution + [ [_('Schedule Remote Job'), new_job_invocation_path, false] ]
     end
 
     def schedule_job_multi_button(*args)
@@ -20,9 +27,9 @@ module ForemanRemoteExecution
       link_to(_('Schedule Remote Job'), new_job_invocation_path(:host_ids => [args.first.id]), :id => :run_button, :class => 'btn btn-default')
     end
 
-    def host_title_actions(*args)
+    def host_title_actions_with_run_button(*args)
       title_actions(button_group(schedule_job_multi_button(*args)))
-      super(*args)
+      host_title_actions_without_run_button(*args)
     end
   end
 end

--- a/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
@@ -1,7 +1,13 @@
 module ForemanRemoteExecution
   module JobTemplatesExtensions
-    def permitted_actions(template)
-      original = super(template)
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :permitted_actions, :run_button
+    end
+
+    def permitted_actions_with_run_button(template)
+      original = permitted_actions_without_run_button(template)
 
       if template.is_a?(JobTemplate)
         original.unshift(display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(:template_id => template.id).merge(:authorizer => authorizer))) unless template.snippet

--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -1,39 +1,44 @@
 module ForemanRemoteExecution
   module HostExtensions
+    extend ActiveSupport::Concern
+
     # rubocop:disable Metrics/BlockLength
-    def self.prepended(base)
-      base.instance_eval do
-        has_many :targeting_hosts, :dependent => :destroy, :foreign_key => 'host_id'
-        has_many :template_invocations, :dependent => :destroy, :foreign_key => 'host_id'
-        has_one :execution_status_object, :class_name => 'HostStatus::ExecutionStatus', :foreign_key => 'host_id'
-        has_many :run_host_job_tasks, :through => :template_invocations
+    included do
+      alias_method_chain :build_required_interfaces, :remote_execution
+      alias_method_chain :reload, :remote_execution
+      alias_method_chain :becomes, :remote_execution
+      alias_method_chain :host_params, :remote_execution
 
-        scoped_search :relation => :run_host_job_tasks, :on => :result, :rename => 'job_invocation.result',
-                      :ext_method => :search_by_job_invocation,
-                      :only_explicit => true,
-                      :complete_value => TemplateInvocation::TaskResultMap::REVERSE_MAP
+      has_many :targeting_hosts, :dependent => :destroy, :foreign_key => 'host_id'
+      has_many :template_invocations, :dependent => :destroy, :foreign_key => 'host_id'
+      has_one :execution_status_object, :class_name => 'HostStatus::ExecutionStatus', :foreign_key => 'host_id'
+      has_many :run_host_job_tasks, :through => :template_invocations
 
-        scoped_search :relation => :template_invocations, :on => :job_invocation_id,
-                      :rename => 'job_invocation.id', :only_explicit => true, :ext_method => :search_by_job_invocation
+      scoped_search :relation => :run_host_job_tasks, :on => :result, :rename => 'job_invocation.result',
+                    :ext_method => :search_by_job_invocation,
+                    :only_explicit => true,
+                    :complete_value => TemplateInvocation::TaskResultMap::REVERSE_MAP
 
-        scoped_search :relation => :execution_status_object, :on => :status, :rename => :execution_status,
-                      :complete_value => { :ok => HostStatus::ExecutionStatus::OK, :error => HostStatus::ExecutionStatus::ERROR }
+      scoped_search :relation => :template_invocations, :on => :job_invocation_id,
+                    :rename => 'job_invocation.id', :only_explicit => true, :ext_method => :search_by_job_invocation
 
-        def search_by_job_invocation(key, operator, value)
-          if key == 'job_invocation.result'
-            operator = operator == '=' ? 'IN' : 'NOT IN'
-            value = TemplateInvocation::TaskResultMap.status_to_task_result(value)
-          end
+      scoped_search :relation => :execution_status_object, :on => :status, :rename => :execution_status,
+                    :complete_value => { :ok => HostStatus::ExecutionStatus::OK, :error => HostStatus::ExecutionStatus::ERROR }
 
-          mapping = {
-            'job_invocation.id'     => %(#{TemplateInvocation.table_name}.job_invocation_id #{operator} ?),
-            'job_invocation.result' => %(#{ForemanTasks::Task.table_name}.result #{operator} (?))
-          }
-          {
-            :conditions => sanitize_sql_for_conditions([mapping[key], value_to_sql(operator, value)]),
-            :joins => { :template_invocations => [:run_host_job_task] }
-          }
+      def self.search_by_job_invocation(key, operator, value)
+        if key == 'job_invocation.result'
+          operator = operator == '=' ? 'IN' : 'NOT IN'
+          value = TemplateInvocation::TaskResultMap.status_to_task_result(value)
         end
+
+        mapping = {
+          'job_invocation.id'     => %(#{TemplateInvocation.table_name}.job_invocation_id #{operator} ?),
+          'job_invocation.result' => %(#{ForemanTasks::Task.table_name}.result #{operator} (?))
+        }
+        {
+          :conditions => sanitize_sql_for_conditions([mapping[key], value_to_sql(operator, value)]),
+          :joins => { :template_invocations => [:run_host_job_task] }
+        }
       end
     end
 
@@ -45,8 +50,8 @@ module ForemanRemoteExecution
       @execution_status_label ||= get_status(HostStatus::ExecutionStatus).to_label(options)
     end
 
-    def host_params
-      params = super
+    def host_params_with_remote_execution
+      params = host_params_without_remote_execution
       keys = remote_execution_ssh_keys
       params['remote_execution_ssh_keys'] = keys if keys.present?
       [:remote_execution_ssh_user, :remote_execution_effective_user_method,
@@ -88,21 +93,21 @@ module ForemanRemoteExecution
       @execution_interface = nil
     end
 
-    def becomes(*args)
-      became = super(*args)
+    def becomes_with_remote_execution(*args)
+      became = becomes_without_remote_execution(*args)
       became.drop_execution_interface_cache if became.respond_to? :drop_execution_interface_cache
       became
     end
 
-    def reload(*args)
+    def reload_with_remote_execution(*args)
       drop_execution_interface_cache
-      super(*args)
+      reload_without_remote_execution(*args)
     end
 
     private
 
-    def build_required_interfaces(attrs = {})
-      super(attrs)
+    def build_required_interfaces_with_remote_execution(attrs = {})
+      build_required_interfaces_without_remote_execution(attrs)
       self.primary_interface.execution = true if self.execution_interface.nil?
     end
   end

--- a/app/models/concerns/foreman_remote_execution/smart_proxy_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/smart_proxy_extensions.rb
@@ -1,5 +1,11 @@
 module ForemanRemoteExecution
   module SmartProxyExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :refresh, :remote_execution
+    end
+
     def pubkey
       self[:pubkey] || update_pubkey
     end
@@ -11,8 +17,8 @@ module ForemanRemoteExecution
       key
     end
 
-    def refresh
-      errors = super
+    def refresh_with_remote_execution
+      errors = refresh_without_remote_execution
       update_pubkey
       errors
     end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -148,7 +148,7 @@ module ForemanRemoteExecution
 
       User.send(:include, ForemanRemoteExecution::UserExtensions)
 
-      Host::Managed.send(:prepend, ForemanRemoteExecution::HostExtensions)
+      Host::Managed.send(:include, ForemanRemoteExecution::HostExtensions)
       Host::Managed.send(:include, ForemanTasks::Concerns::HostActionSubject)
 
       (Nic::Base.descendants + [Nic::Base]).each do |klass|
@@ -156,10 +156,10 @@ module ForemanRemoteExecution
       end
 
       Bookmark.send(:include, ForemanRemoteExecution::BookmarkExtensions)
-      HostsHelper.send(:prepend, ForemanRemoteExecution::HostsHelperExtensions)
-      ProvisioningTemplatesHelper.send(:prepend, ForemanRemoteExecution::JobTemplatesExtensions)
+      HostsHelper.send(:include, ForemanRemoteExecution::HostsHelperExtensions)
+      ProvisioningTemplatesHelper.send(:include, ForemanRemoteExecution::JobTemplatesExtensions)
 
-      SmartProxy.send(:prepend, ForemanRemoteExecution::SmartProxyExtensions)
+      SmartProxy.send(:include, ForemanRemoteExecution::SmartProxyExtensions)
       Subnet.send(:include, ForemanRemoteExecution::SubnetExtensions)
 
       # We need to explicitly force to load the Task model due to Rails loader


### PR DESCRIPTION
This is only intended for the 1.15 and 1.16, the nightlies should
keep the change and the proper fix should be done in Katello
to make it work again.