### PR TITLE
Fixes #22237 - notification on success run

### DIFF
--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -66,6 +66,12 @@ module Actions
         super unless event == Dynflow::Action::Skip
       end
 
+      def finalize
+        # creating the success notification should be the very last thing this tasks do
+        job_invocation = JobInvocation.find(input[:job_invocation_id])
+        job_invocation.build_notification.deliver!
+      end
+
       def humanized_input
         input.fetch(:job_invocation, {}).fetch(:description, '')
       end

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -78,6 +78,14 @@ class JobInvocation < ApplicationRecord
     { :conditions => sanitize_sql_for_conditions(["foreman_tasks_recurring_logics.id IS #{not_operator} NULL"]), :joins => :recurring_logic }
   end
 
+  def notification_recipients_ids
+    [ self.targeting.user_id ]
+  end
+
+  def build_notification
+    UINotifications::RemoteExecutionJobs::BaseJobFinish.new(self)
+  end
+
   def status
     HostStatus::ExecutionStatus::ExecutionTaskStatusMapper.new(task).status
   end

--- a/app/services/ui_notifications/remote_execution_jobs/base_job_finish.rb
+++ b/app/services/ui_notifications/remote_execution_jobs/base_job_finish.rb
@@ -1,0 +1,31 @@
+module UINotifications
+  module RemoteExecutionJobs
+    class BaseJobFinish < ::UINotifications::Base
+      def initialize(job_invocation)
+        @subject = job_invocation
+      end
+
+      def deliver!
+        ::Notification.create!(
+          :audience => Notification::AUDIENCE_USER,
+          :notification_blueprint => blueprint,
+          :initiator => initiator,
+          :message => message,
+          :subject => subject
+        )
+      end
+
+      def initiator
+        User.anonymous_admin
+      end
+
+      def blueprint
+        @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => 'rex_job_succeeded')
+      end
+
+      def message
+        UINotifications::StringParser.new(blueprint.message, { subject: subject })
+      end
+    end
+  end
+end

--- a/db/seeds.d/50-notification_blueprints.rb
+++ b/db/seeds.d/50-notification_blueprints.rb
@@ -1,0 +1,18 @@
+blueprints = [
+  {
+    group: N_('Jobs'),
+    name: 'rex_job_succeeded',
+    message: N_("A job '%{subject}' has finished successfully"),
+    level: 'success',
+    actions:
+    {
+      links:
+      [
+        path_method: :job_invocation_path,
+        title: N_('Job Details')
+      ]
+    }
+  }
+]
+
+blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -119,5 +119,14 @@ module ForemanRemoteExecution
         planned.input[:concurrency_control][:level].wont_be_empty
       end
     end
+
+    describe 'notifications' do
+      it 'creates notification on sucess run' do
+        FactoryBot.create(:notification_blueprint, :name => 'rex_job_succeeded')
+        assert_difference 'NotificationRecipient.where(:user_id => targeting.user.id).count' do
+          finalize_action planned
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
see how it works
![record](https://user-images.githubusercontent.com/109773/34792425-41293588-f648-11e7-8714-fb7cbae35431.gif)

ready for later customization, job_invocation would return different notification builder class set per feature