### PR TITLE
Add POST route for JobInvocations#new

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :job_invocations, :only => [:new, :create, :show, :index] do
+  resources :job_invocations, :only => [:create, :show, :index] do
     collection do
+      match 'new', via: [:get, :post], as: :new
       post 'refresh'
       get 'chart'
       get 'preview_hosts'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     end
   end
 
-  match 'new', to: 'job_invocations#new', via: [:get, :post], as: 'new_job_invocation'
+  match 'job_invocations/new', to: 'job_invocations#new', via: [:get, :post], as: 'new_job_invocation'
   resources :job_invocations, :only => [:create, :show, :index] do
     collection do
       post 'refresh'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,9 +16,9 @@ Rails.application.routes.draw do
     end
   end
 
+  match 'new', to: 'job_invocations#new', via: [:get, :post], as: 'new_job_invocation'
   resources :job_invocations, :only => [:create, :show, :index] do
     collection do
-      match 'new', via: [:get, :post], as: :new
       post 'refresh'
       get 'chart'
       get 'preview_hosts'

--- a/test/functional/job_invocations_controller_test.rb
+++ b/test/functional/job_invocations_controller_test.rb
@@ -46,4 +46,16 @@ class JobInvocationsControllerTest < ActionController::TestCase
     assert_equal(template_invocation_params,
       assigns(:composer).params['template_invocations'])
   end
+
+  test 'new via GET and POST' do
+    template = FactoryBot.create(:job_template, :with_input)
+    feature = FactoryBot.create(:remote_execution_feature, job_template: template)
+    params = { feature: feature.label, inputs: { template.template_inputs.first.name => 'foobar' } }
+
+    get :new, params: params, session: set_session_user
+    assert_response :success
+
+    post :new, params: params, session: set_session_user
+    assert_response :success
+  end
 end


### PR DESCRIPTION
For building Remediation plan with thousands of IDs `GET` method can be problem.