### PR TITLE
Fixes #21888 - convert the taxable_taxonomies for JobTemplate

### DIFF
--- a/db/migrate/20180112125015_fix_taxable_taxonomies_job_template.rb
+++ b/db/migrate/20180112125015_fix_taxable_taxonomies_job_template.rb
@@ -1,0 +1,14 @@
+class FixTaxableTaxonomiesJobTemplate < ActiveRecord::Migration[4.2]
+  def up
+    # we need to count on the fact that the user might already has assigned the templates
+    # to taxonomies after the previous update
+    already_present = TaxableTaxonomy.where(:taxable_type => 'JobTemplate').pluck(:taxable_id)
+    missing = JobTemplate.unscoped.pluck(:id) - already_present
+    TaxableTaxonomy.unscoped.where(:taxable_type => 'Template', :taxable_id => missing).update_all(:taxable_type => 'JobTemplate')
+    TaxableTaxonomy.unscoped.where(:taxable_type => 'Template', :taxable_id => already_present).delete_all
+  end
+
+  def down
+    TaxableTaxonomy.unscoped.where(:taxable_type => 'JobTemplate').update_all(:taxable_type => 'Template')
+  end
+end


### PR DESCRIPTION
In #20708, we were converting the taxable_taxonomies association for
Templates. ProvisioningTemplate and PTable were converted, but not
JobTemplate. This commits completes the migration for remote execution.