### PR TITLE
Fixes #28372 - Fix targeting autocompletion

### DIFF
--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -33,7 +33,7 @@
       <% end %>
     </span>
     <%= selectable_f targeting_fields, :bookmark_id, @composer.available_bookmarks.map { |b| [b.name, b.id] }, :selected => @composer.targeting.bookmark_id, :include_blank => true %>
-    <%= textarea_f targeting_fields, :search_query, :value => @composer.displayed_search_query, :rows => 5, :class => 'autocomplete-input form-control', :'data-url' => auto_complete_search_hosts_path %>
+    <%= autocomplete_f targeting_fields, :search_query, :search_query => @composer.displayed_search_query, :full_path => auto_complete_search_hosts_path %>
 
     <div class="form-group ">
       <label class="col-md-2 control-label"><%= _('Resolves to') %></label>


### PR DESCRIPTION
The previous implementation of autocomplete relied on a legacy js which was
recently dropped from Foreman. This PR uses the new react component for
autocomplete. The drawback is the react component render the search box as an
input, not as a textarea. Sadly the underlying libraries don't seem to be
flexible enough to allow using a textarea easily.

Requires:
- [x] https://github.com/theforeman/foreman/pull/7212