### PR TITLE
Fixes #28247 - Show chart overall result

### DIFF
--- a/webpack/react_app/components/jobInvocations/index.js
+++ b/webpack/react_app/components/jobInvocations/index.js
@@ -7,6 +7,8 @@ import DonutChart from 'foremanReact/components/common/charts/DonutChart';
 import AggregateStatus from './AggregateStatus/index.js';
 import * as JobInvocationActions from '../../redux/actions/jobInvocations';
 
+const colIndexOfMaxValue = columns => columns.reduce((iMax, x, i, arr) => (x[1] > arr[iMax][1] ? i : iMax), 0);
+
 class JobInvocationContainer extends React.Component {
   componentDidMount() {
     const { startJobInvocationsPolling, data: { url } } = this.props;
@@ -16,10 +18,12 @@ class JobInvocationContainer extends React.Component {
 
   render() {
     const { jobInvocations, statuses } = this.props;
+    const iMax = colIndexOfMaxValue(jobInvocations);
 
     return (
       <div id="job_invocations_chart_container">
-        <DonutChart data={Immutable.asMutable(jobInvocations)} />
+        <DonutChart data={Immutable.asMutable(jobInvocations)}
+                    title={{type: 'percent', secondary: (jobInvocations[iMax] || [])[0]}}/>
         <AggregateStatus statuses={statuses} />
       </div>
     );


### PR DESCRIPTION
This reimplements functionality that was once provided by patternfly-react[1],
but was removed in commit 937d2d764a449e31276f1291fc528ff7ed625106. This commit
can be reverted when it gets re-added back there.

I tried opening https://github.com/patternfly/patternfly-react/pull/3299 against PF-react, we'll see how it goes there

[1] - https://github.com/patternfly/patternfly-react/