### PR TITLE
Fixes #31459 - Add advanced template input to job wizard

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -10,10 +10,12 @@ class UiJobWizardController < ::Api::V2::BaseController
 
   def template
     job_template = JobTemplate.authorized.find(params[:id])
+    advanced_template_inputs, template_inputs = map_template_inputs(job_template.template_inputs_with_foreign).partition { |x| x["advanced"] }
     render :json => {
       :job_template => job_template,
       :effective_user => job_template.effective_user,
-      :template_inputs_with_foreign => map_template_inputs(job_template.template_inputs_with_foreign),
+      :template_inputs => template_inputs,
+      :advanced_template_inputs => advanced_template_inputs,
     }
   end
 

--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -13,11 +13,16 @@ class UiJobWizardController < ::Api::V2::BaseController
     render :json => {
       :job_template => job_template,
       :effective_user => job_template.effective_user,
+      :template_inputs_with_foreign => map_template_inputs(job_template.template_inputs_with_foreign),
     }
   end
 
   def resource_name(nested_resource = nil)
     nested_resource || 'job_template'
+  end
+
+  def map_template_inputs(template_inputs_with_foreign)
+    template_inputs_with_foreign.map { |input| input.attributes.merge({:resource_type => input.resource_type&.tableize }) }
   end
 
   def resource_class

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -67,7 +67,7 @@ module ForemanRemoteExecution
                                             :'api/v2/job_templates' => [:index, :show, :revision, :export],
                                             :'api/v2/template_inputs' => [:index, :show],
                                             :'api/v2/foreign_input_sets' => [:index, :show],
-                                            :ui_job_wizard => [:categories, :template]}, :resource_type => 'JobTemplate'
+                                            :ui_job_wizard => [:categories, :template, :map_template_inputs]}, :resource_type => 'JobTemplate'
           permission :create_job_templates, { :job_templates => [:new, :create, :clone_template, :import],
                                               :'api/v2/job_templates' => [:create, :clone, :import] }, :resource_type => 'JobTemplate'
           permission :edit_job_templates, { :job_templates => [:edit, :update],

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -67,7 +67,7 @@ module ForemanRemoteExecution
                                             :'api/v2/job_templates' => [:index, :show, :revision, :export],
                                             :'api/v2/template_inputs' => [:index, :show],
                                             :'api/v2/foreign_input_sets' => [:index, :show],
-                                            :ui_job_wizard => [:categories, :template, :map_template_inputs]}, :resource_type => 'JobTemplate'
+                                            :ui_job_wizard => [:categories, :template]}, :resource_type => 'JobTemplate'
           permission :create_job_templates, { :job_templates => [:new, :create, :clone_template, :import],
                                               :'api/v2/job_templates' => [:create, :clone, :import] }, :resource_type => 'JobTemplate'
           permission :edit_job_templates, { :job_templates => [:edit, :update],

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -18,21 +18,19 @@ export const JobWizard = () => {
 
   const setDefaults = useCallback(response => {
     const responseJob = response.data;
-    const templateValues = {};
-    const inputs = responseJob.template_inputs_with_foreign;
-    if (inputs) {
-      inputs
-        .filter(input => input.advanced)
-        .forEach(input => {
-          templateValues[input.name] = input?.default || '';
-        });
+    const advancedTemplateValues = {};
+    const advancedInputs = responseJob.advanced_template_inputs;
+    if (advancedInputs) {
+      advancedInputs.forEach(input => {
+        advancedTemplateValues[input.name] = input?.default || '';
+      });
     }
-    setAdvancedValues({
-      ...advancedValues,
+    setAdvancedValues(currentAdvancedValues => ({
+      ...currentAdvancedValues,
       effectiveUserValue: responseJob.effective_user?.value || '',
       timeoutToKill: responseJob.job_template?.executionTimeoutInterval || '',
-      templateValues,
-    });
+      templateValues: advancedTemplateValues,
+    }));
   }, []);
   useEffect(() => {
     if (jobTemplateID) {

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -18,9 +18,20 @@ export const JobWizard = () => {
 
   const setDefaults = useCallback(response => {
     const responseJob = response.data;
+    const templateValues = {};
+    const inputs = responseJob.template_inputs_with_foreign;
+    if (inputs) {
+      inputs
+        .filter(input => input.advanced)
+        .forEach(input => {
+          templateValues[input.name] = input?.default || '';
+        });
+    }
     setAdvancedValues({
+      ...advancedValues,
       effectiveUserValue: responseJob.effective_user?.value || '',
-      timeoutToKill: responseJob.job_template.execution_timeout_interval || '',
+      timeoutToKill: responseJob.job_template?.executionTimeoutInterval || '',
+      templateValues,
     });
   }, []);
   useEffect(() => {

--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -10,5 +10,34 @@
     .advanced-fields-title {
       margin-bottom: 10px;
     }
+    #advanced-fields-job-template {
+      .foreman-search-field {
+        // Giving pf3 search bar a pf4 look
+        .search-bar {
+          display: block;
+        }
+        .input-group-btn {
+          display: none;
+        }
+        li {
+          font-size: 16px;
+        }
+        input {
+          font-size: 16px;
+          height: 36px;
+        }
+        .foreman-autocomplete .autocomplete-focus-shortcut {
+          top: 8px;
+          font-size: 16px;
+        }
+        .foreman-autocomplete .autocomplete-aux {
+          top: 8px;
+          font-size: 16px;
+          .autocomplete-clear-button {
+            font-size: 16px;
+          }
+        }
+      }
+    }
   }
 }

--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -40,5 +40,8 @@ export const selectJobTemplate = state =>
 export const selectEffectiveUser = state =>
   selectAPIResponse(state, JOB_TEMPLATE).effective_user;
 
+export const selectAdvancedTemplateInputs = state =>
+  selectAPIResponse(state, JOB_TEMPLATE).advanced_template_inputs || [];
+
 export const selectTemplateInputs = state =>
-  selectAPIResponse(state, JOB_TEMPLATE).template_inputs_with_foreign || [];
+  selectAPIResponse(state, JOB_TEMPLATE).template_inputs || [];

--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -36,3 +36,9 @@ export const selectTemplateError = state =>
 
 export const selectJobTemplate = state =>
   selectAPIResponse(state, JOB_TEMPLATE);
+
+export const selectEffectiveUser = state =>
+  selectAPIResponse(state, JOB_TEMPLATE).effective_user;
+
+export const selectTemplateInputs = state =>
+  selectAPIResponse(state, JOB_TEMPLATE).template_inputs_with_foreign || [];

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -23,4 +23,17 @@ export const jobTemplateResponse = {
     overridable: true,
     current_user: false,
   },
+  template_inputs_with_foreign: [
+    {
+      name: 'plain adv hidden',
+      required: true,
+      input_type: 'user',
+      description: 'some Description',
+      advanced: true,
+      value_type: 'plain',
+      resource_type: 'ansible_roles',
+      default: 'Default val',
+      hidden_value: true,
+    },
+  ],
 };

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -23,13 +23,26 @@ export const jobTemplateResponse = {
     overridable: true,
     current_user: false,
   },
-  template_inputs_with_foreign: [
+  advanced_template_inputs: [
     {
-      name: 'plain adv hidden',
+      name: 'adv plain hidden',
       required: true,
       input_type: 'user',
       description: 'some Description',
       advanced: true,
+      value_type: 'plain',
+      resource_type: 'ansible_roles',
+      default: 'Default val',
+      hidden_value: true,
+    },
+  ],
+  template_inputs: [
+    {
+      name: 'plain hidden',
+      required: true,
+      input_type: 'user',
+      description: 'some Description',
+      advanced: false,
       value_type: 'plain',
       resource_type: 'ansible_roles',
       default: 'Default val',

--- a/webpack/JobWizard/__tests__/integration.test.js
+++ b/webpack/JobWizard/__tests__/integration.test.js
@@ -13,6 +13,8 @@ jest.spyOn(selectors, 'selectJobTemplate');
 jest.spyOn(selectors, 'selectJobTemplates');
 jest.spyOn(selectors, 'selectJobCategories');
 jest.spyOn(selectors, 'selectJobCategoriesStatus');
+jest.spyOn(selectors, 'selectEffectiveUser');
+jest.spyOn(selectors, 'selectTemplateInputs');
 
 const jobCategories = ['Ansible Commands', 'Puppet', 'Services'];
 
@@ -69,6 +71,12 @@ describe('Job wizard fill', () => {
     // setup
     selectors.selectJobCategoriesStatus.mockImplementation(() => 'RESOLVED');
     selectors.selectJobTemplate.mockImplementation(() => jobTemplate);
+    selectors.selectEffectiveUser.mockImplementation(
+      () => jobTemplate.effective_user
+    );
+    selectors.selectTemplateInputs.mockImplementation(
+      () => jobTemplate.template_inputs_with_foreign
+    );
     wrapper.find('.pf-c-button.pf-c-select__toggle-button').simulate('click');
     wrapper.find('.pf-c-select__menu-item').simulate('click');
 
@@ -81,14 +89,22 @@ describe('Job wizard fill', () => {
       .at(2)
       .simulate('click'); // Advanced step
     const effectiveUserInput = () => wrapper.find('input#effective-user');
+    const advancedTemplateInput = () =>
+      wrapper.find('.pf-c-form__group-control textarea');
     const effectiveUesrValue = 'effective user new value';
+    const advancedTemplateInputValue = 'advanced input new value';
     effectiveUserInput().getDOMNode().value = effectiveUesrValue;
     await act(async () => {
       await effectiveUserInput().simulate('change');
       wrapper.update();
     });
+    advancedTemplateInput().getDOMNode().value = advancedTemplateInputValue;
+    advancedTemplateInput().simulate('change');
 
     expect(effectiveUserInput().prop('value')).toEqual(effectiveUesrValue);
+    expect(advancedTemplateInput().prop('value')).toEqual(
+      advancedTemplateInputValue
+    );
 
     wrapper
       .find('.pf-c-wizard__nav-link')
@@ -104,6 +120,9 @@ describe('Job wizard fill', () => {
       .simulate('click'); // Advanced step
 
     expect(effectiveUserInput().prop('value')).toEqual(effectiveUesrValue);
+    expect(advancedTemplateInput().prop('value')).toEqual(
+      advancedTemplateInputValue
+    );
   });
 
   it('have all steps', async () => {

--- a/webpack/JobWizard/__tests__/integration.test.js
+++ b/webpack/JobWizard/__tests__/integration.test.js
@@ -15,6 +15,7 @@ jest.spyOn(selectors, 'selectJobCategories');
 jest.spyOn(selectors, 'selectJobCategoriesStatus');
 jest.spyOn(selectors, 'selectEffectiveUser');
 jest.spyOn(selectors, 'selectTemplateInputs');
+jest.spyOn(selectors, 'selectAdvancedTemplateInputs');
 
 const jobCategories = ['Ansible Commands', 'Puppet', 'Services'];
 
@@ -75,7 +76,11 @@ describe('Job wizard fill', () => {
       () => jobTemplate.effective_user
     );
     selectors.selectTemplateInputs.mockImplementation(
-      () => jobTemplate.template_inputs_with_foreign
+      () => jobTemplate.template_inputs
+    );
+
+    selectors.selectAdvancedTemplateInputs.mockImplementation(
+      () => jobTemplate.advanced_template_inputs
     );
     wrapper.find('.pf-c-button.pf-c-select__toggle-button').simulate('click');
     wrapper.find('.pf-c-select__menu-item').simulate('click');

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -30,9 +30,7 @@ export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
         <TemplateInputsFields
           inputs={templateInputs}
           value={advancedValues.templateValues}
-          setValue={newValue =>
-            setAdvancedValues({ ...advancedValues, templateValues: newValue })
-          }
+          setValue={newValue => setAdvancedValues({ templateValues: newValue })}
         />
         {effectiveUser?.overridable && (
           <EffectiveUserField

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Title, Form } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { selectJobTemplate } from '../../JobWizardSelectors';
+import {
+  selectEffectiveUser,
+  selectTemplateInputs,
+} from '../../JobWizardSelectors';
 import {
   EffectiveUserField,
   TimeoutToKillField,
@@ -12,17 +15,25 @@ import {
   EffectiveUserPasswordField,
   ConcurrencyLevelField,
   TimeSpanLevelField,
+  TemplateInputsFields,
 } from './Fields';
 
 export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
-  const jobTemplate = useSelector(selectJobTemplate);
-  const effectiveUser = jobTemplate.effective_user;
+  const effectiveUser = useSelector(selectEffectiveUser);
+  const templateInputs = useSelector(selectTemplateInputs);
   return (
     <>
       <Title headingLevel="h2" className="advanced-fields-title">
         {__('Advanced Fields')}
       </Title>
-      <Form>
+      <Form id="advanced-fields-job-template">
+        <TemplateInputsFields
+          inputs={templateInputs}
+          value={advancedValues.templateValues}
+          setValue={newValue =>
+            setAdvancedValues({ ...advancedValues, templateValues: newValue })
+          }
+        />
         {effectiveUser?.overridable && (
           <EffectiveUserField
             value={advancedValues.effectiveUserValue}

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -5,7 +5,7 @@ import { Title, Form } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
   selectEffectiveUser,
-  selectTemplateInputs,
+  selectAdvancedTemplateInputs,
 } from '../../JobWizardSelectors';
 import {
   EffectiveUserField,
@@ -20,7 +20,7 @@ import {
 
 export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
   const effectiveUser = useSelector(selectEffectiveUser);
-  const templateInputs = useSelector(selectTemplateInputs);
+  const templateInputs = useSelector(selectAdvancedTemplateInputs);
   return (
     <>
       <Title headingLevel="h2" className="advanced-fields-title">

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -26,7 +26,7 @@ export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
       <Title headingLevel="h2" className="advanced-fields-title">
         {__('Advanced Fields')}
       </Title>
-      <Form id="advanced-fields-job-template">
+      <Form id="advanced-fields-job-template" autoComplete="off">
         <TemplateInputsFields
           inputs={templateInputs}
           value={advancedValues.templateValues}

--- a/webpack/JobWizard/steps/AdvancedFields/Fields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/Fields.js
@@ -129,7 +129,6 @@ export const ConcurrencyLevelField = ({ value, setValue }) => (
     }}
     inputProps={{
       min: 1,
-      type: 'number',
       autoComplete: 'concurrency-level',
       id: 'concurrency-level',
       placeholder: __('For example: 1, 2, 3, 4, 5...'),
@@ -153,7 +152,6 @@ export const TimeSpanLevelField = ({ value, setValue }) => (
     }}
     inputProps={{
       min: 1,
-      type: 'number',
       autoComplete: 'time-span',
       id: 'time-span',
       placeholder: __('For example: 1, 2, 3, 4, 5...'),

--- a/webpack/JobWizard/steps/AdvancedFields/Fields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/Fields.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { FormGroup, TextInput } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { helpLabel } from '../form/FormHelpers';
+import { formatter } from '../form/Formatter';
 
 export const EffectiveUserField = ({ value, setValue }) => (
   <FormGroup
@@ -159,6 +160,11 @@ export const TimeSpanLevelField = ({ value, setValue }) => (
   </FormGroup>
 );
 
+export const TemplateInputsFields = ({ inputs, value, setValue }) => {
+  inputs = inputs?.filter(input => input.advanced);
+  return <>{inputs?.map(input => formatter(input, value, setValue))}</>;
+};
+
 EffectiveUserField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   setValue: PropTypes.func.isRequired,
@@ -179,3 +185,12 @@ ConcurrencyLevelField.propTypes = EffectiveUserField.propTypes;
 ConcurrencyLevelField.defaultProps = EffectiveUserField.defaultProps;
 TimeSpanLevelField.propTypes = EffectiveUserField.propTypes;
 TimeSpanLevelField.defaultProps = EffectiveUserField.defaultProps;
+TemplateInputsFields.propTypes = {
+  inputs: PropTypes.array.isRequired,
+  value: PropTypes.object,
+  setValue: PropTypes.func.isRequired,
+};
+
+TemplateInputsFields.defaultProps = {
+  value: {},
+};

--- a/webpack/JobWizard/steps/AdvancedFields/Fields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/Fields.js
@@ -4,6 +4,7 @@ import { FormGroup, TextInput } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { helpLabel } from '../form/FormHelpers';
 import { formatter } from '../form/Formatter';
+import { NumberInput } from '../form/NumberInput';
 
 export const EffectiveUserField = ({ value, setValue }) => (
   <FormGroup
@@ -27,25 +28,25 @@ export const EffectiveUserField = ({ value, setValue }) => (
 );
 
 export const TimeoutToKillField = ({ value, setValue }) => (
-  <FormGroup
-    label={__('Timeout to kill')}
-    labelIcon={helpLabel(
-      __(
-        'Time in seconds from the start on the remote host after which the job should be killed.'
+  <NumberInput
+    formProps={{
+      label: __('Timeout to kill'),
+      labelIcon: helpLabel(
+        __(
+          'Time in seconds from the start on the remote host after which the job should be killed.'
+        ),
+        'timeout-to-kill'
       ),
-      'timeout-to-kill'
-    )}
-    fieldId="timeout-to-kill"
-  >
-    <TextInput
-      type="number"
-      value={value}
-      placeholder={__('For example: 1, 2, 3, 4, 5...')}
-      autoComplete="timeout-to-kill"
-      id="timeout-to-kill"
-      onChange={newValue => setValue(newValue)}
-    />
-  </FormGroup>
+      fieldId: 'timeout-to-kill',
+    }}
+    inputProps={{
+      value,
+      placeholder: __('For example: 1, 2, 3, 4, 5...'),
+      autoComplete: 'timeout-to-kill',
+      id: 'timeout-to-kill',
+      onChange: newValue => setValue(newValue),
+    }}
+  />
 );
 
 export const PasswordField = ({ value, setValue }) => (
@@ -57,11 +58,11 @@ export const PasswordField = ({ value, setValue }) => (
       ),
       'password'
     )}
-    fieldId="password"
+    fieldId="job-password"
   >
     <TextInput
-      autoComplete="password"
-      id="password"
+      autoComplete="new-password" // to prevent firefox from autofilling the user password
+      id="job-password"
       type="password"
       placeholder="*****"
       value={value}
@@ -115,49 +116,51 @@ export const EffectiveUserPasswordField = ({ value, setValue }) => (
 );
 
 export const ConcurrencyLevelField = ({ value, setValue }) => (
-  <FormGroup
-    label={__('Concurrency level')}
-    labelIcon={helpLabel(
-      __(
-        'Run at most N tasks at a time. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1.'
+  <NumberInput
+    formProps={{
+      label: __('Concurrency level'),
+      labelIcon: helpLabel(
+        __(
+          'Run at most N tasks at a time. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1.'
+        ),
+        'concurrency-level'
       ),
-      'concurrency-level'
-    )}
-    fieldId="concurrency-level"
-  >
-    <TextInput
-      min={1}
-      type="number"
-      autoComplete="concurrency-level"
-      id="concurrency-level"
-      placeholder={__('For example: 1, 2, 3, 4, 5...')}
-      value={value}
-      onChange={newValue => setValue(newValue)}
-    />
-  </FormGroup>
+      fieldId: 'concurrency-level',
+    }}
+    inputProps={{
+      min: 1,
+      type: 'number',
+      autoComplete: 'concurrency-level',
+      id: 'concurrency-level',
+      placeholder: __('For example: 1, 2, 3, 4, 5...'),
+      value,
+      onChange: newValue => setValue(newValue),
+    }}
+  />
 );
 
 export const TimeSpanLevelField = ({ value, setValue }) => (
-  <FormGroup
-    label={__('Time span')}
-    labelIcon={helpLabel(
-      __(
-        'Distribute execution over N seconds. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1.'
+  <NumberInput
+    formProps={{
+      label: __('Time span'),
+      labelIcon: helpLabel(
+        __(
+          'Distribute execution over N seconds. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1.'
+        ),
+        'time-span'
       ),
-      'time-span'
-    )}
-    fieldId="time-span"
-  >
-    <TextInput
-      min={1}
-      type="number"
-      autoComplete="time-span"
-      id="time-span"
-      placeholder={__('For example: 1, 2, 3, 4, 5...')}
-      value={value}
-      onChange={newValue => setValue(newValue)}
-    />
-  </FormGroup>
+      fieldId: 'time-span',
+    }}
+    inputProps={{
+      min: 1,
+      type: 'number',
+      autoComplete: 'time-span',
+      id: 'time-span',
+      placeholder: __('For example: 1, 2, 3, 4, 5...'),
+      value,
+      onChange: newValue => setValue(newValue),
+    }}
+  />
 );
 
 export const TemplateInputsFields = ({ inputs, value, setValue }) => {

--- a/webpack/JobWizard/steps/AdvancedFields/Fields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/Fields.js
@@ -161,11 +161,9 @@ export const TimeSpanLevelField = ({ value, setValue }) => (
   />
 );
 
-export const TemplateInputsFields = ({ inputs, value, setValue }) => {
-  inputs = inputs?.filter(input => input.advanced);
-  return <>{inputs?.map(input => formatter(input, value, setValue))}</>;
-};
-
+export const TemplateInputsFields = ({ inputs, value, setValue }) => (
+  <>{inputs?.map(input => formatter(input, value, setValue))}</>
+);
 EffectiveUserField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   setValue: PropTypes.func.isRequired,

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import * as patternfly from '@patternfly/react-core';
 import { mount } from '@theforeman/test';
 import { AdvancedFields } from '../AdvancedFields';
+import { jobTemplateResponse } from '../../../__tests__/fixtures';
 
 jest.spyOn(patternfly, 'FormGroup');
 patternfly.FormGroup.mockImplementation(props => (
@@ -11,18 +12,7 @@ patternfly.FormGroup.mockImplementation(props => (
 ));
 const mockStore = configureMockStore([]);
 const store = mockStore({
-  JOB_TEMPLATE: {
-    response: {
-      effective_user: { overridable: true },
-      template_inputs_with_foreign: [
-        {
-          name: 'advanced input1',
-          advanced: true,
-          default: 'default value advanced',
-        },
-      ],
-    },
-  },
+  JOB_TEMPLATE: { response: jobTemplateResponse },
 });
 describe('AdvancedFields', () => {
   it('rendring', () => {

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -11,7 +11,18 @@ patternfly.FormGroup.mockImplementation(props => (
 ));
 const mockStore = configureMockStore([]);
 const store = mockStore({
-  JOB_TEMPLATE: { response: { effective_user: { overridable: true } } },
+  JOB_TEMPLATE: {
+    response: {
+      effective_user: { overridable: true },
+      template_inputs_with_foreign: [
+        {
+          name: 'advanced input1',
+          advanced: true,
+          default: 'default value advanced',
+        },
+      ],
+    },
+  },
 });
 describe('AdvancedFields', () => {
   it('rendring', () => {

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
@@ -76,6 +76,7 @@ exports[`AdvancedFields rendring 1`] = `
                   aria-label="open-help-tooltip-button"
                   className="pf-c-form__group-label-help"
                   onClick={[Function]}
+                  type="button"
                 >
                   <HelpIcon
                     color="currentColor"
@@ -107,6 +108,7 @@ exports[`AdvancedFields rendring 1`] = `
                     aria-label="open-help-tooltip-button"
                     className="pf-c-form__group-label-help"
                     onClick={[Function]}
+                    type="button"
                   >
                     <HelpIcon
                       color="currentColor"
@@ -141,6 +143,7 @@ exports[`AdvancedFields rendring 1`] = `
                     aria-label="open-help-tooltip-button"
                     className="pf-c-form__group-label-help"
                     onClick={[Function]}
+                    type="button"
                   >
                     <HelpIcon
                       color="currentColor"
@@ -172,6 +175,7 @@ exports[`AdvancedFields rendring 1`] = `
                   aria-label="open-help-tooltip-button"
                   className="pf-c-form__group-label-help"
                   onClick={[Function]}
+                  type="button"
                 >
                   <HelpIcon
                     color="currentColor"
@@ -202,6 +206,7 @@ exports[`AdvancedFields rendring 1`] = `
                   aria-label="open-help-tooltip-button"
                   className="pf-c-form__group-label-help"
                   onClick={[Function]}
+                  type="button"
                 >
                   <HelpIcon
                     color="currentColor"
@@ -232,6 +237,7 @@ exports[`AdvancedFields rendring 1`] = `
                   aria-label="open-help-tooltip-button"
                   className="pf-c-form__group-label-help"
                   onClick={[Function]}
+                  type="button"
                 >
                   <HelpIcon
                     color="currentColor"
@@ -263,6 +269,7 @@ exports[`AdvancedFields rendring 1`] = `
                     aria-label="open-help-tooltip-button"
                     className="pf-c-form__group-label-help"
                     onClick={[Function]}
+                    type="button"
                   >
                     <HelpIcon
                       color="currentColor"
@@ -299,6 +306,7 @@ exports[`AdvancedFields rendring 1`] = `
                     aria-label="open-help-tooltip-button"
                     className="pf-c-form__group-label-help"
                     onClick={[Function]}
+                    type="button"
                   >
                     <HelpIcon
                       color="currentColor"
@@ -331,6 +339,7 @@ exports[`AdvancedFields rendring 1`] = `
                     aria-label="open-help-tooltip-button"
                     className="pf-c-form__group-label-help"
                     onClick={[Function]}
+                    type="button"
                   >
                     <HelpIcon
                       color="currentColor"
@@ -367,6 +376,7 @@ exports[`AdvancedFields rendring 1`] = `
                     aria-label="open-help-tooltip-button"
                     className="pf-c-form__group-label-help"
                     onClick={[Function]}
+                    type="button"
                   >
                     <HelpIcon
                       color="currentColor"

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
@@ -287,7 +287,6 @@ exports[`AdvancedFields rendring 1`] = `
                 "min": 1,
                 "onChange": [Function],
                 "placeholder": "For example: 1, 2, 3, 4, 5...",
-                "type": "number",
                 "value": "",
               }
             }
@@ -357,7 +356,6 @@ exports[`AdvancedFields rendring 1`] = `
                 "min": 1,
                 "onChange": [Function],
                 "placeholder": "For example: 1, 2, 3, 4, 5...",
-                "type": "number",
                 "value": "",
               }
             }

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
@@ -27,11 +27,36 @@ exports[`AdvancedFields rendring 1`] = `
         Advanced Fields
       </h2>
     </Title>
-    <Form>
+    <Form
+      id="advanced-fields-job-template"
+    >
       <form
         className="pf-c-form"
+        id="advanced-fields-job-template"
         noValidate={true}
       >
+        <TemplateInputsFields
+          inputs={
+            Array [
+              Object {
+                "advanced": true,
+                "default": "default value advanced",
+                "name": "advanced input1",
+              },
+            ]
+          }
+          setValue={[Function]}
+          value={Object {}}
+        >
+          <mockConstructor
+            fieldId="advanced input1"
+            key="advanced input1"
+            label="advanced input1"
+            labelIcon={null}
+          >
+            <div />
+          </mockConstructor>
+        </TemplateInputsFields>
         <EffectiveUserField
           setValue={[Function]}
           value=""

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
@@ -42,8 +42,14 @@ exports[`AdvancedFields rendring 1`] = `
             Array [
               Object {
                 "advanced": true,
-                "default": "default value advanced",
-                "name": "advanced input1",
+                "default": "Default val",
+                "description": "some Description",
+                "hidden_value": true,
+                "input_type": "user",
+                "name": "adv plain hidden",
+                "required": true,
+                "resource_type": "ansible_roles",
+                "value_type": "plain",
               },
             ]
           }
@@ -51,10 +57,30 @@ exports[`AdvancedFields rendring 1`] = `
           value={Object {}}
         >
           <mockConstructor
-            fieldId="advanced input1"
-            key="advanced input1"
-            label="advanced input1"
-            labelIcon={null}
+            fieldId="adv plain hidden"
+            isRequired={true}
+            key="adv plain hidden"
+            label="adv plain hidden"
+            labelIcon={
+              <Popover
+                aria-label="help-text"
+                bodyContent="some Description"
+                id="adv plain hidden-help"
+              >
+                <button
+                  aria-label="open-help-tooltip-button"
+                  className="pf-c-form__group-label-help"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <HelpIcon
+                    color="currentColor"
+                    noVerticalAlign={true}
+                    size="sm"
+                  />
+                </button>
+              </Popover>
+            }
           >
             <div />
           </mockConstructor>

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
@@ -28,9 +28,11 @@ exports[`AdvancedFields rendring 1`] = `
       </h2>
     </Title>
     <Form
+      autoComplete="off"
       id="advanced-fields-job-template"
     >
       <form
+        autoComplete="off"
         className="pf-c-form"
         id="advanced-fields-job-template"
         noValidate={true}
@@ -91,38 +93,74 @@ exports[`AdvancedFields rendring 1`] = `
           setValue={[Function]}
           value=""
         >
-          <mockConstructor
-            fieldId="timeout-to-kill"
-            label="Timeout to kill"
-            labelIcon={
-              <Popover
-                aria-label="help-text"
-                bodyContent="Time in seconds from the start on the remote host after which the job should be killed."
-                id="timeout-to-kill-help"
-              >
-                <button
-                  aria-label="open-help-tooltip-button"
-                  className="pf-c-form__group-label-help"
-                  onClick={[Function]}
+          <NumberInput
+            formProps={
+              Object {
+                "fieldId": "timeout-to-kill",
+                "label": "Timeout to kill",
+                "labelIcon": <Popover
+                  aria-label="help-text"
+                  bodyContent="Time in seconds from the start on the remote host after which the job should be killed."
+                  id="timeout-to-kill-help"
                 >
-                  <HelpIcon
-                    color="currentColor"
-                    noVerticalAlign={true}
-                    size="sm"
-                  />
-                </button>
-              </Popover>
+                  <button
+                    aria-label="open-help-tooltip-button"
+                    className="pf-c-form__group-label-help"
+                    onClick={[Function]}
+                  >
+                    <HelpIcon
+                      color="currentColor"
+                      noVerticalAlign={true}
+                      size="sm"
+                    />
+                  </button>
+                </Popover>,
+              }
+            }
+            inputProps={
+              Object {
+                "autoComplete": "timeout-to-kill",
+                "id": "timeout-to-kill",
+                "onChange": [Function],
+                "placeholder": "For example: 1, 2, 3, 4, 5...",
+                "value": "",
+              }
             }
           >
-            <div />
-          </mockConstructor>
+            <mockConstructor
+              fieldId="timeout-to-kill"
+              helperTextInvalid="Has to be a number"
+              label="Timeout to kill"
+              labelIcon={
+                <Popover
+                  aria-label="help-text"
+                  bodyContent="Time in seconds from the start on the remote host after which the job should be killed."
+                  id="timeout-to-kill-help"
+                >
+                  <button
+                    aria-label="open-help-tooltip-button"
+                    className="pf-c-form__group-label-help"
+                    onClick={[Function]}
+                  >
+                    <HelpIcon
+                      color="currentColor"
+                      noVerticalAlign={true}
+                      size="sm"
+                    />
+                  </button>
+                </Popover>
+              }
+            >
+              <div />
+            </mockConstructor>
+          </NumberInput>
         </TimeoutToKillField>
         <PasswordField
           setValue={[Function]}
           value=""
         >
           <mockConstructor
-            fieldId="password"
+            fieldId="job-password"
             label="Password"
             labelIcon={
               <Popover
@@ -211,61 +249,137 @@ exports[`AdvancedFields rendring 1`] = `
           setValue={[Function]}
           value=""
         >
-          <mockConstructor
-            fieldId="concurrency-level"
-            label="Concurrency level"
-            labelIcon={
-              <Popover
-                aria-label="help-text"
-                bodyContent="Run at most N tasks at a time. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1."
-                id="concurrency-level-help"
-              >
-                <button
-                  aria-label="open-help-tooltip-button"
-                  className="pf-c-form__group-label-help"
-                  onClick={[Function]}
+          <NumberInput
+            formProps={
+              Object {
+                "fieldId": "concurrency-level",
+                "label": "Concurrency level",
+                "labelIcon": <Popover
+                  aria-label="help-text"
+                  bodyContent="Run at most N tasks at a time. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1."
+                  id="concurrency-level-help"
                 >
-                  <HelpIcon
-                    color="currentColor"
-                    noVerticalAlign={true}
-                    size="sm"
-                  />
-                </button>
-              </Popover>
+                  <button
+                    aria-label="open-help-tooltip-button"
+                    className="pf-c-form__group-label-help"
+                    onClick={[Function]}
+                  >
+                    <HelpIcon
+                      color="currentColor"
+                      noVerticalAlign={true}
+                      size="sm"
+                    />
+                  </button>
+                </Popover>,
+              }
+            }
+            inputProps={
+              Object {
+                "autoComplete": "concurrency-level",
+                "id": "concurrency-level",
+                "min": 1,
+                "onChange": [Function],
+                "placeholder": "For example: 1, 2, 3, 4, 5...",
+                "type": "number",
+                "value": "",
+              }
             }
           >
-            <div />
-          </mockConstructor>
+            <mockConstructor
+              fieldId="concurrency-level"
+              helperTextInvalid="Has to be a number"
+              label="Concurrency level"
+              labelIcon={
+                <Popover
+                  aria-label="help-text"
+                  bodyContent="Run at most N tasks at a time. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1."
+                  id="concurrency-level-help"
+                >
+                  <button
+                    aria-label="open-help-tooltip-button"
+                    className="pf-c-form__group-label-help"
+                    onClick={[Function]}
+                  >
+                    <HelpIcon
+                      color="currentColor"
+                      noVerticalAlign={true}
+                      size="sm"
+                    />
+                  </button>
+                </Popover>
+              }
+            >
+              <div />
+            </mockConstructor>
+          </NumberInput>
         </ConcurrencyLevelField>
         <TimeSpanLevelField
           setValue={[Function]}
           value=""
         >
-          <mockConstructor
-            fieldId="time-span"
-            label="Time span"
-            labelIcon={
-              <Popover
-                aria-label="help-text"
-                bodyContent="Distribute execution over N seconds. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1."
-                id="time-span-help"
-              >
-                <button
-                  aria-label="open-help-tooltip-button"
-                  className="pf-c-form__group-label-help"
-                  onClick={[Function]}
+          <NumberInput
+            formProps={
+              Object {
+                "fieldId": "time-span",
+                "label": "Time span",
+                "labelIcon": <Popover
+                  aria-label="help-text"
+                  bodyContent="Distribute execution over N seconds. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1."
+                  id="time-span-help"
                 >
-                  <HelpIcon
-                    color="currentColor"
-                    noVerticalAlign={true}
-                    size="sm"
-                  />
-                </button>
-              </Popover>
+                  <button
+                    aria-label="open-help-tooltip-button"
+                    className="pf-c-form__group-label-help"
+                    onClick={[Function]}
+                  >
+                    <HelpIcon
+                      color="currentColor"
+                      noVerticalAlign={true}
+                      size="sm"
+                    />
+                  </button>
+                </Popover>,
+              }
+            }
+            inputProps={
+              Object {
+                "autoComplete": "time-span",
+                "id": "time-span",
+                "min": 1,
+                "onChange": [Function],
+                "placeholder": "For example: 1, 2, 3, 4, 5...",
+                "type": "number",
+                "value": "",
+              }
             }
           >
-            <div />
-          </mockConstructor>
+            <mockConstructor
+              fieldId="time-span"
+              helperTextInvalid="Has to be a number"
+              label="Time span"
+              labelIcon={
+                <Popover
+                  aria-label="help-text"
+                  bodyContent="Distribute execution over N seconds. If this is set and proxy batch triggering is enabled, then tasks are triggered on the smart proxy in batches of size 1."
+                  id="time-span-help"
+                >
+                  <button
+                    aria-label="open-help-tooltip-button"
+                    className="pf-c-form__group-label-help"
+                    onClick={[Function]}
+                  >
+                    <HelpIcon
+                      color="currentColor"
+                      noVerticalAlign={true}
+                      size="sm"
+                    />
+                  </button>
+                </Popover>
+              }
+            >
+              <div />
+            </mockConstructor>
+          </NumberInput>
         </TimeSpanLevelField>
       </form>
     </Form>

--- a/webpack/JobWizard/steps/form/FormHelpers.js
+++ b/webpack/JobWizard/steps/form/FormHelpers.js
@@ -8,6 +8,7 @@ export const helpLabel = (text, id) => {
   return (
     <Popover id={`${id}-help`} bodyContent={text} aria-label="help-text">
       <button
+        type="button"
         aria-label={__('open-help-tooltip-button')}
         onClick={e => e.preventDefault()}
         className="pf-c-form__group-label-help"

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -25,7 +25,7 @@ const TemplateSearchField = ({
   return (
     <FormGroup
       label={name}
-      labelIcon={helpLabel(labelText)}
+      labelIcon={helpLabel(labelText, name)}
       fieldId={name}
       isRequired={required}
       className="foreman-search-field"
@@ -75,7 +75,7 @@ export const formatter = (input, values, setValue) => {
       <FormGroup
         key={name}
         label={name}
-        labelIcon={helpLabel(labelText)}
+        labelIcon={helpLabel(labelText, name)}
         fieldId={name}
         isRequired={required}
       >
@@ -95,7 +95,7 @@ export const formatter = (input, values, setValue) => {
       <FormGroup
         key={name}
         label={name}
-        labelIcon={helpLabel(labelText)}
+        labelIcon={helpLabel(labelText, name)}
         fieldId={name}
         isRequired={required}
       >

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -1,0 +1,146 @@
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { FormGroup, TextInput, TextArea } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import SearchBar from 'foremanReact/components/SearchBar';
+import { helpLabel } from './FormHelpers';
+import { SelectField } from './SelectField';
+
+const TemplateSearchField = ({
+  name,
+  controller,
+  labelText,
+  required,
+  defaultValue,
+  setValue,
+  values,
+}) => {
+  const searchQuery = useSelector(
+    state => state.autocomplete?.[name]?.searchQuery
+  );
+  useEffect(() => {
+    setValue({ ...values, [name]: searchQuery });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery]);
+  return (
+    <FormGroup
+      label={name}
+      labelIcon={helpLabel(labelText)}
+      fieldId={name}
+      isRequired={required}
+      className="foreman-search-field"
+    >
+      <SearchBar
+        initialQuery={defaultValue}
+        data={{
+          controller,
+          autocomplete: {
+            id: name,
+            url: `/${controller}/auto_complete_search`,
+            useKeyShortcuts: true,
+          },
+        }}
+        onSearch={() => null}
+      />
+    </FormGroup>
+  );
+};
+
+export const formatter = (input, values, setValue) => {
+  const isSelectType = !!input?.options;
+  const inputType = input.value_type;
+  const isTextType = inputType === 'plain' || !inputType; // null defaults to plain
+
+  const { name, required, hidden_value: hidden } = input;
+  const labelText = input.description;
+  const value = values[name];
+
+  if (isSelectType) {
+    const options = input.options.split(/\r?\n/).map(option => option.trim());
+    return (
+      <SelectField
+        key={name}
+        isRequired={required}
+        label={name}
+        fieldId={name}
+        options={options}
+        labelText={labelText}
+        value={value}
+        setValue={newValue => setValue({ ...values, [name]: newValue })}
+      />
+    );
+  }
+  if (isTextType) {
+    return (
+      <FormGroup
+        key={name}
+        label={name}
+        labelIcon={helpLabel(labelText)}
+        fieldId={name}
+        isRequired={required}
+      >
+        <TextArea
+          className={hidden ? 'masked-input' : null}
+          required={required}
+          rows={2}
+          id={name}
+          value={value}
+          onChange={newValue => setValue({ ...values, [name]: newValue })}
+        />
+      </FormGroup>
+    );
+  }
+  if (inputType === 'date') {
+    return (
+      <FormGroup
+        key={name}
+        label={name}
+        labelIcon={helpLabel(labelText)}
+        fieldId={name}
+        isRequired={required}
+      >
+        <TextInput
+          placeholder="YYYY-mm-dd HH:MM"
+          className={hidden ? 'masked-input' : null}
+          required={required}
+          id={name}
+          type="text"
+          value={value}
+          onChange={newValue => setValue({ ...values, [name]: newValue })}
+        />
+      </FormGroup>
+    );
+  }
+  if (inputType === 'search') {
+    const controller = input.resource_type;
+    // TODO: get text from redux autocomplete
+    return (
+      <TemplateSearchField
+        key={name}
+        name={name}
+        defaultValue={value}
+        controller={controller}
+        labelText={labelText}
+        required={required}
+        setValue={setValue}
+        values={values}
+      />
+    );
+  }
+
+  return null;
+};
+
+TemplateSearchField.propTypes = {
+  name: PropTypes.string.isRequired,
+  controller: PropTypes.string.isRequired,
+  labelText: PropTypes.string,
+  required: PropTypes.bool.isRequired,
+  defaultValue: PropTypes.string,
+  setValue: PropTypes.func.isRequired,
+  values: PropTypes.object.isRequired,
+};
+TemplateSearchField.defaultProps = {
+  labelText: null,
+  defaultValue: '',
+};

--- a/webpack/JobWizard/steps/form/NumberInput.js
+++ b/webpack/JobWizard/steps/form/NumberInput.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const NumberInput = ({ formProps, inputProps }) => {
+  const { value } = inputProps;
+  const [validated, setValidated] = useState();
+  useEffect(() => {
+    setValidated(
+      /^\d+$/.test(value) || value === ''
+        ? ValidatedOptions.noval
+        : ValidatedOptions.error
+    );
+  }, [value]);
+
+  return (
+    <FormGroup
+      {...formProps}
+      helperTextInvalid={__('Has to be a number')}
+      validated={validated}
+    >
+      <TextInput type="number" {...inputProps} />
+    </FormGroup>
+  );
+};
+
+NumberInput.propTypes = {
+  formProps: PropTypes.object.isRequired,
+  inputProps: PropTypes.object.isRequired,
+};

--- a/webpack/JobWizard/steps/form/NumberInput.js
+++ b/webpack/JobWizard/steps/form/NumberInput.js
@@ -1,26 +1,28 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 
 export const NumberInput = ({ formProps, inputProps }) => {
-  const { value } = inputProps;
   const [validated, setValidated] = useState();
-  useEffect(() => {
-    setValidated(
-      /^\d+$/.test(value) || value === ''
-        ? ValidatedOptions.noval
-        : ValidatedOptions.error
-    );
-  }, [value]);
-
   return (
     <FormGroup
       {...formProps}
       helperTextInvalid={__('Has to be a number')}
       validated={validated}
     >
-      <TextInput type="number" {...inputProps} />
+      <TextInput
+        type="text"
+        {...inputProps}
+        onChange={newValue => {
+          setValidated(
+            /^\d+$/.test(newValue) || newValue === ''
+              ? ValidatedOptions.noval
+              : ValidatedOptions.error
+          );
+          inputProps.onChange(newValue);
+        }}
+      />
     </FormGroup>
   );
 };

--- a/webpack/JobWizard/steps/form/__tests__/Formatter.test.js
+++ b/webpack/JobWizard/steps/form/__tests__/Formatter.test.js
@@ -57,7 +57,6 @@ describe('formatter', () => {
     expect(shallow(formatter(props, {}, jest.fn()))).toMatchSnapshot();
   });
   it('render search input', () => {
-    // patternfly.FormGroup.mockImplementation(props => <div>{props.children}</div>);
     const props = {
       name: 'search adv',
       required: false,

--- a/webpack/JobWizard/steps/form/__tests__/Formatter.test.js
+++ b/webpack/JobWizard/steps/form/__tests__/Formatter.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import * as patternfly from '@patternfly/react-core';
+import { mount, shallow } from '@theforeman/test';
+import { formatter } from '../Formatter';
+
+jest.spyOn(patternfly, 'Select');
+jest.spyOn(patternfly, 'SelectOption');
+jest.spyOn(patternfly, 'FormGroup');
+patternfly.Select.mockImplementation(props => <div props={props} />);
+patternfly.SelectOption.mockImplementation(props => <div props={props} />);
+patternfly.FormGroup.mockImplementation(props => <div props={props} />);
+const mockStore = configureMockStore([]);
+const store = mockStore({});
+
+describe('formatter', () => {
+  it('render date input', () => {
+    const props = {
+      name: 'date adv',
+      required: false,
+      options: '',
+      advanced: true,
+      value_type: 'date',
+      resource_type: 'ansible_roles',
+      default: '',
+      hidden_value: false,
+    };
+    expect(shallow(formatter(props, {}, jest.fn()))).toMatchSnapshot();
+  });
+  it('render text input', () => {
+    const props = {
+      name: 'plain adv hidden',
+      required: true,
+      description: 'some Description',
+      options: '',
+      advanced: true,
+      value_type: 'plain',
+      resource_type: 'ansible_roles',
+      default: 'Default val',
+      hidden_value: true,
+    };
+    expect(shallow(formatter(props, {}, jest.fn()))).toMatchSnapshot();
+  });
+  it('render select input', () => {
+    const props = {
+      name: 'adv plain search',
+      required: false,
+      input_type: 'user',
+      options: 'a\r\nb\r\nc\r\nd',
+      advanced: true,
+      value_type: 'plain',
+      resource_type: 'ansible_roles',
+      default: '',
+      hidden_value: false,
+    };
+    expect(shallow(formatter(props, {}, jest.fn()))).toMatchSnapshot();
+  });
+  it('render search input', () => {
+    // patternfly.FormGroup.mockImplementation(props => <div>{props.children}</div>);
+    const props = {
+      name: 'search adv',
+      required: false,
+      options: '',
+      advanced: true,
+      value_type: 'search',
+      resource_type: 'foreman_tasks/tasks',
+      default: '',
+      hidden_value: false,
+    };
+    expect(
+      mount(
+        <Provider store={store}>{formatter(props, {}, jest.fn())}</Provider>
+      )
+    ).toMatchSnapshot();
+  });
+});

--- a/webpack/JobWizard/steps/form/__tests__/__snapshots__/Formatter.test.js.snap
+++ b/webpack/JobWizard/steps/form/__tests__/__snapshots__/Formatter.test.js.snap
@@ -149,7 +149,7 @@ exports[`formatter render text input 1`] = `
       "labelIcon": <Popover
         aria-label="help-text"
         bodyContent="some Description"
-        id="undefined-help"
+        id="plain adv hidden-help"
       >
         <button
           aria-label="open-help-tooltip-button"

--- a/webpack/JobWizard/steps/form/__tests__/__snapshots__/Formatter.test.js.snap
+++ b/webpack/JobWizard/steps/form/__tests__/__snapshots__/Formatter.test.js.snap
@@ -155,6 +155,7 @@ exports[`formatter render text input 1`] = `
           aria-label="open-help-tooltip-button"
           className="pf-c-form__group-label-help"
           onClick={[Function]}
+          type="button"
         >
           <HelpIcon
             color="currentColor"

--- a/webpack/JobWizard/steps/form/__tests__/__snapshots__/Formatter.test.js.snap
+++ b/webpack/JobWizard/steps/form/__tests__/__snapshots__/Formatter.test.js.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formatter render date input 1`] = `
+<div
+  props={
+    Object {
+      "children": <ForwardRef
+        className={null}
+        id="date adv"
+        onChange={[Function]}
+        placeholder="YYYY-mm-dd HH:MM"
+        required={false}
+        type="text"
+      />,
+      "fieldId": "date adv",
+      "isRequired": false,
+      "label": "date adv",
+      "labelIcon": null,
+    }
+  }
+/>
+`;
+
+exports[`formatter render search input 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <TemplateSearchField
+    controller="foreman_tasks/tasks"
+    defaultValue=""
+    key="search adv"
+    labelText={null}
+    name="search adv"
+    required={false}
+    setValue={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "search adv": undefined,
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    values={Object {}}
+  >
+    <mockConstructor
+      className="foreman-search-field"
+      fieldId="search adv"
+      isRequired={false}
+      label="search adv"
+      labelIcon={null}
+    >
+      <div
+        props={
+          Object {
+            "children": <SearchBar
+              data={
+                Object {
+                  "autocomplete": Object {
+                    "id": "search adv",
+                    "url": "/foreman_tasks/tasks/auto_complete_search",
+                    "useKeyShortcuts": true,
+                  },
+                  "controller": "foreman_tasks/tasks",
+                }
+              }
+              initialQuery=""
+              onSearch={[Function]}
+            />,
+            "className": "foreman-search-field",
+            "fieldId": "search adv",
+            "isRequired": false,
+            "label": "search adv",
+            "labelIcon": null,
+          }
+        }
+      />
+    </mockConstructor>
+  </TemplateSearchField>
+</Provider>
+`;
+
+exports[`formatter render select input 1`] = `
+<mockConstructor
+  fieldId="adv plain search"
+  label="adv plain search"
+>
+  <mockConstructor
+    className="without_select2"
+    isOpen={false}
+    isRequired={false}
+    maxHeight="45vh"
+    menuAppendTo={[Function]}
+    onSelect={[Function]}
+    onToggle={[Function]}
+    selections={null}
+  >
+    <mockConstructor
+      key="0"
+      value="a"
+    />
+    <mockConstructor
+      key="1"
+      value="b"
+    />
+    <mockConstructor
+      key="2"
+      value="c"
+    />
+    <mockConstructor
+      key="3"
+      value="d"
+    />
+  </mockConstructor>
+</mockConstructor>
+`;
+
+exports[`formatter render text input 1`] = `
+<div
+  props={
+    Object {
+      "children": <ForwardRef
+        className="masked-input"
+        id="plain adv hidden"
+        onChange={[Function]}
+        required={true}
+        rows={2}
+      />,
+      "fieldId": "plain adv hidden",
+      "isRequired": true,
+      "label": "plain adv hidden",
+      "labelIcon": <Popover
+        aria-label="help-text"
+        bodyContent="some Description"
+        id="undefined-help"
+      >
+        <button
+          aria-label="open-help-tooltip-button"
+          className="pf-c-form__group-label-help"
+          onClick={[Function]}
+        >
+          <HelpIcon
+            color="currentColor"
+            noVerticalAlign={true}
+            size="sm"
+          />
+        </button>
+      </Popover>,
+    }
+  }
+/>
+`;

--- a/webpack/__mocks__/foremanReact/components/SearchBar.js
+++ b/webpack/__mocks__/foremanReact/components/SearchBar.js
@@ -1,2 +1,4 @@
-const SearchBar = () => jest.fn();
+import React from 'react';
+
+const SearchBar = () => <div>search</div>;
 export default SearchBar;


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman_remote_execution/pull/553

render the inputs from `template_inputs_with_foreign` into the advanced field step
New:
![Screenshot from 2020-12-06 15-24-44](https://user-images.githubusercontent.com/30431079/101286831-6b33bc80-37f5-11eb-9f43-5630c58cef9c.png)

old:
![Screenshot from 2020-12-06 15-25-10](https://user-images.githubusercontent.com/30431079/101286827-67a03580-37f5-11eb-9cc3-52000224c8c9.png)