### PR TITLE
fixes #24240 - replace render text with plain

### DIFF
--- a/app/controllers/job_templates_controller.rb
+++ b/app/controllers/job_templates_controller.rb
@@ -19,10 +19,15 @@ class JobTemplatesController < ::TemplatesController
     host = params[:preview_host_id].present? ? base.find(params[:preview_host_id]) : base.first
     @template.template = params[:template]
     renderer = InputTemplateRenderer.new(@template, host)
-    if (output = renderer.preview)
+    output = renderer.preview
+    if output
       render :plain => output
     else
-      render :status => 406, :text => _('Problem with previewing the template: %{error}. Note that you must save template input changes before you try to preview it.' % {:error => renderer.error_message})
+      render status: :not_acceptable,
+             plain: _(
+               'Problem with previewing the template: %{error}. Note that you must save template input changes before you try to preview it.' %
+               {:error => renderer.error_message}
+             )
     end
   end
 

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -1,13 +1,11 @@
 FactoryBot.define do
-
-  factory :job_template do |f|
-    f.sequence(:name) { |n| "Job template #{n}" }
+  factory :job_template do
+    sequence(:name) { |n| "Job template #{n}" }
     sequence(:job_category) { |n| "job name #{n}" }
-    f.template 'id'
-    f.provider_type 'SSH'
+    template 'id'
+    provider_type 'SSH'
     organizations { [Organization.find_by(name: 'Organization 1')] } if SETTINGS[:organizations_enabled]
     locations { [Location.find_by(name: 'Location 1')] } if SETTINGS[:locations_enabled]
-
 
     trait :with_input do
       after(:build) do |template, evaluator|

--- a/test/functional/job_templates_controller_test.rb
+++ b/test/functional/job_templates_controller_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+class JobTemplatesControllerTest < ActionController::TestCase
+  context '#preview' do
+    let(:template) { FactoryBot.create(:job_template) }
+    let(:host) { FactoryBot.create(:host, :managed) }
+
+    test 'should render a preview version of a template' do
+      post :preview, params: { job_template: template.to_param, template: 'uptime' }, session: set_session_user
+      assert_response :success
+    end
+
+    test 'should render a preview version of a template for a specific host' do
+      post :preview, params: {
+        job_template: template.to_param,
+        template: '<%= @host.name %>',
+        preview_host_id: host.id
+      }, session: set_session_user
+      assert_response :success
+      assert_equal host.name, @response.body
+    end
+
+    test 'should render a error message when template has errors' do
+      InputTemplateRenderer.any_instance.stubs(:render).returns(false)
+      post :preview, params: { job_template: template.to_param }, session: set_session_user
+      assert_response :not_acceptable
+    end
+  end
+end


### PR DESCRIPTION
This should fix

```
Warning! Template is missing Missing template job_templates/preview, templates/preview, application/preview with {:locale=>[:en], :formats=>[:html, :text, :js, :css, :ics, :csv, :vcf, :png, :jpeg, :gif, :bmp, :tiff, :svg, :mpeg, :xml, :rss, :atom, :yaml, :multipart_form, :url_encoded_form, :json, :pdf, :zip, :gzip], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :rabl]}. Searched in: * "/home/inecas/Projects/ws/foreman-rex/foreman-rails5/app/views" * "/home/inecas/Projects/ws/foreman-rex/foreman_ansible/app/views" * "/home/inecas/Projects/ws/foreman-rex/foreman_remote_execution/app/views" * "/home/inecas/Projects/ws/foreman-rex/foreman-tasks/app/views" * "/home/inecas/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/apipie-rails-0.5.9/app/views"
```

when there is an error during the template rendering.

Extracted from #363.

cc: @iNecas 