### PR TITLE
Fixes #28997 - remove %{puppet_options} from the format_description

### DIFF
--- a/test/unit/job_invocation_test.rb
+++ b/test/unit/job_invocation_test.rb
@@ -91,7 +91,7 @@ class JobInvocationTest < ActiveSupport::TestCase
       it 'handles missing keys correctly' do
         job_invocation.description_format = '%{job_category} - %{missing_key}'
         job_invocation.generate_description
-        job_invocation.description.must_equal "#{job_invocation.job_category} - %{missing_key}"
+        job_invocation.description.must_equal "#{job_invocation.job_category} - ''"
       end
 
       it 'truncates generated description to 255 characters' do


### PR DESCRIPTION
puppet_options user input is optional input, and after moving the `Run Puppet once` button to REX. it runs `Puppet Run Once - SSH Default` task without `puppet_options` so it doesn't populated and therefore presented in the UI as `%{puppet_options}`


