### PR TITLE
Fixes #29793 - Do not rely on hidden_value being defined

### DIFF
--- a/app/helpers/job_invocations_helper.rb
+++ b/app/helpers/job_invocations_helper.rb
@@ -55,4 +55,9 @@ module JobInvocationsHelper
   def show_job_location(location)
     location.presence || _('Any Location')
   end
+
+  def input_safe_value(input)
+    template_input = input.template_input
+    template_input.respond_to?(:hidden_value) && template_input.hidden_value ? '*' * 5 : input.value
+  end
 end

--- a/app/views/job_invocations/_card_user_input.html.erb
+++ b/app/views/job_invocations/_card_user_input.html.erb
@@ -8,7 +8,7 @@
     <p>
     <ul>
       <% template_invocation.input_values.joins(:template_input).each do |input_value| %>
-        <li><b><%= input_value.template_input.name %></b>: <%= input_value.template_input.hidden_value ? '*' * 5 : trunc_with_tooltip(input_value.value, 255) %></li>
+        <li><b><%= input_value.template_input.name %></b>: <%= trunc_with_tooltip(input_safe_value(input_value), 255) %></li>
       <% end %>
     </ul>
     </p>

--- a/app/views/job_invocations/_user_input.html.erb
+++ b/app/views/job_invocations/_user_input.html.erb
@@ -12,7 +12,7 @@
       <% template_invocation.input_values.joins(:template_input).each do |input_value| %>
         <tr>
           <td><b><%= input_value.template_input.name %></b></td>
-          <td><%= input_value.template_input.hidden_value? ? '*' * 5 : input_value.value %></td>
+          <td><%= input_safe_value(input_value) %></td>
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
The original intention in #29465 was that it would use the hidden_value method
if available and continue working as it used to if not. Because of this,
dependency on Foreman wasn't bumped, because it was supposed to work even with
older releases than 2.1 which provided hidden_value. However, we missed some
places and because of that, release 3.2.0 wasn't compatible with Foreman 2.0.