### PR TITLE
Fixes #29783 - Allow overriding proxy selector in jobs

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -29,14 +29,15 @@ module Actions
 
         raise _('Could not use any template used in the job invocation') if template_invocation.blank?
 
+        provider = template_invocation.template.provider
+        proxy_selector = provider.required_proxy_selector_for(template_invocation.template) || proxy_selector
+
         provider_type = template_invocation.template.provider_type.to_s
         proxy = determine_proxy!(proxy_selector, provider_type, host)
 
         renderer = InputTemplateRenderer.new(template_invocation.template, host, template_invocation)
         script = renderer.render
         raise _('Failed rendering template: %s') % renderer.error_message unless script
-
-        provider = template_invocation.template.provider
 
         additional_options = { :hostname => provider.find_ip_or_hostname(host),
                                :script => script,

--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -98,5 +98,10 @@ class RemoteExecutionProvider
     def proxy_action_class
       ForemanRemoteExecutionCore::Actions::RunScript
     end
+
+    # Return a specific proxy selector to use for running a given template
+    # Returns either nil to use the default selector or an instance of a (sub)class of ::ForemanTasks::ProxySelector
+    def required_proxy_selector_for(_template)
+    end
   end
 end

--- a/app/services/default_proxy_proxy_selector.rb
+++ b/app/services/default_proxy_proxy_selector.rb
@@ -1,6 +1,7 @@
-class InternalProxyProxySelector < ::RemoteExecutionProxySelector
+class DefaultProxyProxySelector < ::RemoteExecutionProxySelector
   def initialize
     # TODO: Remove this once we have a reliable way of determining the internal proxy without katello
+    # Tracked as https://projects.theforeman.org/issues/29840
     raise _('Internal proxy selector can only be used if Katello is enabled') unless defined?(::Katello)
     super
   end

--- a/app/services/default_proxy_proxy_selector.rb
+++ b/app/services/default_proxy_proxy_selector.rb
@@ -3,6 +3,7 @@ class DefaultProxyProxySelector < ::RemoteExecutionProxySelector
     # TODO: Remove this once we have a reliable way of determining the internal proxy without katello
     # Tracked as https://projects.theforeman.org/issues/29840
     raise _('Internal proxy selector can only be used if Katello is enabled') unless defined?(::Katello)
+
     super
   end
 

--- a/app/services/internal_proxy_proxy_selector.rb
+++ b/app/services/internal_proxy_proxy_selector.rb
@@ -1,0 +1,16 @@
+class InternalProxyProxySelector < ::RemoteExecutionProxySelector
+  def initialize
+    # TODO: Remove this once we have a reliable way of determining the internal proxy without katello
+    raise _('Internal proxy selector can only be used if Katello is enabled') unless defined?(::Katello)
+    super
+  end
+
+  def available_proxies(host, provider)
+    # TODO: Once we have a internal proxy marker/feature on the proxy, we can
+    # swap the implementation
+    internal_proxy = ::Katello.default_capsule
+    super.reduce({}) do |acc, (key, proxies)|
+      acc.merge(key => proxies.select { |proxy| proxy == internal_proxy })
+    end
+  end
+end


### PR DESCRIPTION
A Satellite 6.8 feature requires a support from remote execution to be able to run a job from the proxy co-located on the same machine as foreman/satellite. The feature is downstream only, so we can rely on Katello being there and we can use Katello's code to determine which proxy is the right one. However this creates this weird situation where we have a downstream only feature and rex depends on katello. I'd rather avoid less reliable methods of determining the proxy like hostname comparison.

I suggest we get this in as-is now and shortly after 2.1 is out we introduce a new feature to the smart proxy, which will mark the proxy as being co-located on the same machine as foreman/satellite and once it gets in, we change the marked code here to use that marker instead of whatever katello uses.

