### PR TITLE
Fixes #29361 Add pagelet to Job invocation detail

### DIFF
--- a/app/views/job_invocations/show.html.erb
+++ b/app/views/job_invocations/show.html.erb
@@ -19,6 +19,7 @@
   <% if @job_invocation.recurring_logic.present? %>
     <li><a href="#recurring_logic" data-toggle="tab"><%= _('Recurring logic') %></a></li>
   <% end %>
+  <%= render_tab_header_for(:main_tabs, subject: @job_invocation) %>
 </ul>
 
 <div class="tab-content">
@@ -38,6 +39,7 @@
     </div>
   </div>
   <% end %>
+  <%= render_tab_content_for(:main_tabs, subject: @job_invocation) %>
 </div>
 
 <script id="job_invocation_refresh" data-refresh-url="<%= job_invocation_path(@job_invocation) %>">


### PR DESCRIPTION
Job invocation page can be easily extended from other plugins, like this:
```
engine.rb

        extend_page "job_invocations/show" do |cx|
          cx.add_pagelet :main_tabs,
                         :partial => "job_invocations/leapp_report",
                         name: _('Leapp report'),
                         :id => 'leapp_report',
                         :onlyif => Proc.new { |subject| subject.job_category == 'Leapp' }
        end
```