### PR TITLE
Fixes #31237 - Extend Registration module with :remote_execution_inteface

### DIFF
--- a/app/controllers/foreman_remote_execution/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/foreman_remote_execution/concerns/api/v2/registration_controller_extensions.rb
@@ -1,12 +1,15 @@
 module ForemanRemoteExecution
   module Concerns
     module Api::V2::RegistrationControllerExtensions
-      extend Apipie::DSL::Concern
-      extend ActiveSupport::Concern
+      module ApipieExtensions
+        extend Apipie::DSL::Concern
 
-      update_api(:global, :host) do
-        param :remote_execution_interface, String, desc: N_("Identifier of the Host interface for Remote execution")
+        update_api(:global, :host) do
+          param :remote_execution_interface, String, desc: N_("Identifier of the Host interface for Remote execution")
+        end
       end
+
+      extend ActiveSupport::Concern
 
       def host_setup_extension
         remote_execution_interface

--- a/app/controllers/foreman_remote_execution/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/foreman_remote_execution/concerns/api/v2/registration_controller_extensions.rb
@@ -1,0 +1,28 @@
+module ForemanRemoteExecution
+  module Concerns
+    module Api::V2::RegistrationControllerExtensions
+      extend Apipie::DSL::Concern
+      extend ActiveSupport::Concern
+
+      update_api(:global, :host) do
+        param :remote_execution_interface, String, desc: N_("Identifier of the Host interface for Remote execution")
+      end
+
+      def host_setup_extension
+        remote_execution_interface
+        super
+      end
+
+      def remote_execution_interface
+        return unless params['remote_execution_interface'].present?
+
+        interfaces = @host.interfaces
+        interfaces.find_by!(identifier: params['remote_execution_interface'])
+
+        # Only one interface at time can be used for REX, all other must be set to false
+        interfaces.each { |int| int.execution = (int.identifier == params['remote_execution_interface']) }
+        interfaces.each(&:save!)
+      end
+    end
+  end
+end

--- a/app/controllers/foreman_remote_execution/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/foreman_remote_execution/concerns/api/v2/registration_controller_extensions.rb
@@ -19,12 +19,7 @@ module ForemanRemoteExecution
       def remote_execution_interface
         return unless params['remote_execution_interface'].present?
 
-        interfaces = @host.interfaces
-        interfaces.find_by!(identifier: params['remote_execution_interface'])
-
-        # Only one interface at time can be used for REX, all other must be set to false
-        interfaces.each { |int| int.execution = (int.identifier == params['remote_execution_interface']) }
-        interfaces.each(&:save!)
+        @host.set_execution_interface(params['remote_execution_interface'])
       end
     end
   end

--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -54,6 +54,17 @@ module ForemanRemoteExecution
       get_interface_by_flag(:execution)
     end
 
+    def set_execution_interface(identifier)
+      if interfaces.find_by(identifier: identifier).nil?
+        msg = (N_("Host's interface '%s' not found.") % identifier)
+        raise ActiveRecord::RecordNotFound, msg
+      end
+
+      # Only one interface at time can be used for REX, all other must be set to false
+      interfaces.each { |int| int.execution = (int.identifier == identifier) }
+      interfaces.each(&:save!)
+    end
+
     def remote_execution_proxies(provider, authorized = true)
       proxies = {}
       proxies[:subnet] = []

--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -56,7 +56,7 @@ module ForemanRemoteExecution
 
     def set_execution_interface(identifier)
       if interfaces.find_by(identifier: identifier).nil?
-        msg = (N_("Host's interface '%s' not found.") % identifier)
+        msg = (N_("Interface with the '%s' identifier was specified as a remote execution interface, however the interface was not found on the host. If the interface exists, it needs to be created in Foreman during the registration.") % identifier)
         raise ActiveRecord::RecordNotFound, msg
       end
 

--- a/app/views/api/v2/registration/_form.html.erb
+++ b/app/views/api/v2/registration/_form.html.erb
@@ -1,0 +1,12 @@
+<div class='form-group'>
+  <label class='col-md-2 control-label'>
+    <%= _('Remote Execution Interface') %>
+    <% help = _('Identifier of the Host interface for Remote execution') %>
+    <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+      <span class="pficon pficon-info "></span>
+    </a>
+  </label>
+  <div class='col-md-4'>
+    <%= text_field_tag 'remote_execution_interface', params[:remote_execution_interface], class: 'form-control' %>
+  </div>
+</div>

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -214,6 +214,7 @@ module ForemanRemoteExecution
 
       ::Api::V2::SubnetsController.include ::ForemanRemoteExecution::Concerns::Api::V2::SubnetsControllerExtensions
       ::Api::V2::RegistrationController.prepend ::ForemanRemoteExecution::Concerns::Api::V2::RegistrationControllerExtensions
+      ::Api::V2::RegistrationController.include ::ForemanRemoteExecution::Concerns::Api::V2::RegistrationControllerExtensions::ApipieExtensions
     end
 
     initializer 'foreman_remote_execution.register_gettext', after: :load_config_initializers do |_app|

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -151,6 +151,12 @@ module ForemanRemoteExecution
         extend_rabl_template 'api/v2/subnets/show', 'api/v2/subnets/remote_execution_proxies'
         parameter_filter ::Subnet, :remote_execution_proxy_ids
         describe_host { overview_buttons_provider :host_overview_buttons }
+
+        # Extend Registration module
+        extend_allowed_registration_vars :remote_execution_interface
+        extend_page 'registration/_form' do |cx|
+          cx.add_pagelet :global_registration, name: N_('Remote Execution'), partial: 'api/v2/registration/form', priority: 100, id: 'remote_execution_interface'
+        end
       end
     end
 
@@ -207,6 +213,7 @@ module ForemanRemoteExecution
       ForemanRemoteExecution.register_rex_feature
 
       ::Api::V2::SubnetsController.include ::ForemanRemoteExecution::Concerns::Api::V2::SubnetsControllerExtensions
+      ::Api::V2::RegistrationController.prepend ::ForemanRemoteExecution::Concerns::Api::V2::RegistrationControllerExtensions
     end
 
     initializer 'foreman_remote_execution.register_gettext', after: :load_config_initializers do |_app|

--- a/test/functional/api/v2/registration_controller_test.rb
+++ b/test/functional/api/v2/registration_controller_test.rb
@@ -1,0 +1,82 @@
+require 'test_plugin_helper'
+
+module Api
+  module V2
+    # Tests for the extra methods to play roles on a Host
+    class RegistrationControllerTest < ActionController::TestCase
+      describe 'host registration' do
+        let(:organization) { FactoryBot.create(:organization) }
+        let(:tax_location) { FactoryBot.create(:location) }
+        let(:template_kind) { template_kinds(:registration) }
+        let(:registration_template) do
+          FactoryBot.create(
+            :provisioning_template,
+            template_kind: template_kind,
+            template: 'template content <%= @host.name %>',
+            locations: [tax_location],
+            organizations: [organization]
+          )
+        end
+        let(:os) do
+          FactoryBot.create(
+            :operatingsystem,
+            :with_associations,
+            family: 'Redhat',
+            provisioning_templates: [
+              registration_template,
+            ]
+          )
+        end
+
+        let(:host_params) do
+          { host: { name: 'centos-test.example.com',
+                    managed: false, build: false,
+                    organization_id: organization.id,
+                    location_id: tax_location.id,
+                    operatingsystem_id: os.id } }
+        end
+
+        setup do
+          FactoryBot.create(
+            :os_default_template,
+            template_kind: template_kind,
+            provisioning_template: registration_template,
+            operatingsystem: os
+          )
+        end
+
+        describe 'remote_execution_interface' do
+          setup do
+            @host = Host.create(host_params[:host])
+            @interface0 = FactoryBot.create(:nic_managed, host: @host, identifier: 'dummy0', execution: false)
+          end
+
+          test 'with existing interface' do
+            params = host_params.merge(remote_execution_interface: @interface0.identifier)
+
+            post :host, params: params, session: set_session_user
+            assert_response :success
+            assert @interface0.reload.execution
+          end
+
+          test 'with not-existing interface' do
+            params = host_params.merge(remote_execution_interface: 'dummy999')
+
+            post :host, params: params, session: set_session_user
+            assert_response :not_found
+          end
+
+          test 'with multiple interfaces' do
+            interface1 = FactoryBot.create(:nic_managed, host: @host, identifier: 'dummy1', execution: false)
+            params = host_params.merge(remote_execution_interface: interface1.identifier)
+
+            post :host, params: params, session: set_session_user
+            assert_response :success
+            refute @interface0.reload.execution
+            assert interface1.reload.execution
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extending Registration module with option to specify which Host's interface is going to be set as primary for REX.
Follow up to https://github.com/theforeman/foreman/pull/8121, which is also requirement for this PR.

**Features**
* Add `:remote_execution_interface` to allowed arguments & variables
* Extend UI Form with field for `:remote_execution_interface` (_All Hosts > Register Host_)
* Set Host REX interface during host registration

**How to test**
* Register host to the Foreman
```
curl -X GET "https://foreman.example.com/register?location_id=2&organization_id=1" --user admin:changeme | bash
```
* Add multiple interfaces (`dummy1`, `dummy2`, `dummy3`)
* In UI generate command again, but this time with specified `remote_execution_interface`
* Run registration again & check that interface for REX have been set correctly

