### PR TITLE
Fixes #24136 - Add SSH pubkey to output of smart proxy API calls

### DIFF
--- a/app/views/api/v2/smart_proxies/pubkey.json.rabl
+++ b/app/views/api/v2/smart_proxies/pubkey.json.rabl
@@ -1,0 +1,1 @@
+attribute :pubkey

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -119,6 +119,8 @@ module ForemanRemoteExecution
         parameter_filter Nic::Interface do |ctx|
           ctx.permit :execution
         end
+
+        extend_rabl_template 'api/v2/smart_proxies/main', 'api/v2/smart_proxies/pubkey'
       end
     end
 


### PR DESCRIPTION
```shell
$ curl -u $CREDENTIALS http://localhost:3000/api/v2/smart_proxies  | json_pp    
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   827    0   827    0     0   6891      0 --:--:-- --:--:-- --:--:--  6891
{
   "sort" : {
      "order" : null,
      "by" : null
   },
   "subtotal" : 1,
   "search" : null,
   "per_page" : 20,
   "page" : 1,
   "results" : [
      {
         "created_at" : "2018-04-05 08:25:49 UTC",
         "name" : "localhost",
         "updated_at" : "2018-04-05 08:31:24 UTC",
         "pubkey" : "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGLI9uVOxZ2j6JOiQ+a8dg3NILN2NM7VLagRFPsOydfMruVnvIVCCx3ZapawOQf4qav6/nyPGeFSZClK3x5N7DqpXYDrOl7YJs3rnVvdCSh4zpenZqaLg2blcB5D5hpaw8b0jvCasRyWNb2Yz/0NkAzKJCUHN0lEJQrsZ/tF3JybqwcH6J4d808SckabhwWLcteFfSWIP4eGmjeDt/2vh7XZXBMdXrraQouQg7YSiKr9U5HeZVC2Ay6aaxwz9+CS/C7papUMcbFcz526wXso1T7vDQFi4m76N+T+jRGdVpot4AQrNjD8CMISDAet6uDeYW/ZES8OfutEOdu1Wl11CT aruzicka@dhcp131-51.brq.redhat.com",
         "id" : 3,
         "url" : "http://localhost:8000",
         "features" : [
            {
               "id" : 10,
               "name" : "Logs"
            },
            {
               "name" : "Dynflow",
               "id" : 11
            },
            {
               "id" : 12,
               "name" : "SSH"
            },
            {
               "id" : 13,
               "name" : "Ansible"
            }
         ]
      }
   ],
   "total" : 1
}
```

If the cached information needs to be updated, `PUT` request to `api/v2/smart_proxies/refresh` should do the trick.