### PR TITLE
Fixes #22993 - refactor audits definitions

### DIFF
--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -1,8 +1,8 @@
 class JobInvocation < ApplicationRecord
+  audited :except => [:task_id, :targeting_id, :task_group_id, :triggering_id]
+
   include Authorizable
   include Encryptable
-
-  audited :except => [ :task_id, :targeting_id, :task_group_id, :triggering_id ]
 
   include ForemanRemoteExecution::ErrorsFlattener
   FLATTENED_ERRORS_MAPPING = {

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -1,4 +1,5 @@
 class JobTemplate < ::Template
+  audited
   include ::Exportable
 
   class NonUniqueInputsError < Foreman::Exception
@@ -12,7 +13,6 @@ class JobTemplate < ::Template
   friendly_id :name
   include Parameterizable::ByIdName
 
-  audited :allow_mass_assignment => true
   has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name, :dependent => :nullify
   has_many :all_template_invocations, :dependent => :destroy, :foreign_key => 'template_id', :class_name => 'TemplateInvocation'
   has_many :template_invocations, -> { where('host_id IS NOT NULL') }, :foreign_key => 'template_id'


### PR DESCRIPTION
while this is not entirely necessary, it would be good to be consistent with other models from plugins and core and have the audited definition first (it must preceed Taxonomix inclusion)