### PR TITLE
Fixes #22605 - JobInvocation API accepts 'feature' param

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,13 @@
+scss:
+  enabled: false
+
+stylelint:
+  enabled: true
+
+ruby:
+  config_file: .rubocop.yml
+
+jshint:
+  enabled: false
+
+fail_on_violations: true


### PR DESCRIPTION
The API for JobInvocation could accept a 'feature' param which finds the
REX feature and creates the JobInvocation for said feature with all the
right parameters.
This saves other plugins from having to find the template ID associated
with the feature they want to run.

Here's a screencast showcasing this feature - clicking on "run playbook" sends a POST request with the feature & required inputs/host ids

https://gfycat.com/gifs/detail/SpottedOfficialCarpenterant