### PR TITLE
Fixes #25144 - Display taxonomies on Job invocation pages

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -58,6 +58,8 @@ class JobInvocationsController < ApplicationController
                                      .where(:template_invocations => { :job_invocation_id => @job_invocation.id})
     end
     @hosts = resource_base_search_and_page
+    @job_organization = Taxonomy.find_by(id: @job_invocation.task.input[:current_organization_id])
+    @job_location = Taxonomy.find_by(id: @job_invocation.task.input[:current_location_id])
   end
 
   def index

--- a/app/helpers/job_invocations_helper.rb
+++ b/app/helpers/job_invocations_helper.rb
@@ -47,4 +47,12 @@ module JobInvocationsHelper
       content_tag(:span, '', :class => 'caret') + title
     end
   end
+
+  def show_job_organization(organization)
+    organization.present? ? organization : _('Any Organization')
+  end
+
+  def show_job_location(location)
+    location.present? ? location : _('Any Location')
+  end
 end

--- a/app/views/job_invocations/_card_target_hosts.html.erb
+++ b/app/views/job_invocations/_card_target_hosts.html.erb
@@ -23,7 +23,6 @@
     <p>
       <%= _('Organization') %>:
       <strong>
-        <%=  %>
         <%= show_job_organization(@job_organization) %>
       </strong>
     </p>

--- a/app/views/job_invocations/_card_target_hosts.html.erb
+++ b/app/views/job_invocations/_card_target_hosts.html.erb
@@ -20,6 +20,19 @@
       <% key = job_invocation.targeting.randomized_ordering ? Targeting::RANDOMIZED : Targeting::ORDERED %>
       <%= _('Execution order') %>: <strong><%= Targeting::ORDERINGS[key].downcase %></strong>
     </p>
+    <p>
+      <%= _('Organization') %>:
+      <strong>
+        <%=  %>
+        <%= show_job_organization(@job_organization) %>
+      </strong>
+    </p>
+    <p>
+      <%= _('Location') %>:
+      <strong>
+        <%= show_job_location(@job_location) %>
+      </strong>
+    </p>
   </div>
   <div class='card-pf-footer'>
     <p>

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -49,6 +49,20 @@
       </div>
     </div>
 
+    <div class="form-group">
+      <label class="col-md-2 control-label">
+        <%= _('Organization') %><br>
+        <%= _('Location') %>
+      </label>
+      <div class="col-md-4">
+        <p class="form-control-static">
+          <%= show_job_organization(Organization.current) %>
+          <br>
+          <%= show_job_location(Location.current) %>
+        </p>
+      </div>
+    </div>
+
     <% @composer.displayed_provider_types.each do |provider_type| %>
       <fieldset id="provider_<%= provider_type %>" class="provider_form">
         <%= f.fields_for 'providers' do |providers_fields| %>

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -49,20 +49,6 @@
       </div>
     </div>
 
-    <div class="form-group">
-      <label class="col-md-2 control-label">
-        <%= _('Organization') %><br>
-        <%= _('Location') %>
-      </label>
-      <div class="col-md-4">
-        <p class="form-control-static">
-          <%= show_job_organization(Organization.current) %>
-          <br>
-          <%= show_job_location(Location.current) %>
-        </p>
-      </div>
-    </div>
-
     <% @composer.displayed_provider_types.each do |provider_type| %>
       <fieldset id="provider_<%= provider_type %>" class="provider_form">
         <%= f.fields_for 'providers' do |providers_fields| %>


### PR DESCRIPTION
Add Location and Organization to Job invocations, so users will now see in which context job has been run.

**List of changes:**

- Current Organization & Location are displayed in `/job_invocations/new` form
- Organization & Location in which job has been run are now displayed in the Targeting section on Job invocation edit page.