### PR TITLE
Job Actions - user customizable quick links to jobs

### DIFF
--- a/app/controllers/job_actions_controller.rb
+++ b/app/controllers/job_actions_controller.rb
@@ -1,0 +1,33 @@
+class JobActionsController < ::ApplicationController
+  before_action :find_resource, :only => [:show, :update, :destroy]
+
+  def index
+    @job_actions = resource_scope
+  end
+
+  def new
+    @job_action = JobAction.new(params.permit(:name, :job_template_id))
+  end
+
+  def create
+    @job_action = JobAction.new(job_action_params)
+    @job_action.save ? process_success : process_error
+  end
+
+  def show
+  end
+
+  def update
+    @job_action.update(job_action_params) ? process_success : process_error
+  end
+
+  def destroy
+    @job_action.destroy ? process_success : process_error
+  end
+
+  private
+
+  def job_action_params
+    params.require(:job_action).permit(:name, :job_template_id)
+  end
+end

--- a/app/controllers/job_actions_controller.rb
+++ b/app/controllers/job_actions_controller.rb
@@ -1,12 +1,12 @@
-class JobActionsController < ::ApplicationController
-  before_action :find_resource, :only => [:show, :update, :destroy]
+class JobActionsController < ApplicationController
+  before_action :find_resource, only: [:show, :update, :destroy]
 
   def index
     @job_actions = resource_scope
   end
 
   def new
-    @job_action = JobAction.new(params.permit(:name, :job_template_id))
+    @job_action = JobAction.new
   end
 
   def create
@@ -26,6 +26,10 @@ class JobActionsController < ::ApplicationController
   end
 
   private
+
+  def resource_scope
+    super(user: current_user)
+  end
 
   def job_action_params
     params.require(:job_action).permit(:name, :job_template_id)

--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -7,14 +7,21 @@ module ForemanRemoteExecution
     end
 
     def multiple_actions
-      super + [ [_('Schedule Remote Job'), new_job_invocation_path, false] ]
+      job_actions = JobAction.authorized(:view_job_actions).all.order(:name).map do |action|
+         [_(action.name), new_job_invocation_path(template_id: action.job_template.id), false]
+      end
+
+      super + [ [_('Schedule Remote Job'), new_job_invocation_path, false] ] + job_actions
     end
 
     def schedule_job_multi_button(*args)
       host_features = rex_host_features(*args)
+      job_actions = JobAction.authorized(:view_job_actions).all.order(:name).map do |action|
+        link_to _(action.name), new_job_invocation_path(template_id: action.job_template.id)
+      end
 
-      if host_features.present?
-        action_buttons(schedule_job_button(*args), *host_features)
+      if host_features.present? || job_actions.present?
+        action_buttons(schedule_job_button(*args), host_features, *job_actions)
       else
         schedule_job_button(*args)
       end

--- a/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/job_templates_extensions.rb
@@ -3,8 +3,9 @@ module ForemanRemoteExecution
     def permitted_actions(template)
       original = super(template)
 
-      if template.is_a?(JobTemplate)
-        original.unshift(display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(:template_id => template.id).merge(:authorizer => authorizer))) unless template.snippet
+      if template.is_a?(JobTemplate) && !template.snippet
+        original.unshift(display_link_if_authorized(_('Create Job Action'), hash_for_new_job_action_path(:job_template_id => template.id)))
+        original.unshift(display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(:template_id => template.id).merge(:authorizer => authorizer)))
       end
 
       original

--- a/app/models/concerns/foreman_remote_execution/user_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/user_extensions.rb
@@ -4,6 +4,7 @@ module ForemanRemoteExecution
 
     included do
       has_many :targetings, :dependent => :nullify
+      has_many :job_actions, dependent: :destroy
     end
   end
 end

--- a/app/models/job_action.rb
+++ b/app/models/job_action.rb
@@ -2,9 +2,10 @@ class JobAction < ApplicationRecord
   include Authorizable
 
   belongs_to :job_template
+  belongs_to :user
+  before_validation :set_user
 
-  validates :job_template, presence: true
-  validates :name, presence: true, uniqueness: true
+  validates :name, :job_template, :user, presence: true
 
   def template_name
     self.job_template.name
@@ -16,5 +17,9 @@ class JobAction < ApplicationRecord
 
   def provider
     self.job_template.provider_type
+  end
+
+  def set_user
+    self.user = User.current
   end
 end

--- a/app/models/job_action.rb
+++ b/app/models/job_action.rb
@@ -1,0 +1,20 @@
+class JobAction < ApplicationRecord
+  include Authorizable
+
+  belongs_to :job_template
+
+  validates :job_template, presence: true
+  validates :name, presence: true, uniqueness: true
+
+  def template_name
+    self.job_template.name
+  end
+
+  def category
+    self.job_template.job_category
+  end
+
+  def provider
+    self.job_template.provider_type
+  end
+end

--- a/app/views/job_actions/_form.html.erb
+++ b/app/views/job_actions/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-8">
 <%= form_for @job_action, html: { id: 'job_action_form' } do |f| %>
   <%= text_f f, :name %>
-  <%= selectable_f f, :job_template_id, JobTemplate.all.map { |t| [t.name, t.id] },
+  <%= selectable_f f, :job_template_id, JobTemplate.authorized(:view_job_templates).map { |t| [t.name, t.id] },
                   { selected: @job_action.job_template_id, include_blank: false },
                     label: _('Job Template') %>
   <%= submit_or_cancel f %>

--- a/app/views/job_actions/_form.html.erb
+++ b/app/views/job_actions/_form.html.erb
@@ -1,0 +1,9 @@
+<div class="col-md-8">
+<%= form_for @job_action, html: { id: 'job_action_form' } do |f| %>
+  <%= text_f f, :name %>
+  <%= selectable_f f, :job_template_id, JobTemplate.all.map { |t| [t.name, t.id] },
+                  { selected: @job_action.job_template_id, include_blank: false },
+                    label: _('Job Template') %>
+  <%= submit_or_cancel f %>
+<% end %>
+</div>

--- a/app/views/job_actions/edit.erb
+++ b/app/views/job_actions/edit.erb
@@ -1,0 +1,2 @@
+<% title _("Job Action") %>
+<%= render partial: 'form' %>

--- a/app/views/job_actions/index.html.erb
+++ b/app/views/job_actions/index.html.erb
@@ -5,9 +5,9 @@
   <thead>
     <tr>
       <th class="col-md-2"><%= sort :name, :as => s_("JobAction|Name") %></th>
-      <th class="">Template</th>
-      <th class="">Category</th>
-      <th class="">Provider</th>
+      <th class=""><%= _('Template') %></th>
+      <th class=""><%= _('Category') %></th>
+      <th class=""><%= _('Provider') %></th>
       <th class="col-md-1"><%= _('Actions') %></th>
     </tr>
   </thead>
@@ -15,7 +15,6 @@
     <% @job_actions.each do |job_action| %>
       <% btns = [
             display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(template_id: job_action.job_template.id)),
-            display_link_if_authorized(_('Clone'), hash_for_new_job_action_path(name: job_action.name, job_template_id: job_action.job_template.id)),
             display_delete_if_authorized(hash_for_job_action_path(id: job_action).merge(auth_object: job_action, authorizer: authorizer), data: { confirm: _("Delete %s?") % job_action.name })
           ]
       %>

--- a/app/views/job_actions/index.html.erb
+++ b/app/views/job_actions/index.html.erb
@@ -1,0 +1,35 @@
+<% title _("Job Actions") %>
+<% title_actions new_link(_("Create Job Action")) %>
+
+<table class="<%= table_css_classes('table-fixed') %>">
+  <thead>
+    <tr>
+      <th class="col-md-2"><%= sort :name, :as => s_("JobAction|Name") %></th>
+      <th class="">Template</th>
+      <th class="">Category</th>
+      <th class="">Provider</th>
+      <th class="col-md-1"><%= _('Actions') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @job_actions.each do |job_action| %>
+      <% btns = [
+            display_link_if_authorized(_('Run'), hash_for_new_job_invocation_path(template_id: job_action.job_template.id)),
+            display_link_if_authorized(_('Clone'), hash_for_new_job_action_path(name: job_action.name, job_template_id: job_action.job_template.id)),
+            display_delete_if_authorized(hash_for_job_action_path(id: job_action).merge(auth_object: job_action, authorizer: authorizer), data: { confirm: _("Delete %s?") % job_action.name })
+          ]
+      %>
+      <tr>
+        <td class="">
+          <%= link_to(job_action.name, job_action_path(job_action)) %>
+        </td>
+        <td><%= job_action.template_name %></td>
+        <td><%= job_action.category %></td>
+        <td><%= job_action.provider %></td>
+        <td align='center'>
+          <%= action_buttons(btns) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/job_actions/new.html.erb
+++ b/app/views/job_actions/new.html.erb
@@ -1,0 +1,2 @@
+<% title _("New Job Action") %>
+<%= render partial: 'form' %>

--- a/app/views/job_actions/show.html.erb
+++ b/app/views/job_actions/show.html.erb
@@ -1,0 +1,2 @@
+<% title _("Job Action") %>
+<%= render partial: 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
   end
   get 'cockpit/redirect', to: 'cockpit#redirect'
 
+  resources :job_actions, except: [:edit]
+
   namespace :api, :defaults => {:format => 'json'} do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       resources :job_invocations, :except => [:new, :edit, :update, :destroy] do

--- a/db/migrate/20200527120721_add_job_action.rb
+++ b/db/migrate/20200527120721_add_job_action.rb
@@ -1,0 +1,8 @@
+class AddJobAction < ActiveRecord::Migration[6.0]
+  def change
+    create_table :job_actions do |t|
+      t.string :name, null: false, limit: 255
+      t.references :job_template, null: false
+    end
+  end
+end

--- a/db/migrate/20200527120721_add_job_action.rb
+++ b/db/migrate/20200527120721_add_job_action.rb
@@ -3,6 +3,7 @@ class AddJobAction < ActiveRecord::Migration[6.0]
     create_table :job_actions do |t|
       t.string :name, null: false, limit: 255
       t.references :job_template, null: false
+      t.references :user, null: false
     end
   end
 end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -84,7 +84,7 @@ module ForemanRemoteExecution
           # Job Action permissions
           permission :view_job_actions, { job_actions: [:show, :index] }, resource_type: 'JobAction'
           permission :create_job_actions, { job_actions: [:new, :create] }, resource_type: 'JobAction'
-          permission :edit_job_actions, { job_actions: [:edit, :update] }, resource_type: 'JobAction'
+          permission :edit_job_actions, { job_actions: [:update] }, resource_type: 'JobAction'
           permission :destroy_job_actions, { job_actions: [:destroy] }, resource_type: 'JobAction'
         end
 
@@ -96,6 +96,9 @@ module ForemanRemoteExecution
           :view_hosts,
           :view_smart_proxies,
           :view_job_actions,
+          :create_job_actions,
+          :edit_job_actions,
+          :destroy_job_actions,
         ].freeze
         MANAGER_PERMISSIONS = USER_PERMISSIONS + [
           :cancel_job_invocations,
@@ -106,9 +109,6 @@ module ForemanRemoteExecution
           :view_audit_logs,
           :filter_autocompletion_for_template_invocation,
           :edit_remote_execution_features,
-          :create_job_actions,
-          :edit_job_actions,
-          :destroy_job_actions,
         ]
 
         # Add a new role called 'Remote Execution User ' if it doesn't exist

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -80,6 +80,12 @@ module ForemanRemoteExecution
           permission :filter_autocompletion_for_template_invocation, { :template_invocations => [ :auto_complete_search, :index ] },
             :resource_type => 'TemplateInvocation'
           permission :cockpit_hosts, { 'cockpit' => [:redirect, :host_ssh_params] }, :resource_type => 'Host'
+
+          # Job Action permissions
+          permission :view_job_actions, { job_actions: [:show, :index] }, resource_type: 'JobAction'
+          permission :create_job_actions, { job_actions: [:new, :create] }, resource_type: 'JobAction'
+          permission :edit_job_actions, { job_actions: [:edit, :update] }, resource_type: 'JobAction'
+          permission :destroy_job_actions, { job_actions: [:destroy] }, resource_type: 'JobAction'
         end
 
         USER_PERMISSIONS = [
@@ -89,6 +95,7 @@ module ForemanRemoteExecution
           :create_template_invocations,
           :view_hosts,
           :view_smart_proxies,
+          :view_job_actions,
         ].freeze
         MANAGER_PERMISSIONS = USER_PERMISSIONS + [
           :cancel_job_invocations,
@@ -99,6 +106,9 @@ module ForemanRemoteExecution
           :view_audit_logs,
           :filter_autocompletion_for_template_invocation,
           :edit_remote_execution_features,
+          :create_job_actions,
+          :edit_job_actions,
+          :destroy_job_actions,
         ]
 
         # Add a new role called 'Remote Execution User ' if it doesn't exist
@@ -113,11 +123,18 @@ module ForemanRemoteExecution
           caption: N_('Job templates'),
           parent: :hosts_menu,
           after: :provisioning_templates
+
         menu :admin_menu, :remote_execution_features,
           url_hash: { controller: :remote_execution_features, action: :index },
           caption: N_('Remote Execution Features'),
           parent: :administer_menu,
           after: :bookmarks
+
+        menu :admin_menu, :job_actions,
+          url_hash: { controller: :job_actions, action: :index },
+          caption: N_('Job Actions'),
+          parent: :administer_menu,
+          after: :remote_execution_features
 
         menu :top_menu, :job_invocations,
           url_hash: { controller: :job_invocations, action: :index },

--- a/test/factories/foreman_remote_execution_factories.rb
+++ b/test/factories/foreman_remote_execution_factories.rb
@@ -100,6 +100,12 @@ FactoryBot.define do
     f.sequence(:label) { |n| "remote_execution_feature_#{n}" }
     f.sequence(:name) { |n| "Remote Execution Feature #{n}" }
   end
+
+  factory :job_action do
+    sequence(:name) { |n| "Job Action #{n}" }
+    job_template
+    user
+  end
 end
 
 FactoryBot.modify do

--- a/test/functional/job_actions_controller_test.rb
+++ b/test/functional/job_actions_controller_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'test_plugin_helper'
+
+class JobActionsControllerTest < ActionController::TestCase
+  setup do
+    as_admin { @user = FactoryBot.create(:user, :admin, :with_mail) }
+    @action = as_user(@user) { FactoryBot.create(:job_action, job_template: FactoryBot.create(:job_template)) }
+  end
+
+  test 'should get index' do
+    get :index, session: set_session_user(@user)
+    assert_response :success
+    assert_equal @action, assigns(:job_actions).first
+    assert_equal 1, assigns(:job_actions).size
+  end
+
+  test 'should get show' do
+    get :show, params: { id: @action.id }, session: set_session_user(@user)
+    assert_response :success
+  end
+
+  test "should see only user's actions - #show" do
+    as_admin { @user2 = FactoryBot.create(:user, :admin, :with_mail) }
+    action2 = as_user(@user2) { FactoryBot.create(:job_action, job_template: FactoryBot.create(:job_template)) }
+
+    get :show, params: { id: action2.id }, session: set_session_user(@user)
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
**Description**
Cu has a number of common jobs that they run. Having a quick link to the most common jobs would improve my workflow and help with initial training.

**Feature**
* New section Administer > Job Actions
* Created actions are available on _All hosts_ page and at _Host detail_ page
* Created actions are private, for current user only.

**Links:**
- [Discourse RFC](https://community.theforeman.org/t/remote-execution-user-customizable-quick-links/19121)
- [Redmine](https://projects.theforeman.org/issues/27463)