### PR TITLE
Adding a new slot on job_invocation detail page

### DIFF
--- a/app/views/job_invocations/show.html.erb
+++ b/app/views/job_invocations/show.html.erb
@@ -19,6 +19,7 @@
   <% if @job_invocation.recurring_logic.present? %>
     <li><a href="#recurring_logic" data-toggle="tab"><%= _('Recurring logic') %></a></li>
   <% end %>
+  <%= slot('jobInvocationsTabHeaderSlot', true) %>
 </ul>
 
 <div class="tab-content">
@@ -38,6 +39,7 @@
     </div>
   </div>
   <% end %>
+  <%= slot('jobInvocationsTabContentSlot', true) %>
 </div>
 
 <script id="job_invocation_refresh" data-refresh-url="<%= job_invocation_path(@job_invocation) %>">


### PR DESCRIPTION
Creating these Slot, we provide to all developers a way to create how many tab/tab content as they required.

We on OAMG-LEAPP [1] team need to show all in-place upgrade reports to the sysadmin. And we think the best place to show it is on Job Invocation Details page. We will have a plugin [2] to fill these slots after these PR and these https://github.com/theforeman/foreman/pull/7509  been approved and merged.

[1] - https://github.com/oamg/leapp   &  https://github.com/oamg/leapp-repository
[2] - https://github.com/oamg/foreman_leapp

Signed-off-by: Fellipe Henrique <fpedrosa@redhat.com>