### PR TITLE
Fixes #30628 - show empty hosts in job invocation api cp 3.3

### DIFF
--- a/app/views/api/v2/job_invocations/main.json.rabl
+++ b/app/views/api/v2/job_invocations/main.json.rabl
@@ -19,7 +19,7 @@ child :targeting do
   attributes :bookmark_id, :search_query, :targeting_type, :user_id, :status, :status_label,
     :randomized_ordering
 
-  child @hosts do
+  child @hosts => :hosts do
     extends 'api/v2/hosts/base'
 
     if params[:host_status] == 'true'

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -44,7 +44,7 @@ module Api
           get :show, params: { :id => @invocation.id }, session: set_session_user(@user)
           assert_response :success
           response = ActiveSupport::JSON.decode(@response.body)
-          assert_empty response['targeting']['hosts']
+          assert_equal response['targeting']['hosts'], []
         end
       end
 


### PR DESCRIPTION
(cherry picked from commit 428e04423e3fdcbfc023d702b2c5dd7c4c5cb5dd)