### PR TITLE
Fixes #22604 - Accept input values as GET params in UI

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -3,6 +3,7 @@ class JobInvocationsController < ApplicationController
   include ::ForemanTasks::Concerns::Parameters::Triggering
 
   def new
+    return @composer = prepare_composer if params[:feature].present?
     ui_params = {
       :host_ids => params[:host_ids],
       :targeting => {
@@ -87,7 +88,12 @@ class JobInvocationsController < ApplicationController
 
   def prepare_composer
     if params[:feature].present?
-      JobInvocationComposer.for_feature(params[:feature], params[:host_ids], {})
+      inputs = params[:inputs].permit!.to_hash if params.include?(:inputs)
+      JobInvocationComposer.for_feature(
+        params[:feature],
+        params[:host_ids],
+        inputs
+      )
     else
       # triggering_params is a Hash
       #   when a hash is merged into ActionController::Parameters,

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -254,6 +254,7 @@ class JobInvocationComposer
     end
 
     def input_values_params
+      return {} if @provided_inputs.blank?
       @provided_inputs.map do |key, value|
         input = job_template.template_inputs_with_foreign.find { |i| i.name == key.to_s }
         unless input

--- a/test/functional/job_invocations_controller_test.rb
+++ b/test/functional/job_invocations_controller_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+class JobInvocationsControllerTest < ActionController::TestCase
+  test 'should parse inputs coming from the URL params' do
+    template = FactoryBot.create(:job_template, :with_input)
+    feature = FactoryBot.create(:remote_execution_feature,
+                                :job_template => template)
+    params = {
+      feature: feature.label,
+      inputs: { template.template_inputs.first.name => 'foobar' }
+    }
+
+    get :new, params: params, session: set_session_user
+    template_invocation_params = [
+      {
+        'input_values' =>
+        [
+          {
+            'value' => 'foobar',
+            'template_input_id' => template.template_inputs.first.id
+          }
+        ],
+        'template_id' => template.id
+      }
+    ]
+    assert_equal(template_invocation_params,
+                 assigns(:composer).params['template_invocations'])
+  end
+
+  test 'should allow no inputs' do
+    template = FactoryBot.create(:job_template)
+    feature = FactoryBot.create(:remote_execution_feature,
+                                :job_template => template)
+    params = {
+      feature: feature.label,
+    }
+    get :new, params: params, session: set_session_user
+    template_invocation_params = [
+      {
+        'template_id' => template.id,
+        'input_values' => {}
+      }
+    ]
+    assert_equal(template_invocation_params,
+                 assigns(:composer).params['template_invocations'])
+  end
+end


### PR DESCRIPTION
The UI should accept template inputs through the URL to display
the JobInvocation new form with pre-filled fields.

For example,
https://centos7-devel.lobatolan.home/job_invocations/new?feature=
ansible_run_insights_plan&inputs[plan_id]=3&inputs[organization_id]=20
would find the 'ansible_run_insights_plan' feature and 'plan_id' /
'organization_id' as pre-filled fields.

A small screencast demonstrating this feature around 1:10 -  https://webmshare.com/1WQee