### PR TITLE
Fixes #29843 - SSH known_deletion failure is non-fatal

### DIFF
--- a/app/models/concerns/foreman_remote_execution/orchestration/ssh.rb
+++ b/app/models/concerns/foreman_remote_execution/orchestration/ssh.rb
@@ -13,6 +13,9 @@ module ForemanRemoteExecution
       proxy = ::SmartProxy.find(proxy_id)
       begin
         proxy.drop_host_from_known_hosts(target)
+      rescue RestClient::ResourceNotFound => e
+        # ignore 404 when known_hosts entry is missing or the module was not enabled
+        Foreman::Logging.exception "Proxy failed to delete SSH known_hosts for #{name}, #{ip}", e, :level => :error
       rescue => e
         Rails.logger.warn e.message
         return false


### PR DESCRIPTION
We should probably not rollback whole deletion transaction. Since the entry is missing, there is nothing we can do about it.