### PR TITLE
Fixes #22483 - use host.host_param instead of host.params if possible

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -45,13 +45,17 @@ module ForemanRemoteExecution
       @execution_status_label ||= get_status(HostStatus::ExecutionStatus).to_label(options)
     end
 
-    def host_params
+    def host_params_hash
       params = super
       keys = remote_execution_ssh_keys
-      params['remote_execution_ssh_keys'] = keys if keys.present?
+      source = 'global'
+      if keys.present?
+        params['remote_execution_ssh_keys'] = {:value => keys, :safe_value => keys, :source => source}
+      end
       [:remote_execution_ssh_user, :remote_execution_effective_user_method,
        :remote_execution_connect_by_ip].each do |key|
-        params[key.to_s] = Setting[key] unless params.key?(key.to_s)
+        value = Setting[key]
+        params[key.to_s] = {:value => value, :safe_value => value, :source => source} unless params.key?(key.to_s)
       end
       params
     end

--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -75,7 +75,7 @@ class RemoteExecutionProvider
     end
 
     def host_setting(host, setting)
-      host.params[setting.to_s] || Setting[setting]
+      host.host_param(setting.to_s) || Setting[setting]
     end
 
     def ssh_password(_host) end

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -27,7 +27,7 @@ class SSHExecutionProvider < RemoteExecutionProvider
     private
 
     def ssh_user(host)
-      host.params['remote_execution_ssh_user']
+      host.host_param('remote_execution_ssh_user')
     end
 
     def ssh_port(host)

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -20,21 +20,21 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
     end
 
     it 'has ssh user in the parameters' do
-      host.params['remote_execution_ssh_user'].must_equal Setting[:remote_execution_ssh_user]
+      host.host_param('remote_execution_ssh_user').must_equal Setting[:remote_execution_ssh_user]
     end
 
     it 'can override ssh user' do
       host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_user', :value => 'amy')
-      host.params['remote_execution_ssh_user'].must_equal 'amy'
+      host.host_param('remote_execution_ssh_user').must_equal 'amy'
     end
 
     it 'has effective user method in the parameters' do
-      host.params['remote_execution_effective_user_method'].must_equal Setting[:remote_execution_effective_user_method]
+      host.host_param('remote_execution_effective_user_method').must_equal Setting[:remote_execution_effective_user_method]
     end
 
     it 'can override effective user method' do
       host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_method', :value => 'su')
-      host.params['remote_execution_effective_user_method'].must_equal 'su'
+      host.host_param('remote_execution_effective_user_method').must_equal 'su'
     end
 
     it 'has ssh keys in the parameters' do

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -72,7 +72,6 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
 
     describe 'ssh user' do
       it 'uses the remote_execution_ssh_user on the host param' do
-        host.params['remote_execution_ssh_user'] = 'my user'
         host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_user', :value => 'my user')
         proxy_options[:ssh_user].must_equal 'my user'
       end
@@ -80,7 +79,6 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
 
     describe 'sudo' do
       it 'uses the remote_execution_ssh_user on the host param' do
-        host.params['remote_execution_effective_user_method'] = 'sudo'
         method_param = FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_method', :value => 'sudo')
         host.host_parameters << method_param
         proxy_options[:effective_user_method].must_equal 'sudo'
@@ -158,7 +156,7 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
       end
 
       it 'gets ip from flagged interfaces' do
-        host.params['remote_execution_connect_by_ip'] = true
+        host.host_params['remote_execution_connect_by_ip'] = true
         # no ip address set on relevant interface - fallback to fqdn
         SSHExecutionProvider.find_ip_or_hostname(host).must_equal 'somehost.somedomain.org'
 


### PR DESCRIPTION
We change the way how we extend the host params to be compatible with
the `host_param` helper.

We also use the `host.host_param` if possible, as it has better
performance properties (the value gets memorized and it doesn't
recalculate the smart variables every time it's called.