### PR TITLE
Fixes #25534 - Seamless cockpit integration

### DIFF
--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -28,6 +28,23 @@ module Api
         process_response @remote_execution_feature.update_attributes(remote_execution_feature_params)
       end
 
+      def cockpit_url_for_host(host)
+        tmpl = Setting[:remote_execution_cockpit_href]
+        tmpl && tmpl != "" ? tmpl % { :host => host } : nil
+      end
+
+      def cockpit_redirect
+        return head(:forbidden) unless params[:redirect_uri]
+        redir_url = URI.parse(params[:redirect_uri])
+        cockpit_url = cockpit_url_for_host("")
+        redir_url.query = if redir_url.hostname == URI.join(Setting[:foreman_url], cockpit_url).hostname
+                            "access_token=#{request.session_options[:id]}"
+                          else
+                            "error_description=Sorry"
+                          end
+        redirect_to(redir_url.to_s)
+      end
+
       private
 
       def parent_scope

--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -28,23 +28,6 @@ module Api
         process_response @remote_execution_feature.update_attributes(remote_execution_feature_params)
       end
 
-      def cockpit_url_for_host(host)
-        tmpl = Setting[:remote_execution_cockpit_href]
-        tmpl && tmpl != "" ? tmpl % { :host => host } : nil
-      end
-
-      def cockpit_redirect
-        return head(:forbidden) unless params[:redirect_uri]
-        redir_url = URI.parse(params[:redirect_uri])
-        cockpit_url = cockpit_url_for_host("")
-        redir_url.query = if redir_url.hostname == URI.join(Setting[:foreman_url], cockpit_url).hostname
-                            "access_token=#{request.session_options[:id]}"
-                          else
-                            "error_description=Sorry"
-                          end
-        redirect_to(redir_url.to_s)
-      end
-
       private
 
       def parent_scope

--- a/app/controllers/cockpit_controller.rb
+++ b/app/controllers/cockpit_controller.rb
@@ -1,0 +1,34 @@
+class CockpitController < ApplicationController
+  before_action :find_resource, :only => [:host_ssh_params]
+
+  def host_ssh_params
+    render :json => SSHExecutionProvider.ssh_params(@host)
+  end
+
+  def redirect
+    return invalid_request unless params[:redirect_uri]
+    redir_url = URI.parse(params[:redirect_uri])
+
+    cockpit_url = SSHExecutionProvider.cockpit_url_for_host('')
+    redir_url.query = if redir_url.hostname == URI.join(Setting[:foreman_url], cockpit_url).hostname
+                        "access_token=#{request.session_options[:id]}"
+                      else
+                        "error_description=Sorry"
+                      end
+    redirect_to(redir_url.to_s)
+  end
+
+  private
+
+  def resource_name
+    "host"
+  end
+
+  def controller_permission
+    :hosts
+  end
+
+  def action_permission
+    :cockpit
+  end
+end

--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -20,13 +20,9 @@ module ForemanRemoteExecution
       link_to(_('Schedule Remote Job'), new_job_invocation_path(:host_ids => [args.first.id]), :id => :run_button, :class => 'btn btn-default')
     end
 
-    def cockpit_url_for_host(host)
-      tmpl = Setting[:remote_execution_cockpit_href]
-      tmpl && tmpl != "" ? tmpl % { :host => host } : nil
-    end
-
-    def web_console_button(*args)
-      url = cockpit_url_for_host(args.first.name)
+    def web_console_button(host, *args)
+      return unless authorized_for(permission: 'cockpit_hosts', auth_object: host)
+      url = SSHExecutionProvider.cockpit_url_for_host(host.name)
       url ? link_to(_('Web Console'), url, :class => 'btn btn-default') : nil
     end
 

--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -20,9 +20,21 @@ module ForemanRemoteExecution
       link_to(_('Schedule Remote Job'), new_job_invocation_path(:host_ids => [args.first.id]), :id => :run_button, :class => 'btn btn-default')
     end
 
+    def cockpit_url_for_host(host)
+      tmpl = Setting[:remote_execution_cockpit_href]
+      tmpl && tmpl != "" ? tmpl % { :host => host } : nil
+    end
+
+    def web_console_button(*args)
+      url = cockpit_url_for_host(args.first.name)
+      url ? link_to(_('Web Console'), url, :class => 'btn btn-default') : nil
+    end
+
     def host_title_actions(*args)
-      title_actions(button_group(schedule_job_multi_button(*args)))
+      title_actions(button_group(schedule_job_multi_button(*args)),
+                    button_group(web_console_button(*args)))
       super(*args)
     end
   end
+
 end

--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -1,6 +1,6 @@
 class Setting::RemoteExecution < Setting
 
-  ::Setting::BLANK_ATTRS.concat %w{remote_execution_ssh_password remote_execution_ssh_key_passphrase remote_execution_sudo_password remote_execution_cockpit_href}
+  ::Setting::BLANK_ATTRS.concat %w{remote_execution_ssh_password remote_execution_ssh_key_passphrase remote_execution_sudo_password remote_execution_cockpit_url}
 
   # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
   def self.load_defaults
@@ -68,7 +68,7 @@ class Setting::RemoteExecution < Setting
                  N_('When enabled, working directories will be removed after task completion. You may override this per host by setting a parameter called remote_execution_cleanup_working_dirs.'),
                  true,
                  N_('Cleanup working directories')),
-        self.set('remote_execution_cockpit_href',
+        self.set('remote_execution_cockpit_url',
                  N_('Where to find the Cockpit instance for the Web Console button.  By default, no button is shown.'),
                  nil,
                  N_('Cockpit URL'),

--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -1,6 +1,6 @@
 class Setting::RemoteExecution < Setting
 
-  ::Setting::BLANK_ATTRS.concat %w{remote_execution_ssh_password remote_execution_ssh_key_passphrase remote_execution_sudo_password}
+  ::Setting::BLANK_ATTRS.concat %w{remote_execution_ssh_password remote_execution_ssh_key_passphrase remote_execution_sudo_password remote_execution_cockpit_href}
 
   # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
   def self.load_defaults
@@ -67,7 +67,12 @@ class Setting::RemoteExecution < Setting
         self.set('remote_execution_cleanup_working_dirs',
                  N_('When enabled, working directories will be removed after task completion. You may override this per host by setting a parameter called remote_execution_cleanup_working_dirs.'),
                  true,
-                 N_('Cleanup working directories'))
+                 N_('Cleanup working directories')),
+        self.set('remote_execution_cockpit_href',
+                 N_('Where to find the Cockpit instance for the Web Console button.  By default, no button is shown.'),
+                 nil,
+                 N_('Cockpit URL'),
+                 nil)
       ].each { |s| self.create! s.update(:category => 'Setting::RemoteExecution') }
     end
 

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -38,9 +38,12 @@ class SSHExecutionProvider < RemoteExecutionProvider
         :ssh_user => ssh_user(host),
         :ssh_port => ssh_port(host),
         :ssh_password => ssh_password(host),
-        :ssh_key_passphrase => ssh_key_passphrase(host),
-        :ssh_key_file => File.expand_path(ForemanRemoteExecutionCore.settings.fetch(:ssh_identity_key_file))
+        :ssh_key_passphrase => ssh_key_passphrase(host)
       }
+    end
+
+    def cockpit_url_for_host(host)
+      Setting[:remote_execution_cockpit_url] % { :host => host } if Setting[:remote_execution_cockpit_url].present?
     end
 
     private

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -29,6 +29,20 @@ class SSHExecutionProvider < RemoteExecutionProvider
       'ssh'
     end
 
+    def ssh_params(host)
+      proxy_selector = ::RemoteExecutionProxySelector.new
+      proxy = proxy_selector.determine_proxy(host, 'SSH')
+      {
+        :hostname => find_ip_or_hostname(host),
+        :proxy => proxy.class == Symbol ? proxy : proxy.url,
+        :ssh_user => ssh_user(host),
+        :ssh_port => ssh_port(host),
+        :ssh_password => ssh_password(host),
+        :ssh_key_passphrase => ssh_key_passphrase(host),
+        :ssh_key_file => File.expand_path(ForemanRemoteExecutionCore.settings.fetch(:ssh_identity_key_file))
+      }
+    end
+
     private
 
     def ssh_user(host)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,11 @@ Rails.application.routes.draw do
     end
   end
 
+  constraints(:id => %r{[^/]+}) do
+    get 'cockpit/host_ssh_params/:id', to: 'cockpit#host_ssh_params'
+  end
+  get 'cockpit/redirect', to: 'cockpit#redirect'
+
   namespace :api, :defaults => {:format => 'json'} do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       resources :job_invocations, :except => [:new, :edit, :update, :destroy] do
@@ -80,9 +85,6 @@ Rails.application.routes.draw do
       end
 
       resources :remote_execution_features, :only => [:show, :index, :update]
-
-      get 'cockpit_redirect', to: 'remote_execution_features#cockpit_redirect'
-
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,9 @@ Rails.application.routes.draw do
       end
 
       resources :remote_execution_features, :only => [:show, :index, :update]
+
+      get 'cockpit_redirect', to: 'remote_execution_features#cockpit_redirect'
+
     end
   end
 end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -66,6 +66,7 @@ module ForemanRemoteExecution
           # this permissions grants user to get auto completion hints when setting up filters
           permission :filter_autocompletion_for_template_invocation, { :template_invocations => [ :auto_complete_search, :index ] },
                      :resource_type => 'TemplateInvocation'
+          permission :cockpit_hosts, { 'cockpit' => [:redirect, :host_ssh_params] }, :resource_type => 'Host'
         end
 
         USER_PERMISSIONS = [

--- a/test/functional/cockpit_controller_test.rb
+++ b/test/functional/cockpit_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_plugin_helper'
+
+class CockpitControllerTest < ActionController::TestCase
+  def setup
+    Setting::RemoteExecution.load_defaults
+    as_admin do
+      @host = FactoryBot.create(:host)
+    end
+  end
+
+  test "should get host_ssh_params" do
+    get :host_ssh_params, params: { id: @host.id }, session: set_session_user
+    assert_response :success
+    response = ActiveSupport::JSON.decode(@response.body)
+    assert response.key?('ssh_user'), 'ssh_params response must include ssh_user'
+  end
+end


### PR DESCRIPTION
This adds a "Web Console" button next to the "Schedule Remote Job"
button in the title row of a host page.
    
The button links to a specially configured Cockpit instance.  It's
location is configured with the new remote_execution_cockpit_href
setting.
    
The Cockpit instance will use the new /cockpit_redirect path to get a
token via OAuth style redirection.