### PR TITLE
Fixes #24085 - Include missing link in breadcrumbs

### DIFF
--- a/app/views/template_invocations/show.html.erb
+++ b/app/views/template_invocations/show.html.erb
@@ -1,4 +1,5 @@
-<% items = [{ :caption => @template_invocation.job_invocation.description,
+<% items = [{ :caption => _('Job invocations'), :url => job_invocations_path },
+            { :caption => @template_invocation.job_invocation.description,
               :url => job_invocation_path(@template_invocation.job_invocation_id) },
             { :caption => _('Template Invocation for %s') % @template_invocation.host.name }] %>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7326770/41962336-0c6b044e-79f5-11e8-9a05-fb31c5b19064.png)

CC @Rohoover