### PR TITLE
Fixes #24866 - Backport template renderer caching for 1.5-stable

### DIFF
--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -49,6 +49,8 @@ module Actions
         job_invocation.password = job_invocation.key_passphrase = job_invocation.sudo_password = nil
         job_invocation.save!
 
+        Rails.logger.debug "cleaning cache for keys that begin with 'job_invocation_#{job_invocation.id}'"
+        Rails.cache.delete_matched(/\A#{JobInvocation::CACHE_PREFIX}_#{job_invocation.id}/)
         # creating the success notification should be the very last thing this tasks do
         job_invocation.build_notification.deliver!
       end

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -1,4 +1,6 @@
 class JobInvocation < ApplicationRecord
+  CACHE_PREFIX = "job_invocation".freeze
+
   audited :except => [:task_id, :targeting_id, :task_group_id, :triggering_id]
 
   include Authorizable

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -39,6 +39,36 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
           renderer.error_message.wont_be_empty
         end
       end
+
+      describe 'caching helper' do
+        it 'caches the value under given key in real mode' do
+          renderer.stubs(:invocation => OpenStruct.new(:job_invocation_id => 1))
+
+          i = 1
+          result = renderer.cached('some_key') { i }
+          result.must_equal 1
+          i += 1
+          result = renderer.cached('some_key') { i }
+          result.must_equal 1
+          i += 1
+          result = renderer.cached('different_key') { i }
+          result.must_equal 3
+        end
+
+        it 'does not cache the value in preview mode' do
+          renderer.stubs(:invocation => OpenStruct.new(:job_invocation_id => 1), :preview? => true)
+
+          i = 1
+          result = renderer.cached('some_key') { i }
+          result.must_equal 1
+          i += 1
+          result = renderer.cached('some_key') { i }
+          result.must_equal 2
+          i += 1
+          result = renderer.cached('different_key') { i }
+          result.must_equal 3
+        end
+      end
     end
 
     context 'with matching input defined' do


### PR DESCRIPTION
This is a backport of https://github.com/theforeman/foreman_remote_execution/pull/374. Because 1.5-stable doesn't have the updated template renderer code, we can't just cherry-pick the 1.6 commit.