### PR TITLE
Fixes #30808 - Use IPv6-proxy if no IPv4-proxy

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -56,7 +56,10 @@ module ForemanRemoteExecution
 
     def remote_execution_proxies(provider, authorized = true)
       proxies = {}
-      proxies[:subnet]   = execution_interface.subnet.remote_execution_proxies.with_features(provider) if execution_interface&.subnet
+      proxies[:subnet] = []
+      proxies[:subnet] += execution_interface.subnet6.remote_execution_proxies.with_features(provider) if execution_interface&.subnet6
+      proxies[:subnet] += execution_interface.subnet.remote_execution_proxies.with_features(provider) if execution_interface&.subnet
+      proxies[:subnet].uniq!
       proxies[:fallback] = smart_proxies.with_features(provider) if Setting[:remote_execution_fallback_proxy]
 
       if Setting[:remote_execution_global_proxy]


### PR DESCRIPTION
It would also be possible to add the IPv6-subnet as `:subnet6`, but this would require adding `:subnet6` to the [`strategy`-list in Foreman-Tasks](https://github.com/theforeman/foreman-tasks/blob/904c07ca7f2be446e5453eeb271f9c4bc98628de/app/services/foreman_tasks/proxy_selector.rb#L11).

I would like to put this up for discussion :-)