### PR TITLE
Fixes #25149 - Warning for Job taxonomies in re-rerun

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -3,7 +3,6 @@ class JobInvocationsController < ApplicationController
   include ::ForemanTasks::Concerns::Parameters::Triggering
   include ::JobInvocationsChartHelper
 
-
   def new
     return @composer = prepare_composer if params[:feature].present?
     ui_params = {
@@ -35,6 +34,8 @@ class JobInvocationsController < ApplicationController
   def rerun
     job_invocation = resource_base.find(params[:id])
     @composer = JobInvocationComposer.from_job_invocation(job_invocation, params)
+    @job_organization = Taxonomy.find_by(id: job_invocation.task.input[:current_organization_id])
+    @job_location = Taxonomy.find_by(id: job_invocation.task.input[:current_location_id])
     render :action => 'new'
   end
 

--- a/app/views/job_invocations/_form.html.erb
+++ b/app/views/job_invocations/_form.html.erb
@@ -126,5 +126,6 @@
 
   <%= render :partial => 'preview_hosts_modal' %>
 
+  <%= render partial: 'rerun_taxonomies' if action_name == 'rerun' %>
   <%= submit_or_cancel f, false, :cancel_path => job_invocations_path, :disabled => !@composer.rerun_possible? %>
 <% end %>

--- a/app/views/job_invocations/_rerun_taxonomies.html.erb
+++ b/app/views/job_invocations/_rerun_taxonomies.html.erb
@@ -1,0 +1,22 @@
+<% if Organization.current != @job_organization %>
+  <div class="form-group">
+    <div class="col-md-6">
+      <div class="alert alert-warning">
+        <span class="pficon pficon-warning-triangle-o"></span>
+        <%= _("Current organization %{org_c} is different from job's organization %{org_j}.") % { org_c: show_job_organization(Organization.current),
+                                                                                                  org_j: show_job_organization(@job_organization) } %>
+      </div>
+    </div>
+  </div>
+<% end %>
+<% if Location.current != @job_location %>
+  <div class="form-group">
+    <div class="col-md-6">
+      <div class="alert alert-warning">
+        <span class="pficon pficon-warning-triangle-o"></span>
+        <%= _("Current location %{loc_c} is different from job's location %{loc_j}.") % { loc_c: show_job_location(Location.current),
+                                                                                          loc_j: show_job_location(@job_location) } %>
+      </div>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
When user is trying to re-run job in different Organization or Location, warning on re-run page is displayed.

**How to test:**
- Run job in Default organization & Default location
- Switch to different org/loc
- Rerun job

Warnings about taxonomies are displayed.