### PR TITLE
Fixes #30213 - long host list breaks page

### DIFF
--- a/app/assets/stylesheets/foreman_remote_execution/job_invocations.scss
+++ b/app/assets/stylesheets/foreman_remote_execution/job_invocations.scss
@@ -1,9 +1,6 @@
-div.infoblock {
-  margin-bottom: 20px;
-  line-height: 2;
-
+.target-hosts-card {
   pre {
-    margin-top: 5px;
+    white-space:pre-line;
   }
 }
 

--- a/app/views/job_invocations/_card_target_hosts.html.erb
+++ b/app/views/job_invocations/_card_target_hosts.html.erb
@@ -1,5 +1,5 @@
 <% template_invocations = job_invocation.pattern_template_invocations %>
-<div class="card-pf card-pf-accented">
+<div class="card-pf card-pf-accented target-hosts-card">
   <div class="card-pf-title">
     <h2 style="height: 18px;" class="card-pf-title">
       <%= _('Target hosts') %>


### PR DESCRIPTION
in job invocations long host list breaks page, the page is too long to really use or understand when there are too many hosts in the list.
`infoblock` class was removed a long time ago.

before:
![Screenshot from 2020-06-25 12-42-22](https://user-images.githubusercontent.com/30431079/85696919-0589c300-b6e2-11ea-81b8-8078ef9e87b5.png)
After
![Screenshot from 2020-06-25 12-47-15](https://user-images.githubusercontent.com/30431079/85696911-04589600-b6e2-11ea-94a7-c5386cb00cc8.png)