### PR TITLE
Fixes #23394 - Unable to set effective user for job templates

### DIFF
--- a/app/controllers/api/v2/job_templates_controller.rb
+++ b/app/controllers/api/v2/job_templates_controller.rb
@@ -57,12 +57,10 @@ module Api
           param :snippet, :bool, :allow_nil => true
           param :audit_comment, String, :allow_nil => true
           param :locked, :bool, :desc => N_('Whether or not the template is locked for editing')
-          param :ssh, Hash, :desc => N_('SSH provider specific options') do
-            param :effective_user, Hash, :desc => N_('Effective user options') do
-              param :value, String, :desc => N_('What user should be used to run the script (using sudo-like mechanisms)'), :allowed_nil => true
-              param :overridable, :bool, :desc => N_('Whether it should be allowed to override the effective user from the invocation form.')
-              param :current_user, :bool, :desc => N_('Whether the current user login should be used as the effective user')
-            end
+          param :effective_user_attributes, Hash, :desc => N_('Effective user options') do
+            param :value, String, :desc => N_('What user should be used to run the script (using sudo-like mechanisms)'), :allowed_nil => true
+            param :overridable, :bool, :desc => N_('Whether it should be allowed to override the effective user from the invocation form.')
+            param :current_user, :bool, :desc => N_('Whether the current user login should be used as the effective user')
           end
           param_group :taxonomies, ::Api::V2::BaseController
         end

--- a/test/functional/api/v2/job_templates_controller_test.rb
+++ b/test/functional/api/v2/job_templates_controller_test.rb
@@ -59,6 +59,18 @@ module Api
         assert_response :unprocessable_entity
       end
 
+      test 'should update effective user' do
+        template = { name: @template.name, job_category: @template.job_category,
+                     template: @template.template, provider_type: 'SSH',
+                     effective_user_attributes: {
+                       value: 'nobody',
+                       overridable: true,
+                       current_user: false,
+                     } }
+        put :update, params: { id: @template.to_param, job_template: template }
+        assert_response :ok
+      end
+
       test 'should destroy' do
         delete :destroy, params: { :id => @template.to_param }
         assert_response :ok


### PR DESCRIPTION
There was a problem with the API structure, it didn't work since day one.
The `ssh` sub entry was not recognized by `strong params`, making the `ssh`
object (hash) and children not to be accessible.

This PR fixes the issue, but "breaks" the bad API documentation that existed
before.