### PR TITLE
Fixes #29422 - web console should open in a new tab or window

### DIFF
--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -34,7 +34,7 @@ module ForemanRemoteExecution
       return unless authorized_for(permission: 'cockpit_hosts', auth_object: host)
 
       url = SSHExecutionProvider.cockpit_url_for_host(host.name)
-      url ? link_to(_('Web Console'), url, :class => 'btn btn-default', :id => :'web-console-button') : nil
+      url ? link_to(_('Web Console'), url, :class => 'btn btn-default', :id => :'web-console-button', :target => '_new') : nil
     end
 
     def host_title_actions(*args)


### PR DESCRIPTION
after feedback from the whole team, we decided for us that cockpit in a new tab is way more convenient.