### PR TITLE
Fixes #22209 - Render empty lines properly in output

### DIFF
--- a/app/assets/stylesheets/foreman_remote_execution/template_invocation.css.scss
+++ b/app/assets/stylesheets/foreman_remote_execution/template_invocation.css.scss
@@ -44,6 +44,7 @@ div.terminal {
   div.line div.content {
     position: relative;
     margin-left: 50px;
+    white-space: pre;
   }
 
   a {

--- a/app/helpers/job_invocation_output_helper.rb
+++ b/app/helpers/job_invocation_output_helper.rb
@@ -1,5 +1,5 @@
 module JobInvocationOutputHelper
-  COLOR_PATTERN = /\e\[.*?m/.freeze
+  COLOR_PATTERN = /\e\[.*?m/
   CONSOLE_COLOR = {
     '31' => 'red',
     '32' => 'lightgreen',

--- a/app/helpers/job_invocation_output_helper.rb
+++ b/app/helpers/job_invocation_output_helper.rb
@@ -1,4 +1,5 @@
 module JobInvocationOutputHelper
+  COLOR_PATTERN = /\e\[.*?m/.freeze
   CONSOLE_COLOR = {
     '31' => 'red',
     '32' => 'lightgreen',
@@ -17,13 +18,13 @@ module JobInvocationOutputHelper
   }.tap { |h| h.default = 'default' }.freeze
 
   def colorize_line(line)
-    line = line.gsub(/\e\[.*?m/) do |seq|
+    line = line.gsub(COLOR_PATTERN) do |seq|
       color = seq[/(\d+)m/,1]
       "{{{format color:#{color}}}}"
     end
 
     current_color = 'default'
-    out = %{<span style="color: #{@current_color}">}
+    out = %{<span style="color: #{current_color}">}
     parts = line.split(/({{{format.*?}}})/)
     parts.each do |console_line|
       if console_line.include?('{{{format')

--- a/app/helpers/job_invocation_output_helper.rb
+++ b/app/helpers/job_invocation_output_helper.rb
@@ -23,14 +23,14 @@ module JobInvocationOutputHelper
       "{{{format color:#{color}}}}"
     end
 
-    current_color = 'default'
-    out = %{<span style="color: #{current_color}">}
+    @current_color ||= 'default'
+    out = %{<span style="color: #{@current_color}">}
     parts = line.split(/({{{format.*?}}})/)
     parts.each do |console_line|
       if console_line.include?('{{{format')
         if (color_index = console_line[/color:(\d+)/, 1]).present?
-          current_color = CONSOLE_COLOR[color_index]
-          out << %{</span><span style="color: #{current_color}">}
+          @current_color = CONSOLE_COLOR[color_index]
+          out << %{</span><span style="color: #{@current_color}">}
         end
       else
         out << h(console_line)

--- a/app/views/template_invocations/_output_line_set.html.erb
+++ b/app/views/template_invocations/_output_line_set.html.erb
@@ -1,4 +1,4 @@
-<% output_line_set['output'].strip.split("\n").each do |line| %>
+<% output_line_set['output'].gsub("\r\n", "\n").split("\n", -1).each do |line| %>
   <%= content_tag :div, :class => 'line ' + output_line_set['output_type'], :data => { :timestamp => output_line_set['timestamp'] } do %>
 
     <%= content_tag(:span, (@line_counter += 1).to_s.rjust(4).gsub(' ', '&nbsp;').html_safe + ':', :class => 'counter', :title => (output_line_set['timestamp'] && Time.at(output_line_set['timestamp']))) %>

--- a/app/views/template_invocations/_output_line_set.html.erb
+++ b/app/views/template_invocations/_output_line_set.html.erb
@@ -2,6 +2,6 @@
   <%= content_tag :div, :class => 'line ' + output_line_set['output_type'], :data => { :timestamp => output_line_set['timestamp'] } do %>
 
     <%= content_tag(:span, (@line_counter += 1).to_s.rjust(4).gsub(' ', '&nbsp;').html_safe + ':', :class => 'counter', :title => (output_line_set['timestamp'] && Time.at(output_line_set['timestamp']))) %>
-    <%= content_tag(:div, (line.empty? ? '&nbsp;' : colorize_line(line)).html_safe, :class => 'content') %>
+    <%= content_tag(:div, (line.gsub(JobInvocationOutputHelper::COLOR_PATTERN, '').empty? ? '&nbsp;' : colorize_line(line)).html_safe, :class => 'content') %>
   <% end %>
 <% end %>

--- a/app/views/template_invocations/_output_line_set.html.erb
+++ b/app/views/template_invocations/_output_line_set.html.erb
@@ -2,6 +2,6 @@
   <%= content_tag :div, :class => 'line ' + output_line_set['output_type'], :data => { :timestamp => output_line_set['timestamp'] } do %>
 
     <%= content_tag(:span, (@line_counter += 1).to_s.rjust(4).gsub(' ', '&nbsp;').html_safe + ':', :class => 'counter', :title => (output_line_set['timestamp'] && Time.at(output_line_set['timestamp']))) %>
-    <%= content_tag(:div, (line.gsub(JobInvocationOutputHelper::COLOR_PATTERN, '').empty? ? '&nbsp;' : colorize_line(line)).html_safe, :class => 'content') %>
+    <%= content_tag(:div, colorize_line(line.gsub(JobInvocationOutputHelper::COLOR_PATTERN, '').empty? ? "#{line}\n" : line).html_safe, :class => 'content') %>
   <% end %>
 <% end %>


### PR DESCRIPTION
For some reason the output uses CRLF to mark a newline, writing CRs into
the terminal window led to line numbers not matching the lines. Also we
were splitting the output on newlines and trailing empty fields were
omitted.

To reproduce run the following
```shell
printf "\none\n"
printf "\ntwo\n"
printf "\nthree\n"
```