### PR TITLE
Add /remote_execution/ssh_params API

### DIFF
--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -28,6 +28,11 @@ module Api
         process_response @remote_execution_feature.update_attributes(remote_execution_feature_params)
       end
 
+      api :GET, '/remote_execution/ssh_params', N_('Get default parameters for SSH to a host')
+      def ssh_params
+        render :json => SSHExecutionProvider.ssh_params(Host.find_by(name: params[:host_id]))
+      end
+
       private
 
       def parent_scope

--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -30,7 +30,12 @@ module Api
 
       api :GET, '/remote_execution/ssh_params', N_('Get default parameters for SSH to a host')
       def ssh_params
-        render :json => SSHExecutionProvider.ssh_params(Host.find_by(name: params[:host_id]))
+        host = Host.find_by(name: params[:host_id]) || Host.find_by(id: params[:host_id])
+        if host
+          render :json => SSHExecutionProvider.ssh_params(host)
+        else
+          raise ActionController::RoutingError.new('Host not found')
+        end
       end
 
       private

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -25,6 +25,20 @@ class SSHExecutionProvider < RemoteExecutionProvider
       host_setting(host, :remote_execution_ssh_key_passphrase)
     end
 
+    def ssh_params(host)
+      proxy_selector = ::RemoteExecutionProxySelector.new
+      proxy = proxy_selector.determine_proxy(host, 'SSH')
+      {
+        :hostname => find_ip_or_hostname(host),
+        :proxy => proxy && proxy.url,
+        :ssh_user => ssh_user(host),
+        :ssh_port => ssh_port(host),
+        :ssh_password => ssh_password(host),
+        :ssh_key_passphrase => ssh_key_passphrase(host),
+        :ssh_key_file => File.expand_path(ForemanRemoteExecutionCore.settings.fetch(:ssh_identity_key_file))
+      }
+    end
+
     private
 
     def ssh_user(host)

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -30,7 +30,7 @@ class SSHExecutionProvider < RemoteExecutionProvider
       proxy = proxy_selector.determine_proxy(host, 'SSH')
       {
         :hostname => find_ip_or_hostname(host),
-        :proxy => proxy && proxy.url,
+        :proxy => proxy.class == Symbol ? proxy : proxy.url,
         :ssh_user => ssh_user(host),
         :ssh_port => ssh_port(host),
         :ssh_password => ssh_password(host),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,9 @@ Rails.application.routes.draw do
       end
 
       resources :remote_execution_features, :only => [:show, :index, :update]
+
+      get 'remote_execution/ssh_params', to: 'remote_execution_features#ssh_params'
+
     end
   end
 end


### PR DESCRIPTION
This API would be used by the Foreman/Cockpit integration described here: https://community.theforeman.org/t/seamless-cockpit-and-foreman/9846/23

What do you think?
