### PR TITLE
Fixes #29048 - cant create job with end time

### DIFF
--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -79,8 +79,9 @@ class JobInvocationComposer
       return {} unless ui_params.key?(:triggering)
       trig = ui_params[:triggering]
       keys = (1..5).map { |i| "end_time(#{i}i)" }
-      return trig unless trig.key?(:end_time) && trig[:end_time].keys == keys
-      trig.merge(:end_time => Time.local(*trig[:end_time].values_at(*keys)))
+      values = trig.fetch(:end_time, {}).values_at(*keys)
+      return trig if values.any?(&:nil?)
+      trig.merge(:end_time => Time.local(*values))
     end
 
     def targeting(targeting_params)

--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -465,11 +465,15 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
       describe 'triggering' do
         let(:params) do
-          { :job_invocation => { :providers => { :ssh => ssh_params } }, :triggering => { :mode => 'future' }}.with_indifferent_access
+          { :job_invocation => { :providers => { :ssh => ssh_params } }, :triggering => { :mode => 'future', :end_time=> {"end_time(3i)": 1, "end_time(2i)": 2, "end_time(1i)": 3, "end_time(4i)": 4, "end_time(5i)": 5} }}.with_indifferent_access
         end
 
         it 'accepts the triggering params' do
           composer.job_invocation.triggering.mode.must_equal :future
+        end
+
+        it 'formats the triggering end time when its unordered' do
+          composer.job_invocation.triggering.end_time.must_equal Time.local(3,2,1,4,5)
         end
       end
 


### PR DESCRIPTION
In some environments when you create a job invocation with end_time the end_time hash keys would be unsorted which caused the creation to fail.