### PR TITLE
Fixes #22633 - "humanize" setting names

### DIFF
--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -2,6 +2,7 @@ class Setting::RemoteExecution < Setting
 
   ::Setting::BLANK_ATTRS.concat %w{remote_execution_ssh_password remote_execution_ssh_key_passphrase}
 
+  # rubocop:disable AbcSize
   # rubocop:disable Metrics/MethodLength
   def self.load_defaults
     # Check the table exists
@@ -12,48 +13,56 @@ class Setting::RemoteExecution < Setting
       [
         self.set('remote_execution_fallback_proxy',
                  N_('Search the host for any proxy with Remote Execution, useful when the host has no subnet or the subnet does not have an execution proxy'),
-                 false),
+                 false,
+                 N_('Fallback Any Proxy')),
         self.set('remote_execution_global_proxy',
                  N_('Search for remote execution proxy outside of the proxies assigned to the host. ' +
                  "If locations or organizations are enabled, the search will be limited to the host's " +
                  'organization or location.'),
-                 true),
+                 true,
+                 N_('Enable Global Proxy')),
         self.set('remote_execution_without_proxy',
                  N_('When enabled, the remote execution will try to run the commands directly, when no
                      proxy with remote execution feature is configured for the host.'),
-                 false),
+                 false,
+                 N_('Fallback Without Proxy')),
         self.set('remote_execution_ssh_user',
                  N_('Default user to use for SSH.  You may override per host by setting a parameter called remote_execution_ssh_user.'),
-                 'root'),
+                 'root',
+                 N_('SSH User')),
         self.set('remote_execution_effective_user',
                  N_('Default user to use for executing the script. If the user differs from the SSH user, su or sudo is used to switch the user.'),
-                 'root'),
+                 'root',
+                 N_('Effective User')),
         self.set('remote_execution_effective_user_method',
                  N_('What command should be used to switch to the effective user. One of %s') % SSHExecutionProvider::EFFECTIVE_USER_METHODS.inspect,
                  'sudo',
-                 'remote_execution_effective_user_method',
+                 N_('Effective User Method'),
                  nil,
                  { :collection => proc { Hash[SSHExecutionProvider::EFFECTIVE_USER_METHODS.map { |method| [method, method] }] } }),
         self.set('remote_execution_sync_templates',
                  N_('Whether we should sync templates from disk when running db:seed.'),
-                 true),
+                 true,
+                 N_('Sync Job Templates')),
         self.set('remote_execution_ssh_port',
                  N_('Port to use for SSH communication. Default port 22. You may override per host by setting a parameter called remote_execution_ssh_port.'),
-                 '22'),
+                 '22',
+                 N_('SSH Port')),
         self.set('remote_execution_connect_by_ip',
                  N_('Should the ip addresses on host interfaces be preferred over the fqdn? '\
                  'It is useful, when DNS not resolving the fqdns properly. You may override this per host by setting a parameter called remote_execution_connect_by_ip.'),
-                 false),
+                 false,
+                 N_('Connect by IP')),
         self.set('remote_execution_ssh_password',
                  N_('Default password to use for SSH. You may override per host by setting a parameter called remote_execution_ssh_password'),
                  nil,
-                 N_('Default password to use for SSH'),
+                 N_('Default SSH password'),
                  nil,
                  { :encrypted => true }),
         self.set('remote_execution_ssh_key_passphrase',
                  N_('Default key passphrase to use for SSH. You may override per host by setting a parameter called remote_execution_ssh_key_passphrase'),
                  nil,
-                 N_('Default key passphrase to use for SSH'),
+                 N_('Default SSH key passphrase'),
                  nil,
                  { :encrypted => true })
       ].each { |s| self.create! s.update(:category => 'Setting::RemoteExecution') }
@@ -61,5 +70,6 @@ class Setting::RemoteExecution < Setting
 
     true
   end
+  # rubocop:enable AbcSize
   # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
REX settings are displayed in the Administer > Settings with their
variable names. e.g: 'remote_execution_effective_user_method'.
Instead, they should just show a name that does not look a variable
(snakecase, namespaced..).