### PR TITLE
Fixes #31492 - Add basic hosts and inputs page

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -3,11 +3,10 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Wizard } from '@patternfly/react-core';
 import { get } from 'foremanReact/redux/API';
-import { translate as __ } from 'foremanReact/common/I18n';
 import history from 'foremanReact/history';
 import CategoryAndTemplate from './steps/CategoryAndTemplate/';
 import { AdvancedFields } from './steps/AdvancedFields/AdvancedFields';
-import { JOB_TEMPLATE } from './JobWizardConstants';
+import { JOB_TEMPLATE, WIZARD_TITLES } from './JobWizardConstants';
 import { selectTemplateError } from './JobWizardSelectors';
 import Schedule from './steps/Schedule/';
 import HostsAndInputs from './steps/HostsAndInputs/';
@@ -71,7 +70,7 @@ export const JobWizard = () => {
   const isTemplate = !templateError && !!jobTemplateID;
   const steps = [
     {
-      name: __('Category and Template'),
+      name: WIZARD_TITLES.categoryAndTemplate,
       component: (
         <CategoryAndTemplate
           jobTemplate={jobTemplateID}
@@ -82,7 +81,7 @@ export const JobWizard = () => {
       ),
     },
     {
-      name: __('Target hosts and inputs'),
+      name: WIZARD_TITLES.hostsAndInputs,
       component: (
         <HostsAndInputs
           templateValues={templateValues}
@@ -94,7 +93,7 @@ export const JobWizard = () => {
       canJumpTo: isTemplate,
     },
     {
-      name: __('Advanced Fields'),
+      name: WIZARD_TITLES.advanced,
       component: (
         <AdvancedFields
           advancedValues={advancedValues}
@@ -110,12 +109,12 @@ export const JobWizard = () => {
       canJumpTo: isTemplate,
     },
     {
-      name: __('Schedule'),
+      name: WIZARD_TITLES.schedule,
       component: <Schedule />,
       canJumpTo: isTemplate,
     },
     {
-      name: __('Review Details'),
+      name: WIZARD_TITLES.review,
       component: <p>Review Details</p>,
       nextButtonText: 'Run',
       canJumpTo: isTemplate,

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -16,7 +16,7 @@ export const JobWizard = () => {
   const [jobTemplateID, setJobTemplateID] = useState(null);
   const [category, setCategory] = useState('');
   const [advancedValues, setAdvancedValues] = useState({});
-  const [templateValues, setTemplateValues] = useState({}); // TODO use templateValues in advanced fields - description
+  const [templateValues, setTemplateValues] = useState({}); // TODO use templateValues in advanced fields - description https://github.com/theforeman/foreman_remote_execution/pull/605
   const [selectedHosts, setSelectedHosts] = useState(['host1', 'host2']);
   const dispatch = useDispatch();
 
@@ -33,24 +33,28 @@ export const JobWizard = () => {
       const defaultTemplateValues = {};
       const inputs = template_inputs;
       const advancedInputs = advanced_template_inputs;
-      if (advancedInputs) {
-        advancedInputs.forEach(input => {
-          advancedTemplateValues[input.name] = input?.default || '';
-        });
-      }
       if (inputs) {
-        inputs.forEach(input => {
-          defaultTemplateValues[input.name] = input?.default || '';
+        setTemplateValues(() => {
+          inputs.forEach(input => {
+            defaultTemplateValues[input.name] = input?.default || '';
+          });
+          return defaultTemplateValues;
         });
       }
-      setTemplateValues(defaultTemplateValues);
-      setAdvancedValues(currentAdvancedValues => ({
-        ...currentAdvancedValues,
-        effectiveUserValue: effective_user?.value || '',
-        timeoutToKill: executionTimeoutInterval || '',
-        templateValues: advancedTemplateValues,
-        description: description_format || '',
-      }));
+      setAdvancedValues(currentAdvancedValues => {
+        if (advancedInputs) {
+          advancedInputs.forEach(input => {
+            advancedTemplateValues[input.name] = input?.default || '';
+          });
+        }
+        return {
+          ...currentAdvancedValues,
+          effectiveUserValue: effective_user?.value || '',
+          timeoutToKill: executionTimeoutInterval || '',
+          templateValues: advancedTemplateValues,
+          description: description_format || '',
+        };
+      });
     },
     []
   );

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -10,29 +10,41 @@ import { AdvancedFields } from './steps/AdvancedFields/AdvancedFields';
 import { JOB_TEMPLATE } from './JobWizardConstants';
 import { selectTemplateError } from './JobWizardSelectors';
 import Schedule from './steps/Schedule/';
+import HostsAndInputs from './steps/HostsAndInputs/';
 import './JobWizard.scss';
 
 export const JobWizard = () => {
   const [jobTemplateID, setJobTemplateID] = useState(null);
   const [category, setCategory] = useState('');
   const [advancedValues, setAdvancedValues] = useState({});
+  const [templateValues, setTemplateValues] = useState({}); // TODO use templateValues in advanced fields - description
+  const [selectedHosts, setSelectedHosts] = useState(['host1', 'host2']);
   const dispatch = useDispatch();
 
   const setDefaults = useCallback(
     ({
       data: {
+        template_inputs,
         advanced_template_inputs,
         effective_user,
         job_template: { executionTimeoutInterval, description_format },
       },
     }) => {
       const advancedTemplateValues = {};
+      const defaultTemplateValues = {};
+      const inputs = template_inputs;
       const advancedInputs = advanced_template_inputs;
       if (advancedInputs) {
         advancedInputs.forEach(input => {
           advancedTemplateValues[input.name] = input?.default || '';
         });
       }
+      if (inputs) {
+        inputs.forEach(input => {
+          defaultTemplateValues[input.name] = input?.default || '';
+        });
+      }
+      setTemplateValues(defaultTemplateValues);
       setAdvancedValues(currentAdvancedValues => ({
         ...currentAdvancedValues,
         effectiveUserValue: effective_user?.value || '',
@@ -70,8 +82,15 @@ export const JobWizard = () => {
       ),
     },
     {
-      name: __('Target Hosts'),
-      component: <p>Target Hosts</p>,
+      name: __('Target hosts and inputs'),
+      component: (
+        <HostsAndInputs
+          templateValues={templateValues}
+          setTemplateValues={setTemplateValues}
+          selectedHosts={selectedHosts}
+          setSelectedHosts={setSelectedHosts}
+        />
+      ),
       canJumpTo: isTemplate,
     },
     {

--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -58,4 +58,8 @@
       text-align: start;
     }
   }
+  textarea {
+    min-height: 40px;
+    min-width: 100px;
+  }
 }

--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -1,5 +1,10 @@
 .job-wizard {
+  .wizard-title {
+    margin-bottom: 25px;
+  }
+
   .pf-c-wizard__main {
+    overflow: visible;
     z-index: calc(
       var(--pf-c-wizard__footer--ZIndex) + 1
     ); // So the select box can be shown above the wizard footer
@@ -41,6 +46,9 @@
     }
   }
 
+  .hosts-chip-group {
+    margin-top: 8px;
+  }
   .schedule-tab {
     input[type='radio'],
     input[type='checkbox'] {

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -14,3 +14,11 @@ export const repeatTypes = {
   daily: __('Daily'),
   hourly: __('Hourly'),
 };
+
+export const WIZARD_TITLES = {
+  categoryAndTemplate: __('Category and Template'),
+  hostsAndInputs: __('Target hosts and inputs'),
+  advanced: __('Advanced Fields'),
+  schedule: __('Schedule'),
+  review: __('Review Details'),
+};

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -93,6 +93,14 @@ export const testSetup = (selectors, api) => {
   jest.spyOn(selectors, 'selectJobCategories');
   jest.spyOn(selectors, 'selectJobCategoriesStatus');
 
+  jest.spyOn(selectors, 'selectTemplateInputs');
+  jest.spyOn(selectors, 'selectAdvancedTemplateInputs');
+  selectors.selectTemplateInputs.mockImplementation(
+    () => jobTemplateResponse.template_inputs
+  );
+  selectors.selectAdvancedTemplateInputs.mockImplementation(
+    () => jobTemplateResponse.advanced_template_inputs
+  );
   selectors.selectJobCategories.mockImplementation(() => jobCategories);
   selectors.selectJobTemplates.mockImplementation(() => [
     jobTemplate,

--- a/webpack/JobWizard/__tests__/integration.test.js
+++ b/webpack/JobWizard/__tests__/integration.test.js
@@ -5,6 +5,7 @@ import { render, fireEvent, screen, act } from '@testing-library/react';
 import * as api from 'foremanReact/redux/API';
 import { JobWizard } from '../JobWizard';
 import * as selectors from '../JobWizardSelectors';
+import { WIZARD_TITLES } from '../JobWizardConstants';
 import {
   testSetup,
   mockApi,
@@ -62,13 +63,8 @@ describe('Job wizard fill', () => {
         <JobWizard />
       </Provider>
     );
-    const steps = [
-      'Target hosts and inputs',
-      'Advanced Fields',
-      'Schedule',
-      'Review Details',
-      'Category and Template',
-    ];
+    const titles = Object.values(WIZARD_TITLES);
+    const steps = [titles[1], titles[0], ...titles.slice(2)]; // the first title is selected at the beggining
     // eslint-disable-next-line no-unused-vars
     for await (const step of steps) {
       const stepSelector = screen.getByText(step);

--- a/webpack/JobWizard/__tests__/integration.test.js
+++ b/webpack/JobWizard/__tests__/integration.test.js
@@ -63,7 +63,7 @@ describe('Job wizard fill', () => {
       </Provider>
     );
     const steps = [
-      'Target Hosts',
+      'Target hosts and inputs',
       'Advanced Fields',
       'Schedule',
       'Review Details',

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { Title, Form } from '@patternfly/react-core';
-import { translate as __ } from 'foremanReact/common/I18n';
+import { Form } from '@patternfly/react-core';
 import {
   selectEffectiveUser,
   selectAdvancedTemplateInputs,
@@ -19,6 +18,8 @@ import {
   TemplateInputsFields,
 } from './Fields';
 import { DescriptionField } from './DescriptionField';
+import { WIZARD_TITLES } from '../../JobWizardConstants';
+import { WizardTitle } from '../form/WizardTitle';
 
 export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
   const effectiveUser = useSelector(selectEffectiveUser);
@@ -26,9 +27,10 @@ export const AdvancedFields = ({ advancedValues, setAdvancedValues }) => {
   const templateInputs = useSelector(selectTemplateInputs);
   return (
     <>
-      <Title headingLevel="h2" className="advanced-fields-title">
-        {__('Advanced Fields')}
-      </Title>
+      <WizardTitle
+        title={WIZARD_TITLES.advanced}
+        className="advanced-fields-title"
+      />
       <Form id="advanced-fields-job-template" autoComplete="off">
         <TemplateInputsFields
           inputs={advancedTemplateInputs}

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -10,6 +10,7 @@ import {
   testSetup,
   mockApi,
 } from '../../../__tests__/fixtures';
+import { WIZARD_TITLES } from '../../../JobWizardConstants';
 
 const store = testSetup(selectors, api);
 mockApi(api);
@@ -82,7 +83,7 @@ describe('AdvancedFields', () => {
       </Provider>
     );
     await act(async () => {
-      fireEvent.click(screen.getByText('Advanced Fields'));
+      fireEvent.click(screen.getByText(WIZARD_TITLES.advanced));
     });
     const searchValue = 'search test';
     const textValue = 'I am a text';
@@ -99,7 +100,7 @@ describe('AdvancedFields', () => {
     fireEvent.click(selectField);
     await act(async () => {
       await fireEvent.click(screen.getByText('option 2'));
-      fireEvent.click(screen.getAllByText('Advanced Fields')[0]); // to remove focus
+      fireEvent.click(screen.getAllByText(WIZARD_TITLES.advanced)[0]); // to remove focus
       await fireEvent.change(textField, {
         target: { value: textValue },
       });
@@ -119,9 +120,11 @@ describe('AdvancedFields', () => {
     expect(searchField.value).toBe(searchValue);
     expect(dateField.value).toBe(dateValue);
     await act(async () => {
-      fireEvent.click(screen.getByText('Category and Template'));
+      fireEvent.click(screen.getByText(WIZARD_TITLES.categoryAndTemplate));
     });
-    expect(screen.getAllByText('Category and Template')).toHaveLength(3);
+    expect(screen.getAllByText(WIZARD_TITLES.categoryAndTemplate)).toHaveLength(
+      3
+    );
 
     await act(async () => {
       fireEvent.click(screen.getByText('Advanced Fields'));

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -15,18 +15,9 @@ const store = testSetup(selectors, api);
 mockApi(api);
 
 jest.spyOn(selectors, 'selectEffectiveUser');
-jest.spyOn(selectors, 'selectTemplateInputs');
-jest.spyOn(selectors, 'selectAdvancedTemplateInputs');
 
 selectors.selectEffectiveUser.mockImplementation(
   () => jobTemplate.effective_user
-);
-selectors.selectTemplateInputs.mockImplementation(
-  () => jobTemplate.template_inputs
-);
-
-selectors.selectAdvancedTemplateInputs.mockImplementation(
-  () => jobTemplate.advanced_template_inputs
 );
 describe('AdvancedFields', () => {
   it('should save data between steps for advanced fields', async () => {
@@ -72,7 +63,7 @@ describe('AdvancedFields', () => {
       .simulate('click');
 
     expect(wrapper.find('.pf-c-wizard__nav-link.pf-m-current').text()).toEqual(
-      'Target Hosts'
+      'Target hosts and inputs'
     );
     wrapper
       .find('.pf-c-wizard__nav-link')

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Title, Text, TextVariants, Form, Alert } from '@patternfly/react-core';
+import { Text, TextVariants, Form, Alert } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { SelectField } from '../form/SelectField';
 import { GroupedSelectField } from '../form/GroupedSelectField';
+import { WizardTitle } from '../form/WizardTitle';
+import { WIZARD_TITLES } from '../../JobWizardConstants';
 
 export const CategoryAndTemplate = ({
   jobCategories,
@@ -40,9 +42,7 @@ export const CategoryAndTemplate = ({
   const isError = !!(categoryError || allTemplatesError || templateError);
   return (
     <>
-      <Title headingLevel="h2" className="wizard-title">
-        {__('Category and Template')}
-      </Title>
+      <WizardTitle title={WIZARD_TITLES.categoryAndTemplate} />
       <Text component={TextVariants.p}>{__('All fields are required.')}</Text>
       <Form>
         <SelectField

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
@@ -40,7 +40,9 @@ export const CategoryAndTemplate = ({
   const isError = !!(categoryError || allTemplatesError || templateError);
   return (
     <>
-      <Title headingLevel="h2">{__('Category and Template')}</Title>
+      <Title headingLevel="h2" className="wizard-title">
+        {__('Category and Template')}
+      </Title>
       <Text component={TextVariants.p}>{__('All fields are required.')}</Text>
       <Form>
         <SelectField

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.test.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.test.js
@@ -5,6 +5,7 @@ import * as api from 'foremanReact/redux/API';
 import { JobWizard } from '../../JobWizard';
 import * as selectors from '../../JobWizardSelectors';
 import { testSetup, mockApi } from '../../__tests__/fixtures';
+import { WIZARD_TITLES } from '../../JobWizardConstants';
 
 const store = testSetup(selectors, api);
 mockApi(api);
@@ -32,7 +33,7 @@ describe('Category And Template', () => {
     await act(async () => {
       await fireEvent.click(screen.getByText('Puppet'));
     });
-    fireEvent.click(screen.getAllByText('Category and Template')[0]); // to remove focus
+    fireEvent.click(screen.getAllByText(WIZARD_TITLES.categoryAndTemplate)[0]); // to remove focus
     expect(
       screen.queryAllByLabelText('Ansible Commands', { selector: 'button' })
     ).toHaveLength(0);
@@ -47,7 +48,7 @@ describe('Category And Template', () => {
     await act(async () => {
       await fireEvent.click(screen.getByText('template2'));
     });
-    fireEvent.click(screen.getAllByText('Category and Template')[0]); // to remove focus
+    fireEvent.click(screen.getAllByText(WIZARD_TITLES.categoryAndTemplate)[0]); // to remove focus
     expect(
       screen.queryAllByDisplayValue('template1', { selector: 'button' })
     ).toHaveLength(0);

--- a/webpack/JobWizard/steps/HostsAndInputs/SelectedChips.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/SelectedChips.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Chip, ChipGroup } from '@patternfly/react-core';
+
+export const SelectedChips = ({ selected, setSelected }) => {
+  const deleteItem = itemToRemove => {
+    setSelected(oldSelected =>
+      oldSelected.filter(item => item !== itemToRemove)
+    );
+  };
+  return (
+    <ChipGroup className="hosts-chip-group">
+      {selected.map(chip => (
+        <Chip key={chip} id={chip} onClick={() => deleteItem(chip)}>
+          {chip}
+        </Chip>
+      ))}
+    </ChipGroup>
+  );
+};
+
+SelectedChips.propTypes = {
+  selected: PropTypes.array.isRequired,
+  setSelected: PropTypes.func.isRequired,
+};

--- a/webpack/JobWizard/steps/HostsAndInputs/TemplateInputs.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/TemplateInputs.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { formatter } from '../form/Formatter';
+
+export const TemplateInputs = ({ inputs, value, setValue }) => {
+  if (inputs.length)
+    return <>{inputs?.map(input => formatter(input, value, setValue))}</>;
+  return (
+    <p className="gray-text">
+      {__('There are no available input fields for the selected template.')}
+    </p>
+  );
+};
+TemplateInputs.propTypes = {
+  inputs: PropTypes.array.isRequired,
+  value: PropTypes.object,
+  setValue: PropTypes.func.isRequired,
+};
+
+TemplateInputs.defaultProps = {
+  value: {},
+};

--- a/webpack/JobWizard/steps/HostsAndInputs/TemplateInputs.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/TemplateInputs.js
@@ -5,7 +5,7 @@ import { formatter } from '../form/Formatter';
 
 export const TemplateInputs = ({ inputs, value, setValue }) => {
   if (inputs.length)
-    return <>{inputs?.map(input => formatter(input, value, setValue))}</>;
+    return inputs.map(input => formatter(input, value, setValue));
   return (
     <p className="gray-text">
       {__('There are no available input fields for the selected template.')}

--- a/webpack/JobWizard/steps/HostsAndInputs/__tests__/SelectedChips.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/__tests__/SelectedChips.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { fireEvent, screen, render, act } from '@testing-library/react';
+import * as api from 'foremanReact/redux/API';
+import { JobWizard } from '../../../JobWizard';
+import * as selectors from '../../../JobWizardSelectors';
+import { testSetup, mockApi } from '../../../__tests__/fixtures';
+
+const store = testSetup(selectors, api);
+mockApi(api);
+
+describe('TemplateInputs', () => {
+  it('should save data between steps for template input fields', async () => {
+    render(
+      <Provider store={store}>
+        <JobWizard advancedValues={{}} setAdvancedValues={jest.fn()} />
+      </Provider>
+    );
+    await act(async () => {
+      await fireEvent.click(
+        screen.getByText('Target hosts and inputs', { selector: 'button' })
+      );
+    });
+
+    expect(
+      screen.getAllByLabelText('host2', { selector: 'button' })
+    ).toHaveLength(1);
+    const chip1 = screen.getByLabelText('host1', { selector: 'button' });
+    fireEvent.click(chip1);
+    expect(
+      screen.queryAllByLabelText('host1', { selector: 'button' })
+    ).toHaveLength(0);
+    expect(
+      screen.queryAllByLabelText('host2', { selector: 'button' })
+    ).toHaveLength(1);
+  });
+});

--- a/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { fireEvent, screen, render, act } from '@testing-library/react';
+import * as api from 'foremanReact/redux/API';
+import { JobWizard } from '../../../JobWizard';
+import * as selectors from '../../../JobWizardSelectors';
+import { testSetup, mockApi } from '../../../__tests__/fixtures';
+
+const store = testSetup(selectors, api);
+mockApi(api);
+
+describe('TemplateInputs', () => {
+  it('should save data between steps for template input fields', async () => {
+    render(
+      <Provider store={store}>
+        <JobWizard />
+      </Provider>
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Target hosts and inputs'));
+    });
+    const textValue = 'I am a plain text';
+    const textField = screen.getByLabelText('plain hidden', {
+      selector: 'textarea',
+    });
+
+    await act(async () => {
+      await fireEvent.change(textField, {
+        target: { value: textValue },
+      });
+    });
+    expect(
+      screen.getByLabelText('plain hidden', {
+        selector: 'textarea',
+      }).value
+    ).toBe(textValue);
+    await act(async () => {
+      fireEvent.click(screen.getByText('Category and Template'));
+    });
+    expect(screen.getAllByText('Category and Template')).toHaveLength(3);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Target hosts and inputs'));
+    });
+    expect(textField.value).toBe(textValue);
+  });
+});

--- a/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
@@ -5,6 +5,7 @@ import * as api from 'foremanReact/redux/API';
 import { JobWizard } from '../../../JobWizard';
 import * as selectors from '../../../JobWizardSelectors';
 import { testSetup, mockApi } from '../../../__tests__/fixtures';
+import { WIZARD_TITLES } from '../../../JobWizardConstants';
 
 const store = testSetup(selectors, api);
 mockApi(api);
@@ -17,7 +18,7 @@ describe('TemplateInputs', () => {
       </Provider>
     );
     await act(async () => {
-      fireEvent.click(screen.getByText('Target hosts and inputs'));
+      fireEvent.click(screen.getByText(WIZARD_TITLES.hostsAndInputs));
     });
     const textValue = 'I am a plain text';
     const textField = screen.getByLabelText('plain hidden', {
@@ -35,12 +36,14 @@ describe('TemplateInputs', () => {
       }).value
     ).toBe(textValue);
     await act(async () => {
-      fireEvent.click(screen.getByText('Category and Template'));
+      fireEvent.click(screen.getByText(WIZARD_TITLES.categoryAndTemplate));
     });
-    expect(screen.getAllByText('Category and Template')).toHaveLength(3);
+    expect(screen.getAllByText(WIZARD_TITLES.categoryAndTemplate)).toHaveLength(
+      3
+    );
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Target hosts and inputs'));
+      fireEvent.click(screen.getByText(WIZARD_TITLES.hostsAndInputs));
     });
     expect(textField.value).toBe(textValue);
   });

--- a/webpack/JobWizard/steps/HostsAndInputs/index.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/index.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { Title, Button, Form, FormGroup } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { selectTemplateInputs } from '../../JobWizardSelectors';
+import { SelectField } from '../form/SelectField';
+import { SelectedChips } from './SelectedChips';
+import { TemplateInputs } from './TemplateInputs';
+
+const HostsAndInputs = ({
+  templateValues,
+  setTemplateValues,
+  selectedHosts,
+  setSelectedHosts,
+}) => {
+  const templateInputs = useSelector(selectTemplateInputs);
+  const hostMethods = [
+    __('Hosts'),
+    __('Host collection'),
+    __('Host group'),
+    __('Search query'),
+  ];
+  const [hostMethod, setHostMethod] = useState(hostMethods[0]);
+  return (
+    <>
+      <Title headingLevel="h2" className="wizard-title">
+        {__('Target hosts and inputs')}
+      </Title>
+      <Form>
+        <FormGroup fieldId="host_selection">
+          <SelectField
+            fieldId="host_methods"
+            options={hostMethods}
+            setValue={setHostMethod}
+            value={hostMethod}
+          />
+          <SelectedChips
+            selected={selectedHosts}
+            setSelected={setSelectedHosts}
+          />
+        </FormGroup>
+        <span>
+          {__('Apply to')}{' '}
+          <Button variant="link" isInline>
+            {selectedHosts.length} {__('hosts')}
+          </Button>
+        </span>
+        <TemplateInputs
+          inputs={templateInputs}
+          value={templateValues}
+          setValue={setTemplateValues}
+        />
+      </Form>
+    </>
+  );
+};
+
+HostsAndInputs.propTypes = {
+  templateValues: PropTypes.object.isRequired,
+  setTemplateValues: PropTypes.func.isRequired,
+  selectedHosts: PropTypes.array.isRequired,
+  setSelectedHosts: PropTypes.func.isRequired,
+};
+
+export default HostsAndInputs;

--- a/webpack/JobWizard/steps/HostsAndInputs/index.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Title, Button, Form, FormGroup } from '@patternfly/react-core';
+import { Button, Form, FormGroup } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -7,6 +7,8 @@ import { selectTemplateInputs } from '../../JobWizardSelectors';
 import { SelectField } from '../form/SelectField';
 import { SelectedChips } from './SelectedChips';
 import { TemplateInputs } from './TemplateInputs';
+import { WIZARD_TITLES } from '../../JobWizardConstants';
+import { WizardTitle } from '../form/WizardTitle';
 
 const HostsAndInputs = ({
   templateValues,
@@ -24,9 +26,7 @@ const HostsAndInputs = ({
   const [hostMethod, setHostMethod] = useState(hostMethods[0]);
   return (
     <>
-      <Title headingLevel="h2" className="wizard-title">
-        {__('Target hosts and inputs')}
-      </Title>
+      <WizardTitle title={WIZARD_TITLES.hostsAndInputs} />
       <Form>
         <FormGroup fieldId="host_selection">
           <SelectField

--- a/webpack/JobWizard/steps/Schedule/index.js
+++ b/webpack/JobWizard/steps/Schedule/index.js
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { Title, Button, Form } from '@patternfly/react-core';
+import { Button, Form } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { ScheduleType } from './ScheduleType';
 import { RepeatOn } from './RepeatOn';
 import { QueryType } from './QueryType';
 import { StartEndDates } from './StartEndDates';
-import { repeatTypes } from '../../JobWizardConstants';
+import { repeatTypes, WIZARD_TITLES } from '../../JobWizardConstants';
+import { WizardTitle } from '../form/WizardTitle';
 
 const Schedule = () => {
   const [repeatType, setRepeatType] = useState(repeatTypes.noRepeat);
@@ -14,27 +15,29 @@ const Schedule = () => {
   const [ends, setEnds] = useState('');
 
   return (
-    <Form className="schedule-tab">
-      <Title headingLevel="h2">{__('Schedule')}</Title>
-      <ScheduleType />
+    <>
+      <WizardTitle title={WIZARD_TITLES.schedule} />
+      <Form className="schedule-tab">
+        <ScheduleType />
 
-      <RepeatOn
-        repeatType={repeatType}
-        setRepeatType={setRepeatType}
-        repeatAmount={repeatAmount}
-        setRepeatAmount={setRepeatAmount}
-      />
-      <StartEndDates
-        starts={starts}
-        setStarts={setStarts}
-        ends={ends}
-        setEnds={setEnds}
-      />
-      <Button variant="link" className="advanced-scheduling-button" isInline>
-        {__('Advanced scheduling')}
-      </Button>
-      <QueryType />
-    </Form>
+        <RepeatOn
+          repeatType={repeatType}
+          setRepeatType={setRepeatType}
+          repeatAmount={repeatAmount}
+          setRepeatAmount={setRepeatAmount}
+        />
+        <StartEndDates
+          starts={starts}
+          setStarts={setStarts}
+          ends={ends}
+          setEnds={setEnds}
+        />
+        <Button variant="link" className="advanced-scheduling-button" isInline>
+          {__('Advanced scheduling')}
+        </Button>
+        <QueryType />
+      </Form>
+    </>
   );
 };
 

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -22,11 +22,12 @@ const TemplateSearchField = ({
     setValue({ ...values, [name]: searchQuery });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery]);
+  const id = name.replace(/ /g, '-');
   return (
     <FormGroup
       label={name}
       labelIcon={helpLabel(labelText, name)}
-      fieldId={name}
+      fieldId={id}
       isRequired={required}
       className="foreman-search-field"
     >
@@ -54,16 +55,16 @@ export const formatter = (input, values, setValue) => {
   const { name, required, hidden_value: hidden } = input;
   const labelText = input.description;
   const value = values[name];
-
+  const id = name.replace(/ /g, '-');
   if (isSelectType) {
     const options = input.options.split(/\r?\n/).map(option => option.trim());
     return (
       <SelectField
         aria-label={name}
-        key={name}
+        key={id}
         isRequired={required}
         label={name}
-        fieldId={name}
+        fieldId={id}
         options={options}
         labelIcon={helpLabel(labelText, name)}
         value={value}
@@ -77,7 +78,7 @@ export const formatter = (input, values, setValue) => {
         key={name}
         label={name}
         labelIcon={helpLabel(labelText, name)}
-        fieldId={name}
+        fieldId={id}
         isRequired={required}
       >
         <TextArea
@@ -85,7 +86,7 @@ export const formatter = (input, values, setValue) => {
           className={hidden ? 'masked-input' : null}
           required={required}
           rows={2}
-          id={name}
+          id={id}
           value={value}
           onChange={newValue => setValue({ ...values, [name]: newValue })}
         />
@@ -98,7 +99,7 @@ export const formatter = (input, values, setValue) => {
         key={name}
         label={name}
         labelIcon={helpLabel(labelText, name)}
-        fieldId={name}
+        fieldId={id}
         isRequired={required}
       >
         <TextInput
@@ -106,7 +107,7 @@ export const formatter = (input, values, setValue) => {
           placeholder="YYYY-mm-dd HH:MM"
           className={hidden ? 'masked-input' : null}
           required={required}
-          id={name}
+          id={id}
           type="text"
           value={value}
           onChange={newValue => setValue({ ...values, [name]: newValue })}
@@ -119,7 +120,7 @@ export const formatter = (input, values, setValue) => {
     // TODO: get text from redux autocomplete
     return (
       <TemplateSearchField
-        key={name}
+        key={id}
         name={name}
         defaultValue={value}
         controller={controller}

--- a/webpack/JobWizard/steps/form/WizardTitle.js
+++ b/webpack/JobWizard/steps/form/WizardTitle.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Title } from '@patternfly/react-core';
+
+export const WizardTitle = ({ title, ...props }) => (
+  <Title headingLevel="h2" className="wizard-title" {...props}>
+    {title}
+  </Title>
+);
+
+WizardTitle.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+export default WizardTitle;


### PR DESCRIPTION
To only include the hosts selection method (without the actual selection), show host chips and show inputs.
Depends on: https://github.com/theforeman/foreman_remote_execution/pull/554 for the input templates
![Screenshot from 2020-12-10 16-16-13](https://user-images.githubusercontent.com/30431079/101783514-09c86200-3b03-11eb-9b10-27d0d415cfbd.png)
![Screenshot from 2020-12-10 16-16-07](https://user-images.githubusercontent.com/30431079/101783520-0af98f00-3b03-11eb-8e60-dba215a359e4.png)

