### PR TITLE
Fixes #22750 - Rerun failed should rerun also on cancelled hosts

### DIFF
--- a/app/helpers/job_invocations_helper.rb
+++ b/app/helpers/job_invocations_helper.rb
@@ -12,35 +12,6 @@ module JobInvocationsHelper
     end
   end
 
-  def job_invocation_task_buttons(task)
-    job_invocation = task.task_groups.find { |group| group.class == JobInvocationTaskGroup }.job_invocation
-    buttons = []
-    if authorized_for(hash_for_new_job_invocation_path)
-      buttons << link_to(_('Rerun'), rerun_job_invocation_path(:id => job_invocation.id),
-                         :class => 'btn btn-default',
-                         :title => _('Rerun the job'))
-    end
-    if authorized_for(hash_for_new_job_invocation_path)
-      buttons << link_to(_('Rerun failed'), rerun_job_invocation_path(:id => job_invocation.id, :failed_only => 1),
-                         :class => 'btn btn-default',
-                         :disabled => task.sub_tasks.none? { |sub_task| task_failed?(sub_task) },
-                         :title => _('Rerun on failed hosts'))
-    end
-    if authorized_for(:permission => :view_foreman_tasks, :auth_object => task)
-      buttons << link_to(_('Job Task'), foreman_tasks_task_path(task),
-                         :class => 'btn btn-default',
-                         :title => _('See the last task details'))
-    end
-    if authorized_for(:permission => :edit_foreman_tasks, :auth_object => task)
-      buttons << link_to(_('Cancel Job'), cancel_foreman_tasks_task_path(task),
-                         :class => 'btn btn-danger',
-                         :title => _('Try to cancel the job'),
-                         :disabled => !task.cancellable?,
-                         :method => :post)
-    end
-    buttons
-  end
-
   def job_invocations_buttons
     [
       documentation_button_rex('3.2ExecutingaJob'),

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -78,7 +78,7 @@ module RemoteExecutionHelper
     if authorized_for(hash_for_new_job_invocation_path)
       buttons << link_to(_('Rerun failed'), rerun_job_invocation_path(:id => job_invocation.id, :failed_only => 1),
                          :class => 'btn btn-default',
-                         :disabled => !job_invocation.failed_hosts.any?,
+                         :disabled => job_invocation.failed_hosts.none?,
                          :title => _('Rerun on failed hosts'))
     end
     if authorized_for(:permission => :view_foreman_tasks, :auth_object => task, :authorizer => task_authorizer)

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -78,7 +78,7 @@ module RemoteExecutionHelper
     if authorized_for(hash_for_new_job_invocation_path)
       buttons << link_to(_('Rerun failed'), rerun_job_invocation_path(:id => job_invocation.id, :failed_only => 1),
                          :class => 'btn btn-default',
-                         :disabled => task.sub_tasks.where(:result => %w(error warning)).count.zero?,
+                         :disabled => !job_invocation.failed_hosts.any?,
                          :title => _('Rerun on failed hosts'))
     end
     if authorized_for(:permission => :view_foreman_tasks, :auth_object => task, :authorizer => task_authorizer)

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -58,6 +58,12 @@ FactoryBot.define do
         invocation.task = FactoryBot.build(:some_task)
       end
     end
+
+    trait :with_unplanned_host do
+      after(:build) do |invocation, _evaluator|
+        invocation.targeting.hosts << FactoryBot.build(:host)
+      end
+    end
   end
 
   factory :remote_execution_provider do |f|

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -193,6 +193,7 @@ module Api
       test 'should rerun failed only' do
         @invocation = FactoryBot.create(:job_invocation, :with_template, :with_failed_task)
         @invocation.job_category = @invocation.pattern_template_invocations.first.template.job_category
+        @invocation.targeting.hosts = @invocation.template_invocations.map(&:host)
         @invocation.save!
         JobInvocation.any_instance.expects(:generate_description)
         JobInvocationComposer.any_instance


### PR DESCRIPTION
If a job is still running the behavior stays the same as it was. However if the
job is finished, rerunning the job will execute it also on hosts which were not
even planned and therefore don't have a template invocation.