### PR TITLE
Remove duplicate license tag in core gemspec

### DIFF
--- a/foreman_remote_execution_core.gemspec
+++ b/foreman_remote_execution_core.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.description = <<DESC
   Ssh remote execution provider code sharable between Foreman and Foreman-Proxy
 DESC
-  s.license = 'GPLv3'
 
   s.files = Dir['lib/foreman_remote_execution_core/**/*'] +
             ['lib/foreman_remote_execution_core.rb', 'LICENSE']


### PR DESCRIPTION
This keeps in the SPDX compatible version