### PR TITLE
Fixes #20689 - make REX interface accessible by API

### DIFF
--- a/app/models/concerns/api/v2/interfaces_controller_extensions.rb
+++ b/app/models/concerns/api/v2/interfaces_controller_extensions.rb
@@ -1,0 +1,13 @@
+module Api
+  module V2
+    module InterfacesControllerExtensions
+      extend Apipie::DSL::Concern
+
+      update_api(:create, :update) do
+        param :interface, Hash do
+          param :execution, :bool, :desc => N_('Should this interface be used for remote execution?')
+        end
+      end
+    end
+  end
+end

--- a/app/views/api/v2/interfaces/execution_flag.json.rabl
+++ b/app/views/api/v2/interfaces/execution_flag.json.rabl
@@ -1,0 +1,1 @@
+attributes :execution

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -138,6 +138,7 @@ module ForemanRemoteExecution
         end
 
         extend_rabl_template 'api/v2/smart_proxies/main', 'api/v2/smart_proxies/pubkey'
+        extend_rabl_template 'api/v2/interfaces/main', 'api/v2/interfaces/execution_flag'
         describe_host { overview_buttons_provider :host_overview_buttons }
       end
     end
@@ -184,6 +185,7 @@ module ForemanRemoteExecution
       SmartProxy.prepend ForemanRemoteExecution::SmartProxyExtensions
       Subnet.include ForemanRemoteExecution::SubnetExtensions
 
+      ::Api::V2::InterfacesController.include Api::V2::InterfacesControllerExtensions
       # We need to explicitly force to load the Task model due to Rails loader
       # having issues with resolving it to Rake::Task otherwise
       require_dependency 'foreman_tasks/task'


### PR DESCRIPTION
adds 'execution' attribute to https://foreman/api/hosts/host_id/interfaces