### PR TITLE
Fixes #24113 - fix fake executor

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -121,7 +121,7 @@ module Actions
       def update_host_status
         host = Host.find(input[:host][:id])
         status = host.execution_status_object || host.build_execution_status_object
-        status.status = exit_status.to_i.zero? ? HostStatus::ExecutionStatus::OK : HostStatus::ExecutionStatus::ERROR
+        status.status = exit_status.to_s == "0" ? HostStatus::ExecutionStatus::OK : HostStatus::ExecutionStatus::ERROR
         status.save!
       end
 

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -121,7 +121,7 @@ module Actions
       def update_host_status
         host = Host.find(input[:host][:id])
         status = host.execution_status_object || host.build_execution_status_object
-        status.status = exit_status.zero? ? HostStatus::ExecutionStatus::OK : HostStatus::ExecutionStatus::ERROR
+        status.status = exit_status.to_i.zero? ? HostStatus::ExecutionStatus::OK : HostStatus::ExecutionStatus::ERROR
         status.save!
       end
 

--- a/lib/foreman_remote_execution_core/fake_script_runner.rb
+++ b/lib/foreman_remote_execution_core/fake_script_runner.rb
@@ -24,7 +24,7 @@ module ForemanRemoteExecutionCore
         @data.freeze
       end
 
-      def self.build(options)
+      def build(options)
         new(options)
       end
     end


### PR DESCRIPTION
This fixes the error with undefined method build, as well as issue with
checking the exit status, as in case of exception, it's actually
'EXCEPTION' string.