### PR TITLE
Fixes #27302 - Make query type option more visible

### DIFF
--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -103,7 +103,7 @@
       <%= number_f f, :time_span, :label => _('Time span'), :placeholder => 'N', :min => 1, :label_help => N_("Distribute execution over N seconds")  %>
     </div>
 
-    <div class="form-group advanced hidden">
+    <div class="form-group">
       <%= add_label({ :label => _('Type of query'), :label_help => _("Type has impact on when is the query evaluated to hosts.<br><ul><li><b>Static</b> - evaluates just after you submit this form</li><li><b>Dynamic</b> - evaluates just before the execution is started, so if it's planed in future, targeted hosts set may change before it</li></ul>") }, f, :targetting_type) %>
 
       <div class="col-md-4">


### PR DESCRIPTION
This pull request is a follow up on https://projects.theforeman.org/issues/27302 and https://community.theforeman.org/t/changing-the-default-from-static-to-dynamic-query-for-rex/14649

It will look like this with the change:
![image](https://user-images.githubusercontent.com/3658213/61613296-415e1200-ac61-11e9-9c11-4511c8e2edae.png)
