### PR TITLE
Fixes #26428 - exposed $CONTROL_SCRIPT and manual-mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ AllCops:
 
 Rails:
   Enabled: true
+  Exclude:
+    - 'lib/foreman_remote_execution_core/**'
 
 Rails/Date:
   Enabled: false

--- a/lib/foreman_remote_execution_core/async_scripts/control.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/control.sh
@@ -1,0 +1,143 @@
+#!/bin/sh
+#
+# Control script for the remote execution jobs.
+#
+# The initial script calls `$CONTROL_SCRIPT init-script-finish` once the original script exits.
+# In automatic mode, the exit code is sent back to the proxy on `init-script-finish`.
+#
+# What the script provides is also a manual mode, where the author of the rex script can take
+# full control of the job lifecycle. This allows keeping the marked as running even when
+# the initial script finishes.
+#
+# The manual mode is turned on by calling `$CONTROL_SCRIPT manual-control`. After calling this,
+# one can call `echo message | $CONTROL_SCRIPT update` to send output to the remote execution jobs
+# and `$CONTROL_SCRIPT finish 0` once finished (with 0 as exit code) to send output to the remote execution jobs
+# and `$CONTROL_SCRIPT finish 0` once finished (with 0 as exit code)
+BASE_DIR="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))"
+
+# load the data required for generating the callback
+source $BASE_DIR/env.sh
+
+if ! which curl >/dev/null; then
+    echo 'curl is required' >&2
+    exit 1
+fi
+
+URL_PREFIX="$CALLBACK_HOST/dynflow/tasks/$TASK_ID"
+AUTH="$TASK_ID:$OTP"
+CURL="curl --silent --show-error"
+
+# prepare the callback payload
+function payload() {
+    if [ -e "$BASE_DIR/exit_code" ]; then
+        exit_code="\"$(cat "$BASE_DIR/exit_code")\""
+    else
+        exit_code=null
+    fi
+
+    if [ -e "$BASE_DIR/manual_mode" ]; then
+        manual_mode=true
+        output=$($BASE_DIR/retrieve.sh | base64 -w0)
+    else
+        manual_mode=false
+    fi
+
+    echo "{ \"step_id\": \"$STEP_ID\","\
+         "  \"manual_mode\": $manual_mode,"\
+         "  \"exit_code\": $exit_code,"\
+         "  \"output\": \"$output\" }"
+}
+
+# send the callback data to proxy
+function update() {
+    $CURL -X POST -d "$(payload)" -u "$AUTH" "$URL_PREFIX"/update
+}
+
+# wait for named pipe $1 to retrieve data. If $2 is provided, it serves as timeout
+# in seconds on how long to wait when reading.
+function wait_for_pipe() {
+    pipe_path=$1
+    if [ -n "$2" ]; then
+        timeout="-t $2"
+    fi
+    if read $timeout <>$pipe_path; then
+        rm $pipe_path
+        return 0
+    else
+        return 1
+    fi
+}
+
+# function run in background, when receiving update data via STDIN.
+function periodic_update() {
+    interval=1
+    # reading some data from periodic_update_control signals we're done
+    while ! wait_for_pipe $BASE_DIR/periodic_update_control 1; do
+        update
+    done
+    # one more update before we finish
+    update
+    # signal the main process that we are finished
+    echo > $BASE_DIR/periodic_update_finished
+}
+
+# signal the periodic_update process that the main process is finishing
+function periodic_update_finish() {
+    if [ -e $BASE_DIR/periodic_update_control ]; then
+       echo > $BASE_DIR/periodic_update_control
+    fi
+}
+
+function finish() {
+    echo finish
+    $CURL -X POST -d "$(payload)" -u "$AUTH" "$URL_PREFIX"/done
+}
+
+ACTION=${1:-finish}
+
+case "$ACTION" in
+    init-script-finish)
+        if ! [ -e $BASE_DIR/manual_mode ]; then
+            # make the exit code of initialization script the exit code of the whole job
+            cp init_exit_code exit_code
+            finish
+        fi
+        ;;
+    finish)
+        # take exit code passed via the command line, with fallback
+        # to the exit code of the initialization script
+        exit_code=${2:-$(cat $BASE_DIR/init_exit_code)}
+        echo $exit_code > $BASE_DIR/exit_code
+        finish
+        if [ -e $BASE_DIR/manual_mode ]; then
+            rm $BASE_DIR/manual_mode
+        fi
+        ;;
+    update)
+        # read data from input when redirected though a pipe
+        if ! [ -t 0 ]; then
+            # couple of named pipes to coordinate the main process with the periodic_update
+            mkfifo $BASE_DIR/periodic_update_control
+            mkfifo $BASE_DIR/periodic_update_finished
+            trap "periodic_update_finish" EXIT
+            # run periodic update as separate process to keep sending updates in output to server
+            periodic_update &
+            # redirect the input into output
+            cat | tee -a $BASE_DIR/output
+            periodic_update_finish
+            # ensure the periodic update finished before we return
+            wait_for_pipe $BASE_DIR/periodic_update_finished
+        else
+            update
+        fi
+        ;;
+    # mark the script to be in manual mode: this means the script author needs to use `update` and `finish`
+    # commands to send output to the remote execution job or mark it as finished.
+    manual-mode)
+        touch $BASE_DIR/manual_mode
+        ;;
+    *)
+        echo "Unknown action $ACTION"
+        exit 1
+        ;;
+esac

--- a/lib/foreman_remote_execution_core/async_scripts/control.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/control.sh
@@ -30,7 +30,7 @@ CURL="curl --silent --show-error"
 # prepare the callback payload
 payload() {
     if [ -e "$BASE_DIR/exit_code" ]; then
-        exit_code="\"$(cat "$BASE_DIR/exit_code")\""
+        exit_code="$(cat "$BASE_DIR/exit_code")"
     else
         exit_code=null
     fi

--- a/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
@@ -57,9 +57,9 @@ payload() {
         manual_mode=false
     fi
 
-    echo "{ \"step_id\": \"$STEP_ID\","\
+    echo "{ \"exit_code\": $exit_code,"\
+         "  \"step_id\": \"$STEP_ID\","\
          "  \"manual_mode\": $manual_mode,"\
-         "  \"exit_code\": $exit_code,"\
          "  \"output\": \"$output\" }"
 }
 

--- a/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
@@ -6,7 +6,7 @@ if ! pgrep --help 2>/dev/null >/dev/null; then
     exit 1
 fi
 
-BASE_DIR="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))"
+BASE_DIR="$(dirname $(readlink -f "$0"))"
 
 function release_lock() {
     rm $BASE_DIR/retrieve_lock
@@ -23,7 +23,7 @@ trap "release_lock" EXIT
 
 pid=$(cat "$BASE_DIR/pid")
 
-if [ -e $BASE_DIR/manual_mode ] || ([ -n "$PID"] && pgrep -P "$pid" >/dev/null 2>&1); then
+if [ -e $BASE_DIR/manual_mode ] || ([ -n "$pid" ] && pgrep -P "$pid" >/dev/null 2>&1); then
   echo RUNNING
 else
   echo "DONE $(cat "$BASE_DIR/exit_code" 2>/dev/null)"

--- a/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
@@ -14,15 +14,75 @@ URL_PREFIX="$CALLBACK_HOST/dynflow/tasks/$TASK_ID"
 AUTH="$TASK_ID:$OTP"
 CURL="curl --silent --show-error --fail --max-time 10"
 
+MY_LOCK_FILE="$BASE_DIR/retrieve_lock.$$"
+MY_PID=$$
+echo $MY_PID >"$MY_LOCK_FILE"
+LOCK_FILE="$BASE_DIR/retrieve_lock"
+
+RUN_TIMEOUT=30 # for how long can the script hold the lock
+WAIT_TIMEOUT=60 # for how long the script is trying to acquire the lock
+START_TIME=$(date +%s)
+
+fail() {
+    echo RUNNING
+    echo "$1"
+    exit 1
+}
+
+acquire_lock() {
+    # try to acquire lock by creating the file (ln should be atomic an fail in case
+    # another process succeeded first). We also check the content of the lock file,
+    # in case our process won when competing over the lock while invalidating
+    # the lock on timeout.
+    ln "$MY_LOCK_FILE" "$LOCK_FILE" 2>/dev/null || [ "$(head -n1 "$LOCK_FILE")" = "$MY_PID" ]
+    return $?
+}
+
 # acquiring the lock before proceeding, to ensure only one instance of the script is running
-while ! mkfifo "$BASE_DIR/retrieve_lock" 1>/dev/null 2>&1; do
+while ! acquire_lock; do
     # we failed to create retrieve_lock - assuming there is already another retrieve script running
-    # waiting until it finished before we try to acquire it
-    read -t 10 <>"$BASE_DIR/retrieve_lock"
+    current_pid=$(head -n1 "$LOCK_FILE")
+    if [ -z "$current_pid" ]; then
+        continue
+    fi
+    # check whether the lock is not too old (compared to $RUN_TIMEOUT) and try to kill
+    # if it is, so that we don't have a stalled processes here
+    lock_lines_count=$(wc -l < "$LOCK_FILE")
+    current_lock_time=$(stat --format "%Y" "$LOCK_FILE")
+    current_time=$(date +%s)
+
+    if [ "$(( current_time - START_TIME ))" -gt "$WAIT_TIMEOUT" ]; then
+        # We were waiting for the lock for too long - just give up
+        fail "Wait time exceeded $WAIT_TIMEOUT"
+    elif [ "$(( current_time - current_lock_time ))" -gt "$RUN_TIMEOUT" ]; then
+        # The previous lock it hold for too long - re-acquiring procedure
+        if [ "$lock_lines_count" -gt 1 ]; then
+           # there were multiple processes waiting for lock without resolution
+           # longer than the $RUN_TIMEOUT - we reset the lock file and let processes
+           # to compete
+           echo "RETRY" > "$LOCK_FILE"
+        fi
+        if [ "$current_pid" != "RETRY" ]; then
+            # try to kill the currently stalled process
+            kill -9 "$current_pid" 2>/dev/null
+        fi
+        # try to add our process as one candidate
+        echo $MY_PID >> "$LOCK_FILE"
+        if [ "$( head -n2 "$LOCK_FILE" | tail -n1 )" = "$MY_PID" ]; then
+            # our process won the competition for the new lock: it is the first pid
+            # after the original one in the lock file - take ownership of the lock
+            # next iteration only this process will get through
+            echo $MY_PID >"$LOCK_FILE"
+        fi
+    else
+        # still waiting for the original owner to finish
+        sleep 1
+    fi
 done
 
 release_lock() {
-    rm "$BASE_DIR/retrieve_lock"
+    rm "$MY_LOCK_FILE"
+    rm "$LOCK_FILE"
 }
 # ensure the release the lock at exit
 trap "release_lock" EXIT

--- a/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
@@ -8,9 +8,11 @@ fi
 
 BASE_DIR="$(dirname $(readlink -f "$0"))"
 
-function release_lock() {
-    rm $BASE_DIR/retrieve_lock
-}
+# load the data required for generating the callback
+. "$BASE_DIR/env.sh"
+URL_PREFIX="$CALLBACK_HOST/dynflow/tasks/$TASK_ID"
+AUTH="$TASK_ID:$OTP"
+CURL="curl --silent --show-error --fail --max-time 10"
 
 # acquiring the lock before proceeding, to ensure only one instance of the script is running
 while ! mkfifo $BASE_DIR/retrieve_lock 1>/dev/null 2>&1; do
@@ -18,21 +20,66 @@ while ! mkfifo $BASE_DIR/retrieve_lock 1>/dev/null 2>&1; do
     # waiting until it finished before we try to acquire it
     read -t 10 <>$BASE_DIR/retrieve_lock
 done
+
+release_lock() {
+    rm $BASE_DIR/retrieve_lock
+}
 # ensure the release the lock at exit
 trap "release_lock" EXIT
 
 pid=$(cat "$BASE_DIR/pid")
-
-if [ -e $BASE_DIR/manual_mode ] || ([ -n "$pid" ] && pgrep -P "$pid" >/dev/null 2>&1); then
-  echo RUNNING
-else
-  echo "DONE $(cat "$BASE_DIR/exit_code" 2>/dev/null)"
-fi
-[ -f "$BASE_DIR/output" ] || exit 0
 [ -f "$BASE_DIR/position" ] || echo 1 > "$BASE_DIR/position"
 position=$(cat "$BASE_DIR/position")
-tail --bytes "+${position}" "$BASE_DIR/output" > "$BASE_DIR/tmp"
-bytes=$(cat "$BASE_DIR/tmp" | wc --bytes)
-expr "${position}" + "${bytes}" > "$BASE_DIR/position"
-cat "$BASE_DIR/tmp"
 
+prepare_output() {
+    if [ -e $BASE_DIR/manual_mode ] || ([ -n "$pid" ] && pgrep -P "$pid" >/dev/null 2>&1); then
+        echo RUNNING
+    else
+        echo "DONE $(cat "$BASE_DIR/exit_code" 2>/dev/null)"
+    fi
+    [ -f "$BASE_DIR/output" ] || exit 0
+    tail --bytes "+${position}" "$BASE_DIR/output" > "$BASE_DIR/tmp"
+    cat "$BASE_DIR/tmp"
+}
+
+# prepare the callback payload
+payload() {
+    if [ -n "$1" ]; then
+        exit_code="$1"
+    else
+        exit_code=null
+    fi
+
+    if [ -e "$BASE_DIR/manual_mode" ]; then
+        manual_mode=true
+        output=$(prepare_output | base64 -w0)
+    else
+        manual_mode=false
+    fi
+
+    echo "{ \"step_id\": \"$STEP_ID\","\
+         "  \"manual_mode\": $manual_mode,"\
+         "  \"exit_code\": $exit_code,"\
+         "  \"output\": \"$output\" }"
+}
+
+if [ "$1" = "push_update" ]; then
+    if [ -e "$BASE_DIR/exit_code" ]; then
+        exit_code="$(cat "$BASE_DIR/exit_code")"
+        action="done"
+    else
+        exit_code=""
+        action="update"
+    fi
+    $CURL -X POST -d "$(payload $exit_code)" -u "$AUTH" "$URL_PREFIX"/$action 2>>"$BASE_DIR/curl_stderr"
+    success=$?
+else
+    prepare_output
+    success=$?
+fi
+
+if [ "$success" = 0 ]; then
+    # in case the retrieval was successful, move the position of the cursor to be read next time
+    bytes=$(wc --bytes < "$BASE_DIR/tmp")
+    expr "${position}" + "${bytes}" > "$BASE_DIR/position"
+fi

--- a/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+if ! pgrep --help 2>/dev/null >/dev/null; then
+    echo DONE 1
+    echo "pgrep is required" >&2
+    exit 1
+fi
+
+BASE_DIR="$(dirname $(readlink -f "${BASH_SOURCE[0]}"))"
+
+function release_lock() {
+    rm $BASE_DIR/retrieve_lock
+}
+
+# acquiring the lock before proceeding, to ensure only one instance of the script is running
+while ! mkfifo $BASE_DIR/retrieve_lock 1>/dev/null 2>&1; do
+    # we failed to create retrieve_lock - assuming there is already another retrieve script running
+    # waiting until it finished before we try to acquire it
+    read -t 10 <>$BASE_DIR/retrieve_lock
+done
+# ensure the release the lock at exit
+trap "release_lock" EXIT
+
+pid=$(cat "$BASE_DIR/pid")
+
+if [ -e $BASE_DIR/manual_mode ] || ([ -n "$PID"] && pgrep -P "$pid" >/dev/null 2>&1); then
+  echo RUNNING
+else
+  echo "DONE $(cat "$BASE_DIR/exit_code" 2>/dev/null)"
+fi
+[ -f "$BASE_DIR/output" ] || exit 0
+[ -f "$BASE_DIR/position" ] || echo 1 > "$BASE_DIR/position"
+position=$(cat "$BASE_DIR/position")
+tail --bytes "+${position}" "$BASE_DIR/output" > "$BASE_DIR/tmp"
+bytes=$(cat "$BASE_DIR/tmp" | wc --bytes)
+expr "${position}" + "${bytes}" > "$BASE_DIR/position"
+cat "$BASE_DIR/tmp"
+

--- a/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
+++ b/lib/foreman_remote_execution_core/async_scripts/retrieve.sh
@@ -6,7 +6,7 @@ if ! pgrep --help 2>/dev/null >/dev/null; then
     exit 1
 fi
 
-BASE_DIR="$(dirname $(readlink -f "$0"))"
+BASE_DIR="$(dirname "$(readlink -f "$0")")"
 
 # load the data required for generating the callback
 . "$BASE_DIR/env.sh"
@@ -15,14 +15,14 @@ AUTH="$TASK_ID:$OTP"
 CURL="curl --silent --show-error --fail --max-time 10"
 
 # acquiring the lock before proceeding, to ensure only one instance of the script is running
-while ! mkfifo $BASE_DIR/retrieve_lock 1>/dev/null 2>&1; do
+while ! mkfifo "$BASE_DIR/retrieve_lock" 1>/dev/null 2>&1; do
     # we failed to create retrieve_lock - assuming there is already another retrieve script running
     # waiting until it finished before we try to acquire it
-    read -t 10 <>$BASE_DIR/retrieve_lock
+    read -t 10 <>"$BASE_DIR/retrieve_lock"
 done
 
 release_lock() {
-    rm $BASE_DIR/retrieve_lock
+    rm "$BASE_DIR/retrieve_lock"
 }
 # ensure the release the lock at exit
 trap "release_lock" EXIT
@@ -32,7 +32,7 @@ pid=$(cat "$BASE_DIR/pid")
 position=$(cat "$BASE_DIR/position")
 
 prepare_output() {
-    if [ -e $BASE_DIR/manual_mode ] || ([ -n "$pid" ] && pgrep -P "$pid" >/dev/null 2>&1); then
+    if [ -e "$BASE_DIR/manual_mode" ] || ([ -n "$pid" ] && pgrep -P "$pid" >/dev/null 2>&1); then
         echo RUNNING
     else
         echo "DONE $(cat "$BASE_DIR/exit_code" 2>/dev/null)"

--- a/lib/foreman_remote_execution_core/polling_script_runner.rb
+++ b/lib/foreman_remote_execution_core/polling_script_runner.rb
@@ -1,7 +1,24 @@
+require 'base64'
+
 module ForemanRemoteExecutionCore
   class PollingScriptRunner < ScriptRunner
 
     DEFAULT_REFRESH_INTERVAL = 60
+
+    def self.load_script(name)
+      script_dir = File.expand_path('../async_scripts', __FILE__)
+      File.read(File.join(script_dir, name))
+    end
+
+    # The script that controls the flow of the job, able to initiate update or
+    # finish on the task, or take over the control over script lifecycle
+    CONTROL_SCRIPT = load_script('control.sh')
+
+    # The script always outputs at least one line
+    # First line of the output either has to begin with
+    # "RUNNING" or "DONE $EXITCODE"
+    # The following lines are treated as regular output
+    RETRIEVE_SCRIPT = load_script('retrieve.sh')
 
     def initialize(options, user_method, suspended_action: nil)
       super(options, user_method, suspended_action: suspended_action)
@@ -13,19 +30,19 @@ module ForemanRemoteExecutionCore
 
     def prepare_start
       super
-      basedir         = File.dirname @remote_script
-      @pid_path       = File.join(basedir, 'pid')
-      @retrieval_script ||= File.join(basedir, 'retrieve')
-      prepare_retrieval unless @prepared
+      @base_dir = File.dirname @remote_script
+      upload_control_scripts
     end
 
-    def control_script
+    def initialization_script
       close_stdin = '</dev/null'
       close_fds = close_stdin + ' >/dev/null 2>/dev/null'
-      # pipe the output to tee while capturing the exit code in a file, don't wait for it to finish, output PID of the main command
-      <<-SCRIPT.gsub(/^\s+\| /, '')
-      | sh -c '(#{@user_method.cli_command_prefix}#{@remote_script} #{close_stdin}; echo $?>#{@exit_code_path}) | /usr/bin/tee #{@output_path} >/dev/null; #{callback_scriptlet}' #{close_fds} &
-      | echo $! > '#{@pid_path}'
+      main_script = "(#{@remote_script} #{close_stdin} 2>&1; echo $?>#{@base_dir}/init_exit_code) >#{@base_dir}/output"
+      control_script_finish = "#{@control_script_path} init-script-finish"
+      <<-SCRIPT.gsub(/^ +\| /, '')
+      | export CONTROL_SCRIPT="#{@control_script_path}"
+      | sh -c '#{main_script}; #{control_script_finish}' #{close_fds} &
+      | echo $! > '#{@base_dir}/pid'
       SCRIPT
     end
 
@@ -35,9 +52,12 @@ module ForemanRemoteExecutionCore
 
     def refresh
       err = output = nil
-      with_retries do
+      begin
         _, output, err = run_sync("#{@user_method.cli_command_prefix} #{@retrieval_script}")
+      rescue => e
+        @logger.info("Error while connecting to the remote host on refresh: #{e.message}")
       end
+      return if output.nil? || output.empty?
       lines = output.lines
       result = lines.shift.match(/^DONE (\d+)?/)
       publish_data(lines.join, 'stdout') unless lines.empty?
@@ -45,8 +65,23 @@ module ForemanRemoteExecutionCore
       if result
         exitcode = result[1] || 0
         publish_exit_status(exitcode.to_i)
-        run_sync("rm -rf \"#{remote_command_dir}\"") if @cleanup_working_dirs
+        cleanup
       end
+    ensure
+      destroy_session
+    end
+
+    def external_event(event)
+      data = event.data
+      return no_update unless data['manual_mode']
+      continuous_output = ForemanTasksCore::ContinuousOutput.new
+      if data.key?('output')
+        lines = Base64.decode64(data['output']).sub(/\A(RUNNING|DONE).*\n/, '')
+        continuous_output.add_output(lines, 'stdout')
+      end
+      cleanup if data['exit_code']
+      new_update(continuous_output, data['exit_code'])
+    ensure
       destroy_session
     end
 
@@ -55,65 +90,29 @@ module ForemanRemoteExecutionCore
       ForemanTasksCore::OtpManager.drop_otp(@task_id, @otp) if @otp
     end
 
-    def prepare_retrieval
-      # The script always outputs at least one line
-      # First line of the output either has to begin with
-      # "RUNNING" or "DONE $EXITCODE"
-      # The following lines are treated as regular output
-      base = File.dirname(@output_path)
-      posfile = File.join(base, 'position')
-      tmpfile = File.join(base, 'tmp')
-      script = <<-SCRIPT.gsub(/^ +\| /, '')
-      | #!/bin/sh
-      | pid=$(cat "#{@pid_path}")
-      | if ! pgrep --help 2>/dev/null >/dev/null; then
-      |   echo DONE 1
-      |   echo "pgrep is required" >&2
-      |   exit 1
-      | fi
-      | if pgrep -P "$pid" >/dev/null 2>/dev/null; then
-      |   echo RUNNING
-      | else
-      |   echo "DONE $(cat "#{@exit_code_path}" 2>/dev/null)"
-      | fi
-      | [ -f "#{@output_path}" ] || exit 0
-      | [ -f "#{posfile}" ] || echo 1 > "#{posfile}"
-      | position=$(cat "#{posfile}")
-      | tail --bytes "+${position}" "#{@output_path}" > "#{tmpfile}"
-      | bytes=$(cat "#{tmpfile}" | wc --bytes)
-      | expr "${position}" + "${bytes}" > "#{posfile}"
-      | cat "#{tmpfile}"
-      SCRIPT
-      @logger.debug("copying script:\n#{script.lines.map { |line| "    | #{line}" }.join}")
-      cp_script_to_remote(script, 'retrieve')
-      @prepared = true
+    def upload_control_scripts
+      return if @control_scripts_uploaded
+      cp_script_to_remote(env_script, 'env.sh')
+      @control_script_path = cp_script_to_remote(CONTROL_SCRIPT, 'control.sh')
+      @retrieval_script = cp_script_to_remote(RETRIEVE_SCRIPT, 'retrieve.sh')
+      @control_scripts_uploaded = true
     end
 
-    def callback_scriptlet(callback_script_path = nil)
-      if @otp
-        callback_script_path = cp_script_to_remote(callback_script, 'callback') if callback_script_path.nil?
-        "#{@user_method.cli_command_prefix}#{callback_script_path}"
-      else
-        ':' # Shell synonym for "do nothing"
-      end
-    end
-
-    def callback_script
+    # Script setting the dynamic values to env variables: it's sourced from other control scripts
+    def env_script
       <<-SCRIPT.gsub(/^ +\| /, '')
-      | #!/bin/sh
-      | exit_code=$(cat "#{@exit_code_path}")
-      | url="#{@callback_host}/dynflow/tasks/#{@task_id}/done"
-      | json="{ \\\"step_id\\\": #{@step_id} }"
-      | if which curl >/dev/null; then
-      |   curl -X POST -d "$json" -u "#{@task_id}:#{@otp}" "$url"
-      | else
-      |   echo 'curl is required' >&2
-      |   exit 1
-      | fi
+      | CALLBACK_HOST="#{@callback_host}"
+      | TASK_ID="#{@task_id}"
+      | STEP_ID="#{@step_id}"
+      | OTP="#{@otp}"
       SCRIPT
     end
 
     private
+
+    def cleanup
+      run_sync("rm -rf \"#{remote_command_dir}\"") if @cleanup_working_dirs
+    end
 
     def destroy_session
       if @session


### PR DESCRIPTION
Depends on:

- [x] - https://github.com/theforeman/smart_proxy_dynflow/pull/62
- [x] - https://github.com/theforeman/foreman-tasks/pull/416

This patch addes ability to take control over the job, allowing things
like surviving restarts and other advanced stuff. The main commands
allowing this is:

- `$CONTROL_SCRIPT manual-control` : turn on the manual control
- `echo hello | $CONTROL_SCRIPT update` : send output to the job
- `$CONTROL_SCRIPT finish $EXIT_CODE` : mark the job as finished
   with corresponding $EXIT_CODE

Currently, this only works when proxy rex plugin is configured with
`:async: true`.

It also involves refoctoring to make majority of the control scripts
static files, and dynamically generate only `env.sh` script, containing
dynamic data only, that other scripts can source from.

A sample template I've been testing this with:
```ruby
if [ -z "$CONTROL_SCRIPT" ]; then
    cat <<EOF
The script can be run only on a smart proxy with remote exeuction plugin in async mode.
It can be turned on with `--foreman-proxy-plugin-remote-execution-ssh-async-ssh true` installer option
EOF
fi

<% if input('mode') == 'manual' %>
$CONTROL_SCRIPT manual-mode
echo message 1 | $CONTROL_SCRIPT update >/dev/null
echo message 2 | $CONTROL_SCRIPT update >/dev/null

cat <<EOF | $CONTROL_SCRIPT update >/dev/null
Once really finished, call:

$CONTROL_SCRIPT finish 0
EOF
<% else %>
echo "Automatic mode"
<% end %>
```