### PR TITLE
Fixes #30206 - Targeting hosts - Search & pagination as React components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        foreman-core-branch: [2.1-stable, develop]
+        foreman-core-branch: [develop]
         ruby-version: [2.5, 2.6]
         node-version: [12]
     steps:

--- a/app/views/job_invocations/_tab_hosts.html.erb
+++ b/app/views/job_invocations/_tab_hosts.html.erb
@@ -1,24 +1,5 @@
 <% if job_invocation.resolved? %>
-  <%= form_with url: job_invocation_path(job_invocation), method: "get", id: "search-form" do |f| %>
-    <div class="row">
-      <div class="title_filter col-md-6">
-        <div class="input-group">
-            <%= autocomplete_f(f, :search, value: params[:search].try(:squeeze, " "), placeholder: _("Filter") + ' ...', path: hosts_path, only_input: true) %>
-            <span class="input-group-btn">
-              <button class="btn btn-default" type="submit">
-                <%= icon_text('search', content_tag(:span, _('Search'), :class => 'hidden-xs', :kind => 'fa')) %>
-              </button>
-            </span>
-        </div>
-      </div>
-    </div>
-  <% end %>
-  <br>
-
-  <div id="targeting_hosts">
-    <%= mount_react_component('TargetingHosts', '#targeting_hosts') %>
-  </div>
-  <%= will_paginate_with_info @hosts, :container => true %>
+  <%= react_component('TargetingHosts' ) %>
 <% else %>
   <div class="alert alert-warning">
     <%=

--- a/app/views/job_invocations/show.html.erb
+++ b/app/views/job_invocations/show.html.erb
@@ -2,6 +2,9 @@
 <% stylesheet 'foreman_remote_execution/foreman_remote_execution' %>
 <% javascript 'charts', 'foreman_remote_execution/template_invocation' %>
 <% javascript *webpack_asset_paths('foreman_remote_execution', :extension => 'js') %>
+<% content_for(:stylesheets) do %>
+  <%= webpacked_plugins_css_for :foreman_remote_execution %>
+<% end %>
 
 <%= breadcrumbs name_field: 'description' %>
 

--- a/app/views/job_invocations/show.json.erb
+++ b/app/views/job_invocations/show.json.erb
@@ -1,4 +1,5 @@
 {
   "autoRefresh": "<%= @auto_refresh %>",
-  "hosts": <%= targeting_hosts(@job_invocation, @hosts).to_json.html_safe %>
+  "hosts": <%= targeting_hosts(@job_invocation, @hosts).to_json.html_safe %>,
+  "total_hosts": <%= @total_hosts %>
 }

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -44,7 +44,7 @@ module ForemanRemoteExecution
 
     initializer 'foreman_remote_execution.register_plugin', before: :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_remote_execution do
-        requires_foreman '>= 1.25'
+        requires_foreman '>= 2.2'
 
         apipie_documented_controllers ["#{ForemanRemoteExecution::Engine.root}/app/controllers/api/v2/*.rb"]
 

--- a/webpack/__mocks__/foremanReact/components/Pagination/PaginationWrapper.js
+++ b/webpack/__mocks__/foremanReact/components/Pagination/PaginationWrapper.js
@@ -1,0 +1,2 @@
+const PaginationWrapper = () => jest.fn();
+export default PaginationWrapper;

--- a/webpack/__mocks__/foremanReact/components/SearchBar.js
+++ b/webpack/__mocks__/foremanReact/components/SearchBar.js
@@ -1,0 +1,2 @@
+const SearchBar = () => jest.fn();
+export default SearchBar;

--- a/webpack/__mocks__/foremanReact/constants.js
+++ b/webpack/__mocks__/foremanReact/constants.js
@@ -1,3 +1,24 @@
 export const STATUS = {
+  PENDING: 'PENDING',
+  RESOLVED: 'RESOLVED',
   ERROR: 'ERROR',
 };
+
+export const getControllerSearchProps = (
+  controller,
+  id = 'searchBar',
+  canCreate = true
+) => ({
+  controller,
+  autocomplete: {
+    id,
+    searchQuery: '',
+    url: `${controller}/auto_complete_search`,
+    useKeyShortcuts: true,
+  },
+  bookmarks: {
+    url: '/api/bookmarks',
+    canCreate,
+    documentationUrl: `4.1.5Searching`,
+  },
+});

--- a/webpack/__mocks__/foremanReact/redux/API/APISelectors.js
+++ b/webpack/__mocks__/foremanReact/redux/API/APISelectors.js
@@ -1,0 +1,2 @@
+export const selectAPIStatus = () => 'RESOLVED';
+export const selectAPIResponse = state => state;

--- a/webpack/__mocks__/foremanReact/redux/middlewares/IntervalMiddleware/IntervalSelectors.js
+++ b/webpack/__mocks__/foremanReact/redux/middlewares/IntervalMiddleware/IntervalSelectors.js
@@ -1,0 +1,1 @@
+export const selectDoesIntervalExist = () => false;

--- a/webpack/react_app/components/TargetingHosts/TargetingHosts.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHosts.js
@@ -5,8 +5,8 @@ import { LoadingState, Alert } from 'patternfly-react';
 import { STATUS } from 'foremanReact/constants';
 import HostItem from './components/HostItem';
 
-const TargetingHosts = ({ status, items }) => {
-  if (status === STATUS.ERROR) {
+const TargetingHosts = ({ apiStatus, items }) => {
+  if (apiStatus === STATUS.ERROR) {
     return (
       <Alert type="error">
         {__(
@@ -16,8 +16,24 @@ const TargetingHosts = ({ status, items }) => {
     );
   }
 
+  const tableBodyRows = items.length ? (
+    items.map(({ name, link, status, actions }) => (
+      <HostItem
+        key={name}
+        name={name}
+        link={link}
+        status={status}
+        actions={actions}
+      />
+    ))
+  ) : (
+    <tr>
+      <td colSpan="3">{__('No hosts found.')}</td>
+    </tr>
+  );
+
   return (
-    <LoadingState loading={!items.length}>
+    <LoadingState loading={!items.length && apiStatus === STATUS.PENDING}>
       <div>
         <table className="table table-bordered table-striped table-hover">
           <thead>
@@ -27,17 +43,7 @@ const TargetingHosts = ({ status, items }) => {
               <th>{__('Actions')}</th>
             </tr>
           </thead>
-          <tbody>
-            {items.map(host => (
-              <HostItem
-                key={host.name}
-                name={host.name}
-                link={host.link}
-                status={host.status}
-                actions={host.actions}
-              />
-            ))}
-          </tbody>
+          <tbody>{tableBodyRows}</tbody>
         </table>
       </div>
     </LoadingState>
@@ -45,7 +51,7 @@ const TargetingHosts = ({ status, items }) => {
 };
 
 TargetingHosts.propTypes = {
-  status: PropTypes.string.isRequired,
+  apiStatus: PropTypes.string.isRequired,
   items: PropTypes.array.isRequired,
 };
 

--- a/webpack/react_app/components/TargetingHosts/TargetingHostsActions.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsActions.js
@@ -1,8 +1,0 @@
-import { getURI } from 'foremanReact/common/urlHelpers';
-import { get } from 'foremanReact/redux/API';
-import { withInterval } from 'foremanReact/redux/middlewares/IntervalMiddleware';
-import { TARGETING_HOSTS } from './TargetingHostsConsts';
-
-const url = getURI().addQuery('format', 'json');
-export const getData = () =>
-  withInterval(get({ key: TARGETING_HOSTS, url }), 1000);

--- a/webpack/react_app/components/TargetingHosts/TargetingHostsHelpers.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsHelpers.js
@@ -1,0 +1,10 @@
+import { getURI } from 'foremanReact/common/urlHelpers';
+
+export const getApiUrl = (searchQuery, pagination) => {
+  const baseUrl = getURI()
+    .search('')
+    .addQuery('page', pagination.page)
+    .addQuery('per_page', pagination.perPage);
+
+  return searchQuery ? baseUrl.addQuery('search', searchQuery) : baseUrl;
+};

--- a/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Grid } from 'patternfly-react';
+
+import SearchBar from 'foremanReact/components/SearchBar';
+import Pagination from 'foremanReact/components/Pagination/PaginationWrapper';
+import { getControllerSearchProps } from 'foremanReact/constants';
+
+import TargetingHosts from './TargetingHosts';
+import './TargetingHostsPage.scss';
+
+const TargetingHostsPage = ({
+  handleSearch,
+  searchQuery,
+  apiStatus,
+  items,
+  totalHosts,
+  pagination,
+  handlePagination,
+}) => (
+  <div id="targeting_hosts">
+    <Grid.Row>
+      <Grid.Col md={6} className="title_filter">
+        <SearchBar
+          onSearch={query => handleSearch(query)}
+          data={{
+            ...getControllerSearchProps('hosts'),
+            autocomplete: {
+              id: 'targeting_hosts_search',
+              searchQuery,
+              url: '/hosts/auto_complete_search',
+              useKeyShortcuts: true,
+            },
+            bookmarks: {},
+          }}
+        />
+      </Grid.Col>
+    </Grid.Row>
+    <br />
+    <TargetingHosts apiStatus={apiStatus} items={items} />
+    <Pagination
+      viewType="list"
+      itemCount={totalHosts}
+      pagination={pagination}
+      onChange={args => handlePagination(args)}
+      dropdownButtonId="targeting-hosts-pagination-dropdown"
+      className="targeting-hosts-pagination"
+    />
+  </div>
+);
+
+TargetingHostsPage.propTypes = {
+  handleSearch: PropTypes.func.isRequired,
+  searchQuery: PropTypes.string.isRequired,
+  apiStatus: PropTypes.string.isRequired,
+  items: PropTypes.array.isRequired,
+  totalHosts: PropTypes.number.isRequired,
+  pagination: PropTypes.object.isRequired,
+  handlePagination: PropTypes.func.isRequired,
+};
+
+export default TargetingHostsPage;

--- a/webpack/react_app/components/TargetingHosts/TargetingHostsPage.scss
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsPage.scss
@@ -1,0 +1,6 @@
+.targeting-hosts-pagination {
+  margin-top: -7px;
+}
+#targeting_hosts {
+  min-height: 350px;
+}

--- a/webpack/react_app/components/TargetingHosts/TargetingHostsSelectors.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsSelectors.js
@@ -2,11 +2,19 @@ import {
   selectAPIStatus,
   selectAPIResponse,
 } from 'foremanReact/redux/API/APISelectors';
+import { selectDoesIntervalExist } from 'foremanReact/redux/middlewares/IntervalMiddleware/IntervalSelectors';
+
 import { TARGETING_HOSTS } from './TargetingHostsConsts';
 
 export const selectItems = state =>
   selectAPIResponse(state, TARGETING_HOSTS).hosts || [];
 
 export const selectAutoRefresh = state =>
-  selectAPIResponse(state, TARGETING_HOSTS).autoRefresh;
-export const selectStatus = state => selectAPIStatus(state, TARGETING_HOSTS);
+  selectAPIResponse(state, TARGETING_HOSTS).autoRefresh || '';
+
+export const selectApiStatus = state => selectAPIStatus(state, TARGETING_HOSTS);
+export const selectTotalHosts = state =>
+  selectAPIResponse(state, TARGETING_HOSTS).total_hosts || 0;
+
+export const selectIntervalExists = state =>
+  selectDoesIntervalExist(state, TARGETING_HOSTS);

--- a/webpack/react_app/components/TargetingHosts/__tests__/TargetingHostsPage.test.js
+++ b/webpack/react_app/components/TargetingHosts/__tests__/TargetingHostsPage.test.js
@@ -1,0 +1,9 @@
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+import TargetingHostsPage from '../TargetingHostsPage';
+import { TargetingHostsPageFixtures } from './fixtures';
+
+describe('TargetingHostsPage', () =>
+  testComponentSnapshotsWithFixtures(
+    TargetingHostsPage,
+    TargetingHostsPageFixtures
+  ));

--- a/webpack/react_app/components/TargetingHosts/__tests__/TargetingHostsSelectors.test.js
+++ b/webpack/react_app/components/TargetingHosts/__tests__/TargetingHostsSelectors.test.js
@@ -1,0 +1,26 @@
+import { testSelectorsSnapshotWithFixtures } from '@theforeman/test';
+
+import {
+  selectItems,
+  selectAutoRefresh,
+  selectApiStatus,
+  selectTotalHosts,
+  selectIntervalExists,
+} from '../TargetingHostsSelectors';
+
+const state = {
+  hosts: [],
+  autoRefresh: 'true',
+  total_hosts: 0,
+};
+
+const fixtures = {
+  'should return hosts': () => selectItems(state),
+  'should return autoRefresh': () => selectAutoRefresh(state),
+  'should return apiStatus': () => selectApiStatus(state),
+  'should return totalHosts': () => selectTotalHosts(state),
+  'should return intervalExists': () => selectIntervalExists(state),
+};
+
+describe('TargetingHostsSelectors', () =>
+  testSelectorsSnapshotWithFixtures(fixtures));

--- a/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHosts.test.js.snap
+++ b/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHosts.test.js.snap
@@ -33,6 +33,13 @@ exports[`TargetingHosts renders 1`] = `
           name="host"
           status="success"
         />
+        <HostItem
+          actions={Array []}
+          key="host2"
+          link="/link2"
+          name="host2"
+          status="success"
+        />
       </tbody>
     </table>
   </div>
@@ -74,7 +81,15 @@ exports[`TargetingHosts renders with loading 1`] = `
           </th>
         </tr>
       </thead>
-      <tbody />
+      <tbody>
+        <tr>
+          <td
+            colSpan="3"
+          >
+            No hosts found.
+          </td>
+        </tr>
+      </tbody>
     </table>
   </div>
 </LoadingState>

--- a/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
+++ b/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TargetingHostsPage renders 1`] = `
+<div
+  id="targeting_hosts"
+>
+  <Row
+    bsClass="row"
+    componentClass="div"
+  >
+    <Col
+      bsClass="col"
+      className="title_filter"
+      componentClass="div"
+      md={6}
+    >
+      <SearchBar
+        data={
+          Object {
+            "autocomplete": Object {
+              "id": "targeting_hosts_search",
+              "searchQuery": "",
+              "url": "/hosts/auto_complete_search",
+              "useKeyShortcuts": true,
+            },
+            "bookmarks": Object {},
+            "controller": "hosts",
+          }
+        }
+        onSearch={[Function]}
+      />
+    </Col>
+  </Row>
+  <br />
+  <TargetingHosts
+    apiStatus="RESOLVED"
+    items={
+      Array [
+        Object {
+          "actions": Array [],
+          "link": "/link",
+          "name": "host",
+          "status": "success",
+        },
+        Object {
+          "actions": Array [],
+          "link": "/link2",
+          "name": "host2",
+          "status": "success",
+        },
+      ]
+    }
+  />
+  <PaginationWrapper
+    className="targeting-hosts-pagination"
+    dropdownButtonId="targeting-hosts-pagination-dropdown"
+    itemCount={1}
+    onChange={[Function]}
+    pagination={
+      Object {
+        "page": 1,
+        "perPage": 20,
+      }
+    }
+    viewType="list"
+  />
+</div>
+`;

--- a/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsSelectors.test.js.snap
+++ b/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsSelectors.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TargetingHostsSelectors should return apiStatus 1`] = `"RESOLVED"`;
+
+exports[`TargetingHostsSelectors should return autoRefresh 1`] = `"true"`;
+
+exports[`TargetingHostsSelectors should return hosts 1`] = `Array []`;
+
+exports[`TargetingHostsSelectors should return intervalExists 1`] = `false`;
+
+exports[`TargetingHostsSelectors should return totalHosts 1`] = `0`;

--- a/webpack/react_app/components/TargetingHosts/__tests__/fixtures.js
+++ b/webpack/react_app/components/TargetingHosts/__tests__/fixtures.js
@@ -1,3 +1,18 @@
+const items = [
+  {
+    name: 'host',
+    link: '/link',
+    status: 'success',
+    actions: [],
+  },
+  {
+    name: 'host2',
+    link: '/link2',
+    status: 'success',
+    actions: [],
+  },
+];
+
 export const HostItemFixtures = {
   renders: {
     name: 'Host1',
@@ -15,29 +30,30 @@ export const HostStatusFixtures = {
 
 export const TargetingHostsFixtures = {
   renders: {
-    status: '',
-    items: [
-      {
-        name: 'host',
-        link: '/link',
-        status: 'success',
-        actions: [],
-      },
-    ],
+    apiStatus: 'RESOLVED',
+    items,
   },
   'renders with error': {
-    status: 'ERROR',
-    items: [
-      {
-        name: 'host',
-        link: '/link',
-        status: 'success',
-        actions: [],
-      },
-    ],
+    apiStatus: 'ERROR',
+    items,
   },
   'renders with loading': {
-    status: '',
+    apiStatus: 'PENDING',
     items: [],
+  },
+};
+
+export const TargetingHostsPageFixtures = {
+  renders: {
+    handleSearch: () => {},
+    searchQuery: '',
+    apiStatus: 'RESOLVED',
+    items,
+    totalHosts: 1,
+    pagination: {
+      page: 1,
+      perPage: 20,
+    },
+    handlePagination: () => {},
   },
 };


### PR DESCRIPTION
Requires https://github.com/theforeman/foreman/pull/7771

* Searching and pagination is now done in React way --> No page reloads
* Fixed issue with Loading spinner: when no items were found, loading spinner was displayed instead of message `No hosts found`
* `job_invocations_controller.rb#show` refactored, resources for Targeting hosts table are loaded only when they are needed.