### PR TITLE
Refs #28072 - remove SELinux wrapper

### DIFF
--- a/extra/cockpit/foreman-cockpit
+++ b/extra/cockpit/foreman-cockpit
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Wrapper script for SELinux transition
-exec /usr/libexec/cockpit-ws "$@"

--- a/extra/cockpit/foreman-cockpit.service
+++ b/extra/cockpit/foreman-cockpit.service
@@ -7,8 +7,8 @@ After=network.target remote-fs.target nss-lookup.target
 Environment=XDG_CONFIG_DIRS=/etc/foreman/
 Environment=FOREMAN_COCKPIT_SETTINGS=/etc/foreman/cockpit/foreman-cockpit-session.yml
 Environment=FOREMAN_COCKPIT_ADDRESS=127.0.0.1
-Environment=FOREMAN_COCKPIT_PORT=9999
-ExecStart=/usr/libexec/foreman-cockpit --no-tls --address $FOREMAN_COCKPIT_ADDRESS --port $FOREMAN_COCKPIT_PORT
+Environment=FOREMAN_COCKPIT_PORT=19090
+ExecStart=/usr/libexec/cockpit-ws --no-tls --address $FOREMAN_COCKPIT_ADDRESS --port $FOREMAN_COCKPIT_PORT
 User=foreman
 Group=foreman
 


### PR DESCRIPTION
I have found out that `cockpit-ws` is actually the cockpit service, I thoguht it's some kind of helper script that does not have a policy. It has a policy and a domain and a port. Therefore wrapper is not only unnecessary but it causes it to start in an incorrect domain.

Thus we need to remove the wrapper, also we need a different port than 9090 (used by Katello) or 9999 (which is already in use in SELinux as `jboss_management_port_t`). So I suggest 19090 which is not used either by IANA or SELinux.

We need this patch to get into 1.24 in order to get SELinux working, sorry guys.