### PR TITLE
Fixes #29399 - Make schedule_job_multi_button method extendable

### DIFF
--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -11,14 +11,18 @@ module ForemanRemoteExecution
     end
 
     def schedule_job_multi_button(*args)
-      host_features = RemoteExecutionFeature.with_host_action_button.order(:label).map do |feature|
-        link_to(_('%s') % feature.name, job_invocations_path(:host_ids => [args.first.id], :feature => feature.label), :method => :post)
-      end
+      host_features = rex_host_features(*args)
 
       if host_features.present?
         action_buttons(schedule_job_button(*args), *host_features)
       else
         schedule_job_button(*args)
+      end
+    end
+
+    def rex_host_features(*args)
+      RemoteExecutionFeature.with_host_action_button.order(:label).map do |feature|
+        link_to(_('%s') % feature.name, job_invocations_path(:host_ids => [args.first.id], :feature => feature.label), :method => :post)
       end
     end
 


### PR DESCRIPTION
Extract loading links for multi-button from method to separate method, so other plugins can extend it and add its own links, like this:

```
    def rex_host_features(*args)
      super + [link_to(_('Preupgrade check with Leapp'), new_job_invocation_path(:host_ids => [args.first.id], :feature => 'leapp_preupgrade')),
               link_to(_('Upgrade with Leapp'), new_job_invocation_path(:host_ids => [args.first.id], :feature => 'leapp_upgrade'))]
    end
```