### PR TITLE
Fixes #31460 - add description field to job wizard

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Wizard } from '@patternfly/react-core';
@@ -17,23 +18,31 @@ export const JobWizard = () => {
   const [advancedValues, setAdvancedValues] = useState({});
   const dispatch = useDispatch();
 
-  const setDefaults = useCallback(response => {
-    const responseJob = response.data;
-    const advancedTemplateValues = {};
-    const advancedInputs = responseJob.advanced_template_inputs;
-    if (advancedInputs) {
-      advancedInputs.forEach(input => {
-        advancedTemplateValues[input.name] = input?.default || '';
-      });
-    }
-    setAdvancedValues(currentAdvancedValues => ({
-      ...currentAdvancedValues,
-      effectiveUserValue: responseJob.effective_user?.value || '',
-      timeoutToKill: responseJob.job_template?.executionTimeoutInterval || '',
-      templateValues: advancedTemplateValues,
-      description: responseJob.job_template.description_format || '',
-    }));
-  }, []);
+  const setDefaults = useCallback(
+    ({
+      data: {
+        advanced_template_inputs,
+        effective_user,
+        job_template: { executionTimeoutInterval, description_format },
+      },
+    }) => {
+      const advancedTemplateValues = {};
+      const advancedInputs = advanced_template_inputs;
+      if (advancedInputs) {
+        advancedInputs.forEach(input => {
+          advancedTemplateValues[input.name] = input?.default || '';
+        });
+      }
+      setAdvancedValues(currentAdvancedValues => ({
+        ...currentAdvancedValues,
+        effectiveUserValue: effective_user?.value || '',
+        timeoutToKill: executionTimeoutInterval || '',
+        templateValues: advancedTemplateValues,
+        description: description_format || '',
+      }));
+    },
+    []
+  );
   useEffect(() => {
     if (jobTemplateID) {
       dispatch(

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -31,6 +31,7 @@ export const JobWizard = () => {
       effectiveUserValue: responseJob.effective_user?.value || '',
       timeoutToKill: responseJob.job_template?.executionTimeoutInterval || '',
       templateValues: advancedTemplateValues,
+      description: responseJob.job_template.description_format || '',
     }));
   }, []);
   useEffect(() => {

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -6,6 +6,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import {
   selectEffectiveUser,
   selectAdvancedTemplateInputs,
+  selectTemplateInputs,
 } from '../../JobWizardSelectors';
 import {
   EffectiveUserField,
@@ -21,7 +22,8 @@ import { DescriptionField } from './DescriptionField';
 
 export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
   const effectiveUser = useSelector(selectEffectiveUser);
-  const templateInputs = useSelector(selectAdvancedTemplateInputs);
+  const advancedTemplateInputs = useSelector(selectAdvancedTemplateInputs);
+  const templateInputs = useSelector(selectTemplateInputs);
   return (
     <>
       <Title headingLevel="h2" className="advanced-fields-title">
@@ -29,7 +31,7 @@ export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
       </Title>
       <Form id="advanced-fields-job-template" autoComplete="off">
         <TemplateInputsFields
-          inputs={templateInputs}
+          inputs={advancedTemplateInputs}
           value={advancedValues.templateValues}
           setValue={newValue => setAdvancedValues({ templateValues: newValue })}
         />
@@ -44,11 +46,9 @@ export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
           />
         )}
         <DescriptionField
-          inputs={templateInputs.filter(input => !input.advanced)}
+          inputs={templateInputs}
           value={advancedValues.description}
-          setValue={newValue =>
-            setAdvancedValues({ ...advancedValues, description: newValue })
-          }
+          setValue={newValue => setAdvancedValues({ description: newValue })}
         />
         <TimeoutToKillField
           value={advancedValues.timeoutToKill}

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -17,6 +17,7 @@ import {
   TimeSpanLevelField,
   TemplateInputsFields,
 } from './Fields';
+import { DescriptionField } from './DescriptionField';
 
 export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
   const effectiveUser = useSelector(selectEffectiveUser);
@@ -42,6 +43,13 @@ export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
             }
           />
         )}
+        <DescriptionField
+          inputs={templateInputs.filter(input => !input.advanced)}
+          value={advancedValues.description}
+          setValue={newValue =>
+            setAdvancedValues({ ...advancedValues, description: newValue })
+          }
+        />
         <TimeoutToKillField
           value={advancedValues.timeoutToKill}
           setValue={newValue =>

--- a/webpack/JobWizard/steps/AdvancedFields/DescriptionField.js
+++ b/webpack/JobWizard/steps/AdvancedFields/DescriptionField.js
@@ -25,26 +25,22 @@ export const DescriptionField = ({ inputs, value, setValue }) => {
   const [generatedDesc, setGeneratedDesc] = useState(generateDesc());
   const [isPreview, setIsPreview] = useState(true);
 
-  const togglePreview = newValue => {
+  const togglePreview = () => {
     setGeneratedDesc(generateDesc());
-    setIsPreview(newValue);
+    setIsPreview(v => !v);
   };
 
-  const showPreview = (
-    <Button variant="link" isInline onClick={() => togglePreview(true)}>
-      {__('See the custom job description')}
-    </Button>
-  );
-  const hidePreview = (
-    <Button variant="link" isInline onClick={() => togglePreview(false)}>
-      {__('Set the custom job description')}
-    </Button>
-  );
   return (
     <FormGroup
       label={__('Description')}
       fieldId="description"
-      helperText={isPreview ? hidePreview : showPreview}
+      helperText={
+        <Button variant="link" isInline onClick={togglePreview}>
+          {isPreview
+            ? __('Edit job description template')
+            : __('Preview job description')}
+        </Button>
+      }
     >
       {isPreview ? (
         <TextInput id="description-preview" value={generatedDesc} isDisabled />

--- a/webpack/JobWizard/steps/AdvancedFields/DescriptionField.js
+++ b/webpack/JobWizard/steps/AdvancedFields/DescriptionField.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { FormGroup, TextInput, Button } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const DescriptionField = ({ inputs, value, setValue }) => {
+  const generateDesc = () => {
+    let newDesc = value;
+    if (value) {
+      const re = new RegExp('%\\{([^\\}]+)\\}', 'gm');
+      const results = [...newDesc.matchAll(re)].map(result => ({
+        name: result[1],
+        text: result[0],
+      }));
+      results.forEach(result => {
+        newDesc = newDesc.replace(
+          result.text,
+          // TODO: Replace with the value of the input from Target Hosts step
+          inputs.find(input => input.name === result.name)?.name || result.text
+        );
+      });
+    }
+    return newDesc;
+  };
+  const [generatedDesc, setGeneratedDesc] = useState(generateDesc());
+  const [isPreview, setIsPreview] = useState(true);
+
+  const togglePreview = newValue => {
+    setGeneratedDesc(generateDesc());
+    setIsPreview(newValue);
+  };
+
+  const showPreview = (
+    <Button variant="link" isInline onClick={() => togglePreview(true)}>
+      {__('See the custom job description')}
+    </Button>
+  );
+  const hidePreview = (
+    <Button variant="link" isInline onClick={() => togglePreview(false)}>
+      {__('Set the custom job description')}
+    </Button>
+  );
+  return (
+    <FormGroup
+      label={__('Description')}
+      fieldId="description"
+      helperText={isPreview ? hidePreview : showPreview}
+    >
+      {isPreview ? (
+        <TextInput id="description-preview" value={generatedDesc} isDisabled />
+      ) : (
+        <TextInput
+          type="text"
+          autoComplete="description"
+          id="description"
+          value={value}
+          onChange={newValue => setValue(newValue)}
+        />
+      )}
+    </FormGroup>
+  );
+};
+
+DescriptionField.propTypes = {
+  inputs: PropTypes.array.isRequired,
+  value: PropTypes.string,
+  setValue: PropTypes.func.isRequired,
+};
+DescriptionField.defaultProps = {
+  value: '',
+};

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/DescriptionField.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/DescriptionField.test.js
@@ -13,11 +13,11 @@ describe('DescriptionField', () => {
     );
     const preview = component.find('#description-preview').hostNodes();
     const findLink = () => component.find('.pf-m-link.pf-m-inline');
-    expect(findLink().text()).toEqual('Set the custom job description');
+    expect(findLink().text()).toEqual('Edit job description template');
     expect(preview.props().value).toEqual('Run command');
     findLink().simulate('click');
     const description = component.find('#description').hostNodes();
     expect(description.props().value).toEqual('Run %{command}');
-    expect(findLink().text()).toEqual('See the custom job description');
+    expect(findLink().text()).toEqual('Preview job description');
   });
 });

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/DescriptionField.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/DescriptionField.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { mount } from '@theforeman/test';
+import { DescriptionField } from '../DescriptionField';
+
+describe('DescriptionField', () => {
+  it('rendring', () => {
+    const component = mount(
+      <DescriptionField
+        inputs={[{ name: 'command' }]}
+        value="Run %{command}"
+        setValue={jest.fn()}
+      />
+    );
+    const preview = component.find('#description-preview').hostNodes();
+    const findLink = () => component.find('.pf-m-link.pf-m-inline');
+    expect(findLink().text()).toEqual('Set the custom job description');
+    expect(preview.props().value).toEqual('Run command');
+    findLink().simulate('click');
+    const description = component.find('#description').hostNodes();
+    expect(description.props().value).toEqual('Run %{command}');
+    expect(findLink().text()).toEqual('See the custom job description');
+  });
+});


### PR DESCRIPTION
Adds the final field to the advanced step. Depends on https://github.com/theforeman/foreman_remote_execution/pull/554
As the step to edit the template inputs doesn't exist yet, it doesn't use the value of the input but the name of the input instead.

New:
![Screenshot from 2020-12-07 11-43-51](https://user-images.githubusercontent.com/30431079/101335170-821ff080-3881-11eb-93eb-c1b8b1255fee.png)
onclick it moves to this:

![Screenshot from 2020-12-07 11-43-47](https://user-images.githubusercontent.com/30431079/101335175-82b88700-3881-11eb-9eb2-5a561e64bf83.png)

old:
![image (3)](https://user-images.githubusercontent.com/30431079/101335394-d034f400-3881-11eb-9ed1-1cd2420a8aea.png)


Original generate description is here:
https://github.com/theforeman/foreman_remote_execution/blob/ab166f9d760d0148bdd5dd0672503f57acdf47bb/app/assets/javascripts/foreman_remote_execution/template_invocation.js#L102-L122