### PR TITLE
Fixes #25144 - Include taxonomies in Job invocation targeting

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/targeting.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/targeting.rb
@@ -4,7 +4,7 @@ module Foreman::Controller::Parameters::Targeting
   class_methods do
     def targeting_params_filter
       Foreman::ParameterFilter.new(::Targeting).tap do |filter|
-        filter.permit_by_context :targeting_type, :bookmark_id, :user, :search_query, :nested => true
+        filter.permit_by_context :targeting_type, :bookmark_id, :user, :search_query, :location_id, :organization_id, :nested => true
       end
     end
   end

--- a/app/helpers/job_invocations_helper.rb
+++ b/app/helpers/job_invocations_helper.rb
@@ -47,4 +47,12 @@ module JobInvocationsHelper
       content_tag(:span, '', :class => 'caret') + title
     end
   end
+
+  def show_job_organization(organization)
+    organization.present? ? organization : _('Any Organization')
+  end
+
+  def show_job_location(location)
+    location.present? ? location : _('Any Location')
+  end
 end

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -523,7 +523,9 @@ class JobInvocationComposer
       :bookmark_id => bookmark_id,
       :targeting_type => params[:targeting][:targeting_type],
       :search_query => query,
-      :randomized_ordering => params[:targeting][:randomized_ordering]
+      :randomized_ordering => params[:targeting][:randomized_ordering],
+      :organization_id => params[:targeting][:organization_id],
+      :location_id => params[:targeting][:location_id]
     ) { |t| t.user_id = params[:targeting][:user_id] }
   end
 

--- a/app/models/targeting.rb
+++ b/app/models/targeting.rb
@@ -11,6 +11,8 @@ class Targeting < ApplicationRecord
 
   belongs_to :user
   belongs_to :bookmark
+  belongs_to :organization, optional: true
+  belongs_to :location, optional: true
 
   has_many :targeting_hosts, :dependent => :destroy
   has_many :hosts, -> { order TargetingHost.table_name + '.id' }, :through => :targeting_hosts
@@ -19,7 +21,6 @@ class Targeting < ApplicationRecord
 
   validates :targeting_type, :presence => true, :inclusion => Targeting::TYPES.keys
   validate :bookmark_or_query_is_present
-
   before_create :assign_search_query, :if => :static?
 
   def clone
@@ -30,7 +31,9 @@ class Targeting < ApplicationRecord
         :user => self.user,
         :bookmark_id => self.bookmark.try(:id),
         :targeting_type => self.targeting_type,
-        :search_query => self.search_query
+        :search_query => self.search_query,
+        :organization_id => self.organization_id,
+        :location_id => self.location_id
       )
     end.tap(&:save)
   end

--- a/app/views/api/v2/job_invocations/main.json.rabl
+++ b/app/views/api/v2/job_invocations/main.json.rabl
@@ -17,7 +17,7 @@ end
 
 child :targeting do
   attributes :bookmark_id, :search_query, :targeting_type, :user_id, :status, :status_label,
-             :randomized_ordering
+             :randomized_ordering, :organization_id, :location_id
 
   child :hosts do
     extends 'api/v2/hosts/base'

--- a/app/views/job_invocations/_card_target_hosts.html.erb
+++ b/app/views/job_invocations/_card_target_hosts.html.erb
@@ -20,6 +20,18 @@
       <% key = job_invocation.targeting.randomized_ordering ? Targeting::RANDOMIZED : Targeting::ORDERED %>
       <%= _('Execution order') %>: <strong><%= Targeting::ORDERINGS[key].downcase %></strong>
     </p>
+    <p>
+      <%= _('Organization') %>:
+      <strong>
+        <%= show_job_organization(job_invocation.targeting.organization) %>
+      </strong>
+    </p>
+    <p>
+      <%= _('Location') %>:
+      <strong>
+        <%= show_job_location(job_invocation.targeting.location) %>
+      </strong>
+    </p>
   </div>
   <div class='card-pf-footer'>
     <p>

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -49,6 +49,22 @@
       </div>
     </div>
 
+    <div class="form-group">
+      <label class="col-md-2 control-label">
+        <%= _('Organization') %><br>
+        <%= _('Location') %>
+      </label>
+      <div class="col-md-4">
+        <p class="form-control-static">
+          <%= show_job_organization(Organization.current) %>
+          <br>
+          <%= show_job_location(Location.current) %>
+        </p>
+      </div>
+    </div>
+    <%= targeting_fields.hidden_field :organization_id, value: (Organization.current.present? ? Organization.current.id : nil) %>
+    <%= targeting_fields.hidden_field :location_id, value: (Location.current.present? ? Location.current.id : nil) %>
+
     <% @composer.displayed_provider_types.each do |provider_type| %>
       <fieldset id="provider_<%= provider_type %>" class="provider_form">
         <%= f.fields_for 'providers' do |providers_fields| %>

--- a/db/migrate/20200204123702_targeting_add_taxonomies.rb
+++ b/db/migrate/20200204123702_targeting_add_taxonomies.rb
@@ -1,0 +1,11 @@
+class TargetingAddTaxonomies < ActiveRecord::Migration[5.2]
+  def up
+    add_column(:targetings, :organization_id, :integer)
+    add_column(:targetings, :location_id, :integer)
+  end
+
+  def down
+    remove_column(:targetings, :organization_id)
+    remove_column(:targetings, :location_id)
+  end
+end


### PR DESCRIPTION
Add Location and Organization to Job invocations, so users will now see in which context job has been run.

**List of changes:**
* Current Organization & Location are displayed in `/job_invocations/new` form
* Organization & Location in which job has been run are now displayed in the Targeting section on Job invocation edit page.
 