### PR TITLE
Fixes #22510 - Make inputs with options really optional

### DIFF
--- a/app/models/template_invocation_input_value.rb
+++ b/app/models/template_invocation_input_value.rb
@@ -5,6 +5,17 @@ class TemplateInvocationInputValue < ApplicationRecord
 
   validates :value, :presence => true, :if => proc { |v| v.template_input.required? || v.value.nil? }
 
-  validates :value, :inclusion => { :in => proc { |v| v.template_input.options_array } },
+  validates :value, :inclusion => { :in => proc { |v| options_for_template_input v.template_input } },
                     :if => proc { |v| v.template_input.input_type == 'user' && v.template_input.options_array.present? }
+
+  class << self
+
+    private
+
+    def options_for_template_input(template_input)
+      options = template_input.options_array
+      options += [''] unless template_input.required?
+      options
+    end
+  end
 end


### PR DESCRIPTION
Before this patch even if an input was not marked as required, the
validations wouldn't let the user execute a job where a value for this
job was not provided.