### PR TITLE
Fixes #31116 - add exprimental page for job wizard

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,8 @@ Rails.application.routes.draw do
   get 'cockpit/redirect', to: 'cockpit#redirect'
   get 'ui_job_wizard/categories', to: 'ui_job_wizard#categories'
 
+  match '/experimental/job_wizard', to: 'react#index', :via => [:get]
+
   namespace :api, :defaults => {:format => 'json'} do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       resources :job_invocations, :except => [:new, :edit, :update, :destroy] do

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -53,6 +53,7 @@ module ForemanRemoteExecution
 
     initializer 'foreman_remote_execution.register_plugin', before: :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_remote_execution do
+        register_global_js_file 'global'
         requires_foreman '>= 2.2'
 
         apipie_documented_controllers ["#{ForemanRemoteExecution::Engine.root}/app/controllers/api/v2/*.rb"]
@@ -137,6 +138,13 @@ module ForemanRemoteExecution
           caption: N_('Jobs'),
           parent: :monitor_menu,
           after: :audits
+
+        menu :labs_menu, :job_wizard,
+          url_hash: { controller: 'job_wizard', action: :index },
+          caption: N_('Job wizard'),
+          parent: :lab_features_menu,
+          url: 'experimental/job_wizard',
+          after: :host_wizard
 
         register_custom_status HostStatus::ExecutionStatus
         # add dashboard widget

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Wizard } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import history from 'foremanReact/history';
+
+export const JobWizard = () => {
+  const steps = [
+    {
+      name: __('Category and template'),
+      component: <p>Category and template</p>,
+    },
+    { name: __('Target hosts'), component: <p>TargetHosts </p> },
+    { name: __('Advanced fields'), component: <p> AdvancedFields </p> },
+    { name: __('Schedule'), component: <p>Schedule</p> },
+    {
+      name: __('Review details'),
+      component: <p>ReviewDetails</p>,
+      nextButtonText: 'Run',
+    },
+  ];
+  const title = __('Run Job');
+  return (
+    <Wizard
+      onClose={() => history.goBack()}
+      navAriaLabel={`${title} steps`}
+      steps={steps}
+      height="70vh"
+    />
+  );
+};
+
+export default JobWizard;

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Title, Divider } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
+import { JobWizard } from './JobWizard';
+
+const JobWizardPage = () => {
+  const title = __('Run job');
+  const breadcrumbOptions = {
+    breadcrumbItems: [
+      { caption: __('Jobs'), url: `/jobs` },
+      { caption: title },
+    ],
+  };
+  return (
+    <PageLayout
+      header={title}
+      breadcrumbOptions={breadcrumbOptions}
+      searchable={false}
+    >
+      <React.Fragment>
+        <Title headingLevel="h2" size="2xl">
+          {title}
+        </Title>
+        <Divider component="div" />
+        <JobWizard />
+      </React.Fragment>
+    </PageLayout>
+  );
+};
+
+export default JobWizardPage;

--- a/webpack/Routes/routes.js
+++ b/webpack/Routes/routes.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import JobWizardPage from '../JobWizard';
+
+const ForemanREXRoutes = [
+  {
+    path: '/experimental/job_wizard',
+    exact: true,
+    render: props => <JobWizardPage {...props} />,
+  },
+];
+
+export default ForemanREXRoutes;

--- a/webpack/__mocks__/foremanReact/history.js
+++ b/webpack/__mocks__/foremanReact/history.js
@@ -1,0 +1,1 @@
+export default { goBack: () => null };

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -1,0 +1,4 @@
+import { registerRoutes } from 'foremanReact/routes/RoutingService';
+import routes from './Routes/routes';
+
+registerRoutes('foreman_remote_execution', routes);


### PR DESCRIPTION
A starting page for the PF4 job creation wizard will be in the lab features menu.
It doesn't have any content, yet 
![Screenshot from 2020-10-20 21-31-49](https://user-images.githubusercontent.com/30431079/96629842-d5af9c80-131c-11eb-8c43-9394d76617d6.png)
