### PR TITLE
Fixes #27883 - use button_to for post links

### DIFF
--- a/app/assets/stylesheets/foreman_remote_execution/job_invocations.css.scss
+++ b/app/assets/stylesheets/foreman_remote_execution/job_invocations.css.scss
@@ -6,3 +6,26 @@ div.infoblock {
     margin-top: 5px;
   }
 }
+
+#title_action {
+  .button_to {
+    display: inline-block;
+  }
+
+  .btn-toolbar {
+    .button_to {
+      float: left;
+    }
+  }
+
+  .btn-group {
+    .btn + .button_to,
+    .button_to + .button_to {
+      margin-left: -1px;
+    }
+
+    .button_to:not(:first-child):not(:last-child) .btn {
+      border-radius: 0;
+    }
+  }
+}

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -83,16 +83,16 @@ module RemoteExecutionHelper
                          :title => _('See the last task details'))
     end
     if authorized_for(:permission => :cancel_job_invocations, :auth_object => job_invocation)
-      buttons << link_to(_('Cancel Job'), cancel_job_invocation_path(job_invocation),
-                         :class => 'btn btn-danger',
-                         :title => _('Try to cancel the job'),
-                         :disabled => !task.cancellable?,
-                         :method => :post)
-      buttons << link_to(_('Abort Job'), cancel_job_invocation_path(job_invocation, :force => true),
-                         :class => 'btn btn-danger',
-                         :title => _('Try to abort the job without waiting for the results from the remote hosts'),
-                         :disabled => !task.cancellable?,
-                         :method => :post)
+      buttons << button_to(_('Cancel Job'), cancel_job_invocation_path(job_invocation),
+                           :class => 'btn btn-danger',
+                           :title => _('Try to cancel the job'),
+                           :disabled => !task.cancellable?,
+                           :method => :post)
+      buttons << button_to(_('Abort Job'), cancel_job_invocation_path(job_invocation, :force => true),
+                           :class => 'btn btn-danger',
+                           :title => _('Try to abort the job without waiting for the results from the remote hosts'),
+                           :disabled => !task.cancellable?,
+                           :method => :post)
     end
     return buttons
   end


### PR DESCRIPTION
Links using method=post are rails hack, let's just use `button_to` and just style the form to behave.