### PR TITLE
Fixes #26671 - fix exporting foreign input set

### DIFF
--- a/app/models/foreign_input_set.rb
+++ b/app/models/foreign_input_set.rb
@@ -4,7 +4,7 @@ class ForeignInputSet < ApplicationRecord
   class CircularDependencyError < Foreman::Exception
   end
 
-  attr_exportable :exclude, :include, :include_all, :template => ->(input_set) { input_set.template.name }
+  attr_exportable :exclude, :include, :include_all, :template => ->(input_set) { input_set.target_template.name }
 
   belongs_to :template
   belongs_to :target_template, :class_name => 'Template'


### PR DESCRIPTION
Export of the foreign input set sets the wrong template name. Therefore
reimporting it fails, because it creates a circular dependency. To
reproduce, just export a template with at least one foreign input set
defined and try to import it back (with overwrite enabled).

This patch correctly looks at the target template instead of exported
template itself.