### PR TITLE
Fixes #21308, #21310 - Handle power actions on remote host better

### DIFF
--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -12,6 +12,7 @@ module ForemanRemoteExecutionCore
 
     EXPECTED_POWER_ACTION_MESSAGES = ['restart host', 'shutdown host'].freeze
     DEFAULT_REFRESH_INTERVAL = 1
+    MAX_PROCESS_RETRIES = 4
 
     def initialize(options)
       super()

--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -109,7 +109,7 @@ module ForemanRemoteExecutionCore
 
     def with_disconnect_handling
       yield
-    rescue Net::SSH::Disconnect => e
+    rescue IOError, Net::SSH::Disconnect => e
       @session.shutdown!
       check_expecting_disconnect
       if @expecting_disconnect


### PR DESCRIPTION
- d770b64 fixes the missing constant
- 4dd59b9 makes the `#with_disconnect_handling` method rescue `IOError`, which is raised when the remote host reboots (or at least on ruby-2.4.1)