### PR TITLE
Fixes #27324 - Add Jobs button to host detail page

### DIFF
--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -1,5 +1,11 @@
 module ForemanRemoteExecution
   module HostsHelperExtensions
+    def host_overview_buttons(host)
+      [
+        { :button => link_to_if_authorized(_("Jobs"), hash_for_job_invocations_path(search: "host=#{host.name}"), :title => _("Job invocations"), :class => 'btn btn-default'), :priority => 200 }
+      ]
+    end
+
     def multiple_actions
       super + [ [_('Schedule Remote Job'), new_job_invocation_path, false] ]
     end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -135,6 +135,7 @@ module ForemanRemoteExecution
         end
 
         extend_rabl_template 'api/v2/smart_proxies/main', 'api/v2/smart_proxies/pubkey'
+        describe_host { overview_buttons_provider :host_overview_buttons }
       end
     end
 


### PR DESCRIPTION
**Description**
Add _Jobs_ button to Details section on host edit page. Button goes to Job invocations page with filter set to `name=host.example.com`

![Screenshot_20200203_094425](https://user-images.githubusercontent.com/59385976/73638013-db1f6680-4669-11ea-811f-51b3b699de27.png)

