### PR TITLE
Fixes #27930 - set job invocation buttons initially disabled

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -86,12 +86,12 @@ module RemoteExecutionHelper
       buttons << button_to(_('Cancel Job'), cancel_job_invocation_path(job_invocation),
                            :class => 'btn btn-danger',
                            :title => _('Try to cancel the job'),
-                           :disabled => !task.cancellable?,
+                           :disabled => true,
                            :method => :post)
       buttons << button_to(_('Abort Job'), cancel_job_invocation_path(job_invocation, :force => true),
                            :class => 'btn btn-danger',
                            :title => _('Try to abort the job without waiting for the results from the remote hosts'),
-                           :disabled => !task.cancellable?,
+                           :disabled => true,
                            :method => :post)
     end
     return buttons


### PR DESCRIPTION
While creating a new job,
the buttons are first enabled, and after a few seconds turn disabled..
would it make sense to initially disable them ?

after a few moments they will get updated with the correct state anyway,
it feels better this way.