### PR TITLE
RM#29972 - API::JobInvocations - Host permissions

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -20,6 +20,9 @@ module Api
       param :id, :identifier, :required => true
       def show
         @hosts = @job_invocation.targeting.hosts.authorized(:view_hosts, Host)
+        @template_invocations = @job_invocation.template_invocations
+                                               .where(host: @hosts)
+                                               .includes(:input_values)
       end
 
       def_param_group :job_invocation do

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -19,6 +19,7 @@ module Api
       api :GET, '/job_invocations/:id', N_('Show job invocation')
       param :id, :identifier, :required => true
       def show
+        @hosts = @job_invocation.targeting.hosts.authorized(:view_hosts, Host)
       end
 
       def_param_group :job_invocation do
@@ -146,7 +147,7 @@ module Api
       end
 
       def find_host
-        @host = Host.authorized(:view_hosts).find(params['host_id'])
+        @host = @nested_obj.targeting.hosts.authorized(:view_hosts, Host).find(params['host_id'])
       rescue ActiveRecord::RecordNotFound
         not_found({ :error => { :message => (_("Host with id '%{id}' was not found") % { :id => params['host_id'] }) } })
       end

--- a/app/controllers/api/v2/template_invocations_controller.rb
+++ b/app/controllers/api/v2/template_invocations_controller.rb
@@ -26,7 +26,10 @@ module Api
       private
 
       def resource_scope_for_template_invocations
-        @job_invocation.template_invocations.search_for(*search_options)
+        @job_invocation.template_invocations
+                       .includes(:host)
+                       .where(host: Host.authorized(:view_hosts, Host))
+                       .search_for(*search_options)
       end
 
       def find_job_invocation

--- a/app/helpers/job_invocations_helper.rb
+++ b/app/helpers/job_invocations_helper.rb
@@ -29,7 +29,7 @@ module JobInvocationsHelper
   end
 
   def preview_hosts(template_invocation)
-    hosts = template_invocation.targeting.hosts.take(20)
+    hosts = template_invocation.targeting.hosts.authorized(:view_hosts, Host).take(20)
     hosts.map do |host|
       collapsed_preview(host) +
         render(:partial => 'job_invocations/user_input',

--- a/app/views/api/v2/job_invocations/main.json.rabl
+++ b/app/views/api/v2/job_invocations/main.json.rabl
@@ -28,7 +28,7 @@ child :task do
   attributes :id, :state
 end
 
-child :template_invocations do
+child @template_invocations do
   attributes :template_id, :template_name
   child :input_values do
     attributes :template_input_name, :template_input_id

--- a/app/views/api/v2/job_invocations/main.json.rabl
+++ b/app/views/api/v2/job_invocations/main.json.rabl
@@ -19,7 +19,7 @@ child :targeting do
   attributes :bookmark_id, :search_query, :targeting_type, :user_id, :status, :status_label,
     :randomized_ordering
 
-  child :hosts do
+  child @hosts do
     extends 'api/v2/hosts/base'
   end
 end


### PR DESCRIPTION
Fixed API endpoints:
* `show` - Now `@hosts` are filtered based on user's permissions.
* `output` - Now looking for host in Job Invocation scope plus checking if user is authorized to see host's results.
* `raw_output` - same as for `output`