### PR TITLE
Fixes #24930 - Make output fail with 404 when job is missing

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -4,7 +4,7 @@ module Api
       include ::Api::Version2
       include ::Foreman::Renderer
 
-      before_action :find_required_nested_object, :only => %w{output}
+      before_action :find_optional_nested_object, :only => %w{output}
       before_action :find_host, :only => %w{output}
       before_action :find_resource, :only => %w{show update destroy clone cancel rerun}
 
@@ -122,6 +122,10 @@ module Api
       end
 
       private
+
+      def allowed_nested_id
+        %w(job_invocation_id)
+      end
 
       def action_permission
         case params[:action]

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -4,7 +4,7 @@ module Api
       include ::Api::Version2
       include ::Foreman::Renderer
 
-      before_action :find_optional_nested_object
+      before_action :find_required_nested_object, :only => %w{output}
       before_action :find_host, :only => %w{output}
       before_action :find_resource, :only => %w{show update destroy clone cancel rerun}
 

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -126,6 +126,8 @@ module Api
         invocation_id = @invocation.id + 1
         assert_empty JobInvocation.where(:id => invocation_id)
         get :output, params: { :job_invocation_id => invocation_id, :host_id => 1234 }
+        result = ActiveSupport::JSON.decode(@response.body)
+        assert_equal result['message'], "Job invocation not found by id '#{invocation_id}'"
         assert_response :missing
       end
 

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -122,6 +122,13 @@ module Api
         assert_response :success
       end
 
+      test 'should fail with 404 for non-existing job invocation' do
+        invocation_id = @invocation.id + 1
+        assert_empty JobInvocation.where(:id => invocation_id)
+        get :output, params: { :job_invocation_id => invocation_id, :host_id => 1234 }
+        assert_response :missing
+      end
+
       test 'should cancel a job' do
         @invocation.task.expects(:cancellable?).returns(true)
         @invocation.task.expects(:cancel).returns(true)


### PR DESCRIPTION
Before this commit we failed with 500: Internal Server Error