### PR TITLE
Refs #21457 - Provide the expected interface in the base model

### DIFF
--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -72,5 +72,9 @@ class RemoteExecutionProvider
     def host_setting(host, setting)
       host.params[setting.to_s] || Setting[setting]
     end
+
+    def ssh_password(_host) end
+
+    def ssh_key_passphrase(_host) end
   end
 end


### PR DESCRIPTION
f9d116105f70041f639f23675884d7e43ad9a1be started to depend on these methods being present in the base model. This ensures it doesn't crash when providers don't implement these methods.