### PR TITLE
Fixes #31267 - Add recent jobs card to host details page

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -60,7 +60,7 @@ module ForemanRemoteExecution
         ApipieDSL.configuration.dsl_classes_matchers += [
           "#{ForemanRemoteExecution::Engine.root}/app/lib/foreman_remote_execution/renderer/**/*.rb",
         ]
-
+        register_global_js_file 'global'
         automatic_assets(false)
         precompile_assets(*assets_to_precompile)
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "@theforeman/vendor-dev": "^4.14.0",
     "babel-eslint": "^10.0.0",
     "eslint": "^6.8.0",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "@patternfly/react-catalog-view-extension": "^4.8.126"
   },
   "peerDependencies": {
     "@theforeman/vendor": "^8.3.0"

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -1,4 +1,8 @@
 import { registerRoutes } from 'foremanReact/routes/RoutingService';
 import routes from './Routes/routes';
+import registerReducers from './react_app/extend/reducers';
+import registerFills from './react_app/extend/fills';
 
 registerRoutes('foreman_remote_execution', routes);
+registerReducers();
+registerFills();

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -1,8 +1,6 @@
-import { registerReducer } from 'foremanReact/common/MountingService';
 import componentRegistry from 'foremanReact/components/componentRegistry';
 import JobInvocationContainer from './react_app/components/jobInvocations';
 import TargetingHosts from './react_app/components/TargetingHosts';
-import rootReducer from './react_app/redux/reducers';
 
 const components = [
   { name: 'JobInvocationContainer', type: JobInvocationContainer },
@@ -12,5 +10,3 @@ const components = [
 components.forEach(component => {
   componentRegistry.register(component);
 });
-
-registerReducer('foremanRemoteExecutionReducers', rootReducer);

--- a/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
+++ b/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
@@ -1,0 +1,87 @@
+/* eslint-disable camelcase */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+import ElipsisWithTooltip from 'react-ellipsis-with-tooltip';
+
+import { Grid, GridItem } from '@patternfly/react-core';
+import {
+  OkIcon,
+  ErrorCircleOIcon,
+} from '@patternfly/react-icons/dist/js/icons';
+import {
+  PropertiesSidePanel,
+  PropertyItem,
+} from '@patternfly/react-catalog-view-extension';
+import { ArrowIcon } from '@patternfly/react-icons';
+
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import CardItem from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
+import RelativeDateTime from 'foremanReact/components/common/dates/RelativeDateTime';
+import { translate as __ } from 'foremanReact/common/I18n';
+import './styles.css';
+
+const RecentJobsCard = ({ hostDetails: { name } }) => {
+  const jobsUrl =
+    name && `/api/job_invocations?search=host%3D${name}&per_page=3`;
+  const {
+    response: { results: jobs },
+  } = useAPI('get', jobsUrl);
+
+  const iconMarkup = status => {
+    if (status === 1) return <ErrorCircleOIcon color="#C9190B" />;
+    return <OkIcon color="#3E8635" />;
+  };
+
+  return (
+    <CardItem
+      header={
+        <span>
+          {__('Recent Jobs')}{' '}
+          <a href={`/job_invocations?search=host+%3D+${name}`}>
+            <ArrowIcon />
+          </a>
+        </span>
+      }
+    >
+      <PropertiesSidePanel>
+        {jobs?.map(({ status, status_label, id, start_at, description }) => (
+          <PropertyItem
+            key={id}
+            label={
+              description ? (
+                <Grid>
+                  <GridItem span={8}>
+                    <ElipsisWithTooltip>{description}</ElipsisWithTooltip>
+                  </GridItem>
+                  <GridItem span={1}>{iconMarkup(status)}</GridItem>
+                  <GridItem span={3}>{status_label}</GridItem>
+                </Grid>
+              ) : (
+                <Skeleton />
+              )
+            }
+            value={
+              start_at ? (
+                <a href={`/job_invocations/${id}`}>
+                  <RelativeDateTime date={start_at} />
+                </a>
+              ) : (
+                <Skeleton />
+              )
+            }
+          />
+        ))}
+      </PropertiesSidePanel>
+    </CardItem>
+  );
+};
+
+export default RecentJobsCard;
+
+RecentJobsCard.propTypes = {
+  hostDetails: PropTypes.shape({
+    name: PropTypes.string,
+  }).isRequired,
+};

--- a/webpack/react_app/components/RecentJobsCard/constants.js
+++ b/webpack/react_app/components/RecentJobsCard/constants.js
@@ -1,0 +1,1 @@
+export const HOST_DETAILS_JOBS = 'HOST_DETAILS_JOBS';

--- a/webpack/react_app/components/RecentJobsCard/index.js
+++ b/webpack/react_app/components/RecentJobsCard/index.js
@@ -1,0 +1,1 @@
+export { default } from './RecentJobsCard';

--- a/webpack/react_app/components/RecentJobsCard/styles.css
+++ b/webpack/react_app/components/RecentJobsCard/styles.css
@@ -1,0 +1,15 @@
+.properties-side-panel-pf-property-value {
+  font-size: 14px !important;
+  margin-top: 8px;
+  word-break: break-word;
+}
+
+.properties-side-panel-pf-property-label {
+  font-weight: 700 !important;
+  font-size: 14px !important;
+  margin: 0 !important;
+}
+
+.properties-side-panel-pf-property {
+  margin-top: 24px;
+}

--- a/webpack/react_app/extend/fills.js
+++ b/webpack/react_app/extend/fills.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
+import RecentJobsCard from '../components/RecentJobsCard';
+
+export default addGlobalFill(
+  'details-cards',
+  'rex-host-details-latest-jobs',
+  <RecentJobsCard />,
+  1000
+);

--- a/webpack/react_app/extend/reducers.js
+++ b/webpack/react_app/extend/reducers.js
@@ -1,0 +1,4 @@
+import { registerReducer } from 'foremanReact/common/MountingService';
+import rootReducer from '../redux/reducers';
+
+export default registerReducer('foremanRemoteExecutionReducers', rootReducer);


### PR DESCRIPTION
This adds a card to the experimental host details page
![recent-joba](https://user-images.githubusercontent.com/11807069/98268248-f7ec2000-1f94-11eb-9d2d-fe87831bcc45.png)

- [x] needs https://github.com/theforeman/foreman/pull/8086