### PR TITLE
Fixes #22807 - Do not join on columns of possibly different types

### DIFF
--- a/db/migrate/20160113162007_expand_all_template_invocations.rb
+++ b/db/migrate/20160113162007_expand_all_template_invocations.rb
@@ -14,7 +14,7 @@ class ExpandAllTemplateInvocations < ActiveRecord::Migration[4.2]
     FakeTemplateInvocation.update_all 'host_id = NULL'
 
     # expand all pattern template invocations and link RunHostJob
-    JobInvocation.joins(:targeting).where("#{Targeting.table_name}.resolved_at IS NOT NULL").includes([ :pattern_template_invocations, :targeting, :sub_tasks => :locks ]).each do |job_invocation|
+    JobInvocation.joins(:targeting).where("#{Targeting.table_name}.resolved_at IS NOT NULL").includes([:pattern_template_invocations, :targeting]).each do |job_invocation|
       job_invocation.pattern_template_invocations.each do |pattern_template_invocation|
         job_invocation.targeting.hosts.each do |host|
           task = job_invocation.sub_tasks.find do |sub_task|


### PR DESCRIPTION
Steps to reproduce:
1. Have a postgres DB
2. enable `foreman-tasks` plugin, disable REX
3. `bundle exec rake db:create && bundle exec rake db:migrate`
4. Enable REX
5. Try to run `bundle exec rake db:migrate` again, without this fix it should fail with the error described in the issue

When we tried to do `.includes([:sub_tasks => :locks])` we tried to join `JobInvocation` with `ForemanTasks::Task` but the column used to match the records were of different types. If we don't do this join, we sacrifice a bit of performance by not loading all the needed data at once, but retrieving later should be done using `SELECT ... WHERE` which should work.