### PR TITLE
Fixes #30225 - Make ssh debug logging show useful data

### DIFF
--- a/lib/foreman_remote_execution_core.rb
+++ b/lib/foreman_remote_execution_core.rb
@@ -32,7 +32,9 @@ module ForemanRemoteExecutionCore
       raise "Wrong value '#{@settings[:ssh_log_level]}' for ssh_log_level, must be one of #{SSH_LOG_LEVELS.join(', ')}"
     end
 
-    current = if defined?(SmartProxyDynflowCore)
+    current = if defined?(::Proxy::SETTINGS)
+                ::Proxy::SETTINGS.log_level.to_s.downcase
+              elsif defined?(SmartProxyDynflowCore)
                 SmartProxyDynflowCore::SETTINGS.log_level.to_s.downcase
               else
                 Rails.configuration.log_level.to_s

--- a/lib/foreman_remote_execution_core/log_filter.rb
+++ b/lib/foreman_remote_execution_core/log_filter.rb
@@ -4,11 +4,11 @@ module ForemanRemoteExecutionCore
       @base_logger = base_logger
     end
 
-    def add(severity, *args)
+    def add(severity, *args, &block)
       severity ||= ::Logger::UNKNOWN
       return true if @base_logger.nil? || severity < @level
 
-      @base_logger.add(severity, *args)
+      @base_logger.add(severity, *args, &block)
     end
   end
 end


### PR DESCRIPTION
When debug ssh logging is enabled, it passes a facility as an argument
and a block to the logger. Our implementation of log filter, which
allows only messages of required severity (or higher) to be logger
discarded the block. For this reason, log messages showed only
facility, which wasn't really useful in any way.