### PR TITLE
Fixes #22187 - Show correct job stats

### DIFF
--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -57,7 +57,8 @@ module Actions
       end
 
       def job_invocation
-        @job_invocation ||= JobInvocation.find(input[:job_invocation_id])
+        id = input[:job_invocation_id] || input.fetch(:job_invocation, {})[:id]
+        @job_invocation ||= JobInvocation.find(id)
       end
 
       def batch(from, size)
@@ -65,7 +66,7 @@ module Actions
       end
 
       def total_count
-        hosts.count
+        output[:total_count] || hosts.count
       end
 
       def hosts

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -173,7 +173,7 @@ class JobInvocation < ApplicationRecord
 
   def total_hosts_count
     if targeting.resolved?
-      targeting.hosts.count
+      task.main_action&.total_count || 0
     else
       _('N/A')
     end

--- a/app/views/job_invocations/_tab_overview.html.erb
+++ b/app/views/job_invocations/_tab_overview.html.erb
@@ -9,7 +9,18 @@
   <% template_invocations.each do |template_invocation| %>
     <%= minicard('user', template_invocation.effective_user || Setting[:remote_execution_effective_user],
                  template_invocation.template.name + ' ' + _('effective user')) %>
-    <%= minicard('cluster', job_invocation.total_hosts_count, _('Total hosts')) %>
+    <div class="row">
+      <% missing = job_invocation.total_hosts_count - job_invocation.targeting.hosts.count %>
+      <% size = missing.zero? ? 12 : 6 %>
+      <div class="col-xs-12 col-sm-<%= size %> col-md-<%= size %>" >
+        <%= minicard('cluster', job_invocation.total_hosts_count, _('Total hosts')) %>
+      </div>
+      <% unless missing.zero? %>
+      <div class="col-xs-12 col-sm-6 col-md-6" >
+        <%= minicard('warning-triangle-o', missing, _('Hosts gone missing')) %>
+      </div>
+    <% end %>
+    </div>
     <% if template_invocation.input_values.present? %>
       <%= render :partial => 'card_user_input', :locals => { :template_invocation => template_invocation } %>
     <% end %>


### PR DESCRIPTION
When a host gets deleted after a job was run:
- the chart and index shows the full count of hosts on which the job originally run, including the deleted one
- total hosts card splits into two, shows how many hosts are gone
- table shows only present hosts

![image](https://user-images.githubusercontent.com/7326770/90513375-d5015b00-e15f-11ea-9252-7b4f7f0e9524.png)
