### PR TITLE
Refs #21168 - raise => false only for Rails 5

### DIFF
--- a/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
@@ -10,7 +10,8 @@ module ForemanRemoteExecution
       # the default templates, remove after it's fixed in upstream
       # (https://github.com/theforeman/foreman/pull/4890) and gets
       # into a 1.17 release
-      skip_callback :create, :after, :assign_default_templates, :raise => false
+      skip_options = Rails::VERSION::MAJOR < 5 ? {} : { :raise => false }
+      skip_callback :create, :after, :assign_default_templates, skip_options
       before_create :assign_default_templates
     end
   end


### PR DESCRIPTION
Rails 4 doesn't raise any issue when callback is not found and it
doesn't even know the raise option. Due to this, it considers the
additional option being a sign of need for re-definition of the
original callback, instead of just making it as skipped.

This patch sets the `raise => false` only for Rails 5, where it's
needed.