### PR TITLE
Fixes #22974 - store feature coming via form

### DIFF
--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -11,7 +11,7 @@ class JobInvocationComposer
         :targeting => ui_params.fetch(:targeting, {}).merge(:user_id => User.current.id),
         :triggering => triggering,
         :host_ids => ui_params[:host_ids],
-        :remote_execution_feature_id => ui_params[:remote_execution_feature_id],
+        :remote_execution_feature_id => job_invocation_base[:remote_execution_feature_id],
         :description_format => job_invocation_base[:description_format],
         :password => blank_to_nil(job_invocation_base[:password]),
         :key_passphrase => blank_to_nil(job_invocation_base[:key_passphrase]),


### PR DESCRIPTION
The problem here is that the hidden is under `job_invocation` key so feature was always ignored when user went through the form.