### PR TITLE
Fixes #31297 - Table pagination in react has extra space

### DIFF
--- a/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
@@ -39,7 +39,7 @@ const TargetingHostsPage = ({
     <br />
     <TargetingHosts apiStatus={apiStatus} items={items} />
     <Pagination
-      viewType="list"
+      viewType="table"
       itemCount={totalHosts}
       pagination={pagination}
       onChange={args => handlePagination(args)}

--- a/webpack/react_app/components/TargetingHosts/TargetingHostsPage.scss
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsPage.scss
@@ -1,6 +1,3 @@
-.targeting-hosts-pagination {
-  margin-top: -7px;
-}
 #targeting_hosts {
   min-height: 350px;
 }

--- a/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
+++ b/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
@@ -62,7 +62,7 @@ exports[`TargetingHostsPage renders 1`] = `
         "perPage": 20,
       }
     }
-    viewType="list"
+    viewType="table"
   />
 </div>
 `;


### PR DESCRIPTION
6px margin for pagination was removed from the table in: https://github.com/theforeman/foreman/pull/8133