### PR TITLE
Fixes #23297 - Webpack assets path changed

### DIFF
--- a/app/views/job_invocations/show.html.erb
+++ b/app/views/job_invocations/show.html.erb
@@ -1,7 +1,7 @@
 <% title @job_invocation.description, trunc_with_tooltip(@job_invocation.description, 120) %>
 <% stylesheet 'foreman_remote_execution/job_invocations' %>
 <% javascript 'charts', 'foreman_remote_execution/template_invocation' %>
-<%= javascript_include_tag *webpack_asset_paths('remoteexecution', :extension => 'js'), "data-turbolinks-track" => true, 'defer' => 'defer' %>
+<%= javascript_include_tag *webpack_asset_paths('foreman_remote_execution', :extension => 'js'), "data-turbolinks-track" => true, 'defer' => 'defer' %>
 
 <% if @job_invocation.task %>
   <% title_actions(button_group(job_invocation_task_buttons(@job_invocation.task))) %>


### PR DESCRIPTION
In `app/views/job_invocations/show.html.erb`, we load the webpack
assets currently by calling a path:

*webpack_asset_paths('remoteexecution'

Since #23215 simplified the name of plugin bundles to just be the name
 of the plugin (instead of "name of the plugin minus dashes and
spaces"), it should be changed to:

*webpack_asset_paths('foreman_remote_execution'