### PR TITLE
Refs #21731 - revert using `loop` instead of `process`

### DIFF
--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -297,7 +297,7 @@ module ForemanRemoteExecutionCore
           raise('Error initializing command') unless success
         end
       end
-      session.loop(0.1) { !run_started? }
+      session.process(0) { !run_started? }
       return true
     end
 
@@ -330,7 +330,7 @@ module ForemanRemoteExecutionCore
           started = true
         end
       end
-      session.loop(0.1) { !started }
+      session.process(0) { !started }
       # Closing the channel without sending any data gives us SIGPIPE
       channel.close unless stdin.nil?
       channel.wait


### PR DESCRIPTION
In e65c15a, the `process` call was replaced with `loop` for no obvious
reason. This change leads potentially for the commands to get stuck.

I've reproduced this by trying `sudo` effective method without `sudo`
being present on the system.