### PR TITLE
Fixes #29878 - Move to foreman-js provided tooling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,32 +1,7 @@
 {
-  "root": true,
-  "extends": ["airbnb-base", "./node_modules/@theforeman/vendor-dev/eslint.extends.js"],
-  "plugins": [
-    "react"
-  ],
-  "env": {
-    "browser": true,
-    "es6": true,
-    "node": true,
-    "jasmine": true,
-    "jest": true
-  },
-  "parser": "babel-eslint",
-  "rules": {
-    "react/jsx-uses-vars": "error",
-    "react/jsx-uses-react": "error",
-    "no-unused-vars": [
-      "error",
-      {
-        "vars": "all",
-        "args": "none"
-      }
-    ],
-    "no-underscore-dangle": "off",
-    "no-use-before-define": "off",
-    "import/prefer-default-export": "off",
-    // Import rules off for now due to HoundCI issue
-    "import/no-unresolved": "off",
-    "import/extensions": "off"
-  }
+  "plugins": ["@theforeman/foreman"],
+  "extends": [
+    "plugin:@theforeman/foreman/core",
+    "plugin:@theforeman/foreman/plugins"
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ locale/*/*.po.time_stamp
 Gemfile.lock
 node_modules/
 package-lock.json
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '6.10' # current EPEL 7
-  - '6' # previous LTS
-  - '8' # current LTS
+  - '10'
+  - '12'
 script: ./scripts/travis_run_js_tests.sh

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@theforeman/builder": "^4.2.1",
-    "@theforeman/eslint-plugin-foreman": "4.2.1",
+    "@theforeman/eslint-plugin-foreman": "^4.2.1",
     "@theforeman/stories": "^4.2.1",
     "@theforeman/test": "^4.2.1",
     "@theforeman/vendor-dev": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -3,25 +3,14 @@
   "version": "1.0.0",
   "license": "GPL-3.0",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint -c .eslintrc webpack/ script/",
-    "test": "node node_modules/.bin/jest webpack",
-    "test:watch": "node node_modules/.bin/jest webpack --watchAll",
-    "test:current": "node node_modules/.bin/jest webpack --watch"
-  },
-  "jest": {
-    "verbose": true,
-    "moduleDirectories": [
-      "node_modules",
-      "webpack"
-    ],
-    "setupFiles": [
-      "raf/polyfill",
-      "./webpack/test_setup.js"
-    ],
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "<rootDir>/foreman/"
-    ]
+    "lint": "tfm-lint --plugin -d /webpack",
+    "test": "tfm-test --plugin",
+    "test:watch": "tfm-test --plugin --watchAll",
+    "test:current": "tfm-test --plugin --watch",
+    "publish-coverage": "tfm-publish-coverage",
+    "stories": "tfm-stories --plugin",
+    "stories:build": "tfm-build-stories --plugin",
+    "stories:deploy": "surge --project .storybook-dist"
   },
   "repository": {
     "type": "git",
@@ -32,22 +21,16 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^4.0.2",
-    "@theforeman/vendor-dev": "^4.0.2",
+    "@theforeman/builder": "^4.2.1",
+    "@theforeman/eslint-plugin-foreman": "4.2.1",
+    "@theforeman/stories": "^4.2.1",
+    "@theforeman/test": "^4.2.1",
+    "@theforeman/vendor-dev": "^4.2.1",
     "babel-eslint": "^10.0.0",
-    "babel-jest": "^24.9.0",
-    "enzyme": "^3.2.0",
-    "enzyme-adapter-react-16": "^1.1.0",
-    "enzyme-to-json": "^3.1.2",
-    "eslint": "^4.10.0",
-    "eslint-config-airbnb": "^16.0.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^21.2.0",
-    "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.4.0",
-    "jest": "^24.9.0"
+    "eslint": "^6.8.0",
+    "prettier": "^1.19.1"
   },
   "peerDependencies": {
-    "@theforeman/vendor": ">= 4.0.2"
+    "@theforeman/vendor": ">= 4.2.1"
   }
 }

--- a/scripts/travis_run_js_tests.sh
+++ b/scripts/travis_run_js_tests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ev
 if [[ $( git diff --name-only HEAD~1..HEAD webpack/ .travis.yml package.json | wc -l ) -ne 0 ]]; then
+  npm run lint;
   npm run test;
 fi

--- a/scripts/travis_run_js_tests.sh
+++ b/scripts/travis_run_js_tests.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -ev
 if [[ $( git diff --name-only HEAD~1..HEAD webpack/ .travis.yml package.json | wc -l ) -ne 0 ]]; then
-  npm run lint;
   npm run test;
 fi


### PR DESCRIPTION
* For TravisCI `node.js` version have been updated to 10 & 12
*  Added / updated packages:
```
    "@theforeman/builder": "^4.2.1",
    "@theforeman/eslint-plugin-foreman": "4.2.1",
    "@theforeman/stories": "^4.2.1",
    "@theforeman/test": "^4.2.1",
    "@theforeman/vendor-dev": "^4.2.1",
```
* Removed some obsolete packages (now part of `@theforeman/*`)
* `npm run lint` is now following styling code for foreman core and plugins.
* Functions like `testComponentSnapshotsWithFixtures` from `@theforeman/test` can be used now.
* Added `stories` scripts
