### PR TITLE
Fixes #22609 - customizable notifications per feature

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,5 +91,14 @@ Naming/HeredocDelimiterNaming:
 Style/RescueStandardError:
   Enabled: false
 
+Style/SafeNavigation:
+  Enabled: false
+
 Lint/BooleanSymbol:
   Enabled: false
+
+Metrics/PerceivedComplexity:
+  Max: 8
+
+Metrics/AbcSize:
+  Max: 45

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -11,6 +11,7 @@ class JobInvocationComposer
         :targeting => ui_params.fetch(:targeting, {}).merge(:user_id => User.current.id),
         :triggering => triggering,
         :host_ids => ui_params[:host_ids],
+        :remote_execution_feature_id => ui_params[:remote_execution_feature_id],
         :description_format => job_invocation_base[:description_format],
         :password => blank_to_nil(job_invocation_base[:password]),
         :key_passphrase => blank_to_nil(job_invocation_base[:key_passphrase]),
@@ -94,6 +95,7 @@ class JobInvocationComposer
         :targeting => targeting_params,
         :triggering => triggering_params,
         :description_format => api_params[:description_format],
+        :remote_execution_feature_id => api_params[:remote_execution_feature_id],
         :concurrency_control => concurrency_control_params,
         :execution_timeout_interval => api_params[:execution_timeout_interval] || template.execution_timeout_interval,
         :template_invocations => template_invocations_params }.with_indifferent_access
@@ -178,6 +180,7 @@ class JobInvocationComposer
         :description_format => job_invocation.description_format,
         :concurrency_control => concurrency_control_params,
         :execution_timeout_interval => job_invocation.execution_timeout_interval,
+        :remote_execution_feature_id => job_invocation.remote_execution_feature_id,
         :template_invocations => template_invocations_params }.with_indifferent_access
     end
 
@@ -233,6 +236,7 @@ class JobInvocationComposer
         :targeting => targeting_params,
         :triggering => {},
         :concurrency_control => {},
+        :remote_execution_feature_id => @feature.id,
         :template_invocations => template_invocations_params }.with_indifferent_access
     end
 
@@ -281,7 +285,7 @@ class JobInvocationComposer
   end
 
   attr_accessor :params, :job_invocation, :host_ids, :search_query
-  delegate :job_category, :pattern_template_invocations, :template_invocations, :targeting, :triggering, :to => :job_invocation
+  delegate :job_category, :remote_execution_feature_id, :pattern_template_invocations, :template_invocations, :targeting, :triggering, :to => :job_invocation
 
   def initialize(params, set_defaults = false)
     @params = params
@@ -314,6 +318,7 @@ class JobInvocationComposer
   def compose
     job_invocation.job_category = validate_job_category(params[:job_category])
     job_invocation.job_category ||= available_job_categories.first if @set_defaults
+    job_invocation.remote_execution_feature_id = params[:remote_execution_feature_id]
     job_invocation.targeting = build_targeting
     job_invocation.triggering = build_triggering
     job_invocation.pattern_template_invocations = build_template_invocations

--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -1,5 +1,5 @@
 class RemoteExecutionFeature < ApplicationRecord
-  VALID_OPTIONS = [:provided_inputs, :description, :host_action_button].freeze
+  VALID_OPTIONS = [:provided_inputs, :description, :host_action_button, :notification_builder].freeze
   validates :label, :name, :presence => true, :uniqueness => true
 
   belongs_to :job_template
@@ -27,11 +27,19 @@ class RemoteExecutionFeature < ApplicationRecord
     options[:host_action_button] = false unless options.key?(:host_action_button)
 
     feature = self.find_by(label: label)
+    builder = options[:notification_builder] ? options[:notification_builder].to_s : nil
 
-    attributes = { :name => name, :provided_input_names => options[:provided_inputs], :description => options[:description], :host_action_button => options[:host_action_button] }
+    attributes = { :name => name,
+                   :provided_input_names => options[:provided_inputs],
+                   :description => options[:description],
+                   :host_action_button => options[:host_action_button],
+                   :notification_builder => builder }
     # in case DB does not have the attribute created yet but plugin initializer registers the feature, we need to skip this attribute
-    unless self.attribute_names.include?('host_action_button')
-      attributes.delete(:host_action_button)
+    attrs = [ :host_action_button, :notification_builder ]
+    attrs.each do |attr|
+      unless self.attribute_names.include?(attr.to_s)
+        attributes.delete(attr)
+      end
     end
 
     if feature.nil?

--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -2,7 +2,6 @@ class Setting::RemoteExecution < Setting
 
   ::Setting::BLANK_ATTRS.concat %w{remote_execution_ssh_password remote_execution_ssh_key_passphrase}
 
-  # rubocop:disable AbcSize
   # rubocop:disable Metrics/MethodLength
   def self.load_defaults
     # Check the table exists

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -7,6 +7,7 @@
 <%= form_for @composer.job_invocation, :html => {'data-refresh-url' => refresh_job_invocations_path, :id => 'job_invocation_form'} do |f| %>
 
   <%= selectable_f f, :job_category, @composer.available_job_categories, {}, :label => _('Job category') %>
+  <%= f.hidden_field(:job_category, :value => @composer.remote_execution_feature_id) %>
 
   <% selected_templates_per_provider = {} %>
   <% @composer.displayed_provider_types.each do |provider_type| %>

--- a/db/migrate/20180202072115_add_notification_builder_to_remote_execution_feature.rb
+++ b/db/migrate/20180202072115_add_notification_builder_to_remote_execution_feature.rb
@@ -1,0 +1,5 @@
+class AddNotificationBuilderToRemoteExecutionFeature < ActiveRecord::Migration[4.2]
+  def change
+    add_column :remote_execution_features, :notification_builder, :string
+  end
+end

--- a/db/migrate/20180202123215_add_feature_id_to_job_invocation.rb
+++ b/db/migrate/20180202123215_add_feature_id_to_job_invocation.rb
@@ -1,0 +1,6 @@
+class AddFeatureIdToJobInvocation < ActiveRecord::Migration[4.2]
+  def change
+    add_column :job_invocations, :remote_execution_feature_id, :integer, :index => true
+    add_foreign_key :job_invocations, :remote_execution_features, :column => :remote_execution_feature_id
+  end
+end

--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -655,13 +655,30 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           },
           :targeting_type => 'static_query',
           :search_query => 'some hosts',
-          :inputs => {input1.name => 'some_value'}}
+          :inputs => { input1.name => 'some_value' } }
       end
 
       it 'sets the concurrency level and time span based on the input' do
         assert composer.save!
         composer.job_invocation.time_span.must_equal time_span
         composer.job_invocation.concurrency_level.must_equal level
+      end
+    end
+
+    context 'with rex feature defined' do
+      let(:feature) { FactoryBot.create(:remote_execution_feature) }
+      let(:params) do
+        { :job_category => trying_job_template_1.job_category,
+          :job_template_id => trying_job_template_1.id,
+          :remote_execution_feature_id => feature.id,
+          :targeting_type => 'static_query',
+          :search_query => 'some hosts',
+          :inputs => { input1.name => 'some_value' } }
+      end
+
+      it 'sets the remote execution feature based on the input' do
+        assert composer.save!
+        composer.job_invocation.remote_execution_feature.must_equal feature
       end
     end
 


### PR DESCRIPTION
This allows defining a custom notification builder for feature, if you want to see example usage, see https://github.com/theforeman/foreman_openscap/pull/326

the fact we now store the feature makes it easy in future to add more customization, e.g. job invocation page, based on it