### PR TITLE
Fixes #22421 - Correct Nic migration for Rails 5

### DIFF
--- a/db/migrate/20150903192731_add_execution_to_interface.rb
+++ b/db/migrate/20150903192731_add_execution_to_interface.rb
@@ -1,19 +1,9 @@
 class AddExecutionToInterface < ActiveRecord::Migration[4.2]
-  class FakeNic < ApplicationRecord
-    self.table_name = 'nics'
-
-    def type
-      Nic::Managed
-    end
-  end
-
   def up
     add_column :nics, :execution, :boolean, :default => false
 
-    FakeNic.reset_column_information
-    FakeNic.all.each do |nic|
-      nic.update_column(:execution, true) if nic.primary
-    end
+    Nic::Managed.reset_column_information
+    Nic::Managed.where(primary: true).update_all(execution: true)
   end
 
   def down


### PR DESCRIPTION
This also has an added benefit of running much faster, especially for
installations that have a large number of interfaces.