### PR TITLE
Resolve issue when viewing successful job invocation

### DIFF
--- a/app/views/template_invocations/_output_line_set.html.erb
+++ b/app/views/template_invocations/_output_line_set.html.erb
@@ -1,7 +1,7 @@
 <% output_line_set['output'].gsub("\r\n", "\n").sub(/\n\Z/, '').split("\n", -1).each do |line| %>
   <%= content_tag :div, :class => 'line ' + output_line_set['output_type'], :data => { :timestamp => output_line_set['timestamp'] } do %>
 
-    <%= content_tag(:span, (@line_counter += 1).to_s.rjust(4).gsub(' ', '&nbsp;').html_safe + ':', :class => 'counter', :title => (output_line_set['timestamp'] && Time.at(output_line_set['timestamp']))) %>
+    <%= content_tag(:span, (@line_counter += 1).to_s.rjust(4).gsub(' ', '&nbsp;').html_safe + ':', :class => 'counter', :title => (output_line_set['timestamp'] && Time.at(output_line_set['timestamp'].to_f))) %>
     <%= content_tag(:div, colorize_line(line.gsub(JobInvocationOutputHelper::COLOR_PATTERN, '').empty? ? "#{line}\n" : line).html_safe, :class => 'content') %>
   <% end %>
 <% end %>


### PR DESCRIPTION
`Time.at` is being passed in a string value which results in a "can’t convert String into an exact number" error message whenever you attempt to view the results of a job run on a host.


Another user reported the same issue: https://community.theforeman.org/t/job-invocations-cant-convert-string-into-an-exact-number/18921

![image](https://user-images.githubusercontent.com/32345766/94760115-2444d780-03fe-11eb-8844-4956a47d3ccb.png)
