### PR TITLE
Fixes #30399 - Fix error when deleting discovered hosts

### DIFF
--- a/app/models/concerns/foreman_remote_execution/orchestration/ssh.rb
+++ b/app/models/concerns/foreman_remote_execution/orchestration/ssh.rb
@@ -29,7 +29,10 @@ module ForemanRemoteExecution
       logger.debug "Scheduling SSH known_hosts cleanup"
 
       host, _kind, _target = host_kind_target
-      proxies = host.remote_execution_proxies('SSH').values
+      # #remote_execution_proxies may not be defined on the host object in some case
+      # for example Host::Discovered does not have it defined, even though these hosts
+      # have Nic::Managed interfaces associated with them
+      proxies = (host.try(:remote_execution_proxies, 'SSH') || {}).values
       proxies.flatten.uniq.each do |proxy|
         queue.create(id: queue_id(proxy.id), name: _("Remove SSH known hosts for %s") % self,
           priority: 200, action: [self, :drop_from_known_hosts, proxy.id])


### PR DESCRIPTION
We hook onto Host::Managed and Nic::Managed destroy to perform the ssh known
host key removal. However, we use the host as a base from which we figure out
from which proxies the keys should be removed. Because discovered hosts have
managed nics, but do not implement #remote_execution_proxies, the error
undefined method `remote_execution_proxies` was raised when deleting discovered
hosts.