### PR TITLE
Refs #30816 - Show host id for template input

### DIFF
--- a/app/views/api/v2/job_invocations/main.json.rabl
+++ b/app/views/api/v2/job_invocations/main.json.rabl
@@ -35,7 +35,7 @@ child :task do
 end
 
 child @template_invocations do
-  attributes :template_id, :template_name
+  attributes :template_id, :template_name, :host_id
   child :input_values do
     attributes :template_input_name, :template_input_id
     node :value do |iv|


### PR DESCRIPTION
Each template invocation was in this structure with no way of knowing which host it belongs to:
```
 {
      "template_id": 175,
      "template_name": "Package Action - Ansible Default",
      "template_invocation_input_values": [
        {
          "template_input_name": "state",
          "template_input_id": 76,
          "value": "present"
        },
    },
```
after this pr:
```
 {
      "template_id": 175,
      "template_name": "Package Action - Ansible Default",
      "host_id": 94,
      "template_invocation_input_values": [
        {
          "template_input_name": "state",
          "template_input_id": 76,
          "value": "present"
        },
    },
```
Blocking https://github.com/theforeman/hammer_cli_foreman_remote_execution/pull/36