### PR TITLE
Fixes #22688 - Use UUID column type for storing task UUIDs

### DIFF
--- a/db/migrate/20180226095631_change_task_id_to_uuid.rb
+++ b/db/migrate/20180226095631_change_task_id_to_uuid.rb
@@ -1,0 +1,31 @@
+class ChangeTaskIdToUuid < ActiveRecord::Migration[4.2]
+  def up
+    if on_postgresql?
+      change_table :job_invocations do |t|
+        t.change :task_id, :uuid, :using => 'task_id::uuid'
+      end
+
+      change_table :template_invocations do |t|
+        t.change :run_host_job_task_id, :uuid, :using => 'run_host_job_task_id::uuid'
+      end
+    end
+  end
+
+  def down
+    if on_postgresql?
+      change_table :job_invocations do |t|
+        t.change :task_id, :string, :limit => 255
+      end
+
+      change_table :template_invocations do |t|
+        t.change :run_host_job_task_id, :string, :limit => 255
+      end
+    end
+  end
+
+  private
+
+  def on_postgresql?
+    ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+  end
+end

--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'deface'
   s.add_dependency 'dynflow', '~> 0.8.26'
   s.add_dependency 'foreman_remote_execution_core'
-  s.add_dependency 'foreman-tasks', '>= 0.11.1'
+  s.add_dependency 'foreman-tasks', '~> 0.12'
 
   s.add_development_dependency 'factory_bot_rails', '~> 4.8.0'
   s.add_development_dependency 'rubocop'

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -1,5 +1,5 @@
-
 require 'test_plugin_helper'
+require 'securerandom'
 
 module ForemanRemoteExecution
   class RunHostsJobTest < ActiveSupport::TestCase
@@ -18,8 +18,9 @@ module ForemanRemoteExecution
       end
     end
 
+    let(:uuid) { SecureRandom.uuid }
     let(:task) do
-      OpenStruct.new(:id => '123').tap do |o|
+      OpenStruct.new(:id => uuid).tap do |o|
         o.stubs(:add_missing_task_groups)
         o.stubs(:task_groups).returns([])
       end
@@ -78,7 +79,7 @@ module ForemanRemoteExecution
 
     it 'uses the BindJobInvocation middleware' do
       planned
-      job_invocation.task_id.must_equal '123'
+      job_invocation.task_id.must_equal uuid
     end
 
     # In plan phase this is handled by #action_subject

--- a/test/unit/concerns/foreman_tasks_cleaner_extensions_test.rb
+++ b/test/unit/concerns/foreman_tasks_cleaner_extensions_test.rb
@@ -14,7 +14,7 @@ class ForemanRemoteExecutionForemanTasksCleanerExtensionsTest < ActiveSupport::T
     job.reload
     job.task.must_be :nil?
     job.task_id.wont_be :nil?
-    ForemanTasks::Cleaner.new(:filter => 'id = 1').delete
+    ForemanTasks::Cleaner.new(:filter => '').delete
     JobInvocation.where(:id => job.id).must_be :empty?
   end
 end


### PR DESCRIPTION
Required after https://github.com/theforeman/foreman-tasks/pull/315 goes in