### PR TITLE
Fixes #22168 - Fix ActiveModel::ForbiddenAttributesError

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -89,7 +89,12 @@ class JobInvocationsController < ApplicationController
     if params[:feature].present?
       JobInvocationComposer.for_feature(params[:feature], params[:host_ids], {})
     else
-      JobInvocationComposer.from_ui_params(params.merge(:triggering => triggering_params))
+      # triggering_params is a Hash
+      #   when a hash is merged into ActionController::Parameters,
+      #   it is assumed not to be #permitted?
+      with_triggering = params.merge(:triggering => triggering_params)
+      with_triggering[:triggering].permit!
+      JobInvocationComposer.from_ui_params(with_triggering)
     end
   end
 end


### PR DESCRIPTION
Due to a change in Foreman core if we call triggering_params in REX, we receive
a Hash instead of ActiveController::Params. Merging a Hash into unpermitted
Params leads to the merged Hash not being #permitted? and causing
ActiveModel::ForbiddenAttributesError when trying to mass-assign the
triggering_params when creating a new job.

Related to theforeman/foreman commit 1ccf4df