### PR TITLE
Fixes #30859 - Prevent job from getting stuck after first batch

### DIFF
--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -73,6 +73,7 @@ module Actions
       def total_count
         # For compatibility with already existing tasks
         return output[:total_count] unless output.has_key?(:host_count) || task.pending?
+
         output[:host_count] || hosts.count
       end
 

--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -65,8 +65,15 @@ module Actions
         hosts.offset(from).limit(size)
       end
 
+      def initiate
+        output[:host_count] = total_count
+        super
+      end
+
       def total_count
-        output[:total_count] || hosts.count
+        # For compatibility with already existing tasks
+        return output[:total_count] unless output.has_key?(:host_count) || task.pending?
+        output[:host_count] || hosts.count
       end
 
       def hosts

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -24,6 +24,7 @@ module ForemanRemoteExecution
       OpenStruct.new(:id => uuid).tap do |o|
         o.stubs(:add_missing_task_groups)
         o.stubs(:task_groups).returns([])
+        o.stubs(:pending?).returns(true)
       end
     end
     let(:action) do


### PR DESCRIPTION
By accounting for missing hosts in a job we broke running jobs on hosts past
first batch. There is a module which periodically polls states of sub-tasks and
overwrites then numbers we were using to decide whether to spawn next batch or
not.

With this change we store the expected total count under a different key in
task's output so it won't get overwritten by the included polling module. For
compatibility with already existing jobs we use the value under the original key
in task's output in case the task doesn't have the value set under the new key.