### PR TITLE
Fixes #31500 - Add basic schedule to job wizard

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -8,6 +8,7 @@ import CategoryAndTemplate from './steps/CategoryAndTemplate/';
 import { AdvancedFields } from './steps/AdvancedFields/AdvancedFields';
 import { JOB_TEMPLATE } from './JobWizardConstants';
 import { selectTemplateError } from './JobWizardSelectors';
+import Schedule from './steps/Schedule/';
 import './JobWizard.scss';
 
 export const JobWizard = () => {
@@ -72,7 +73,7 @@ export const JobWizard = () => {
     },
     {
       name: __('Schedule'),
-      component: <p>Schedule</p>,
+      component: <Schedule />,
       canJumpTo: isTemplate,
     },
     {

--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -11,4 +11,14 @@
       margin-bottom: 10px;
     }
   }
+
+  .schedule-tab {
+    input[type='radio'],
+    input[type='checkbox'] {
+      margin: 0;
+    }
+    .advanced-scheduling-button {
+      text-align: start;
+    }
+  }
 }

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -1,6 +1,16 @@
+import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from 'foremanReact/common/helpers';
 
 export const JOB_TEMPLATES = 'JOB_TEMPLATES';
 export const JOB_CATEGORIES = 'JOB_CATEGORIES';
 export const JOB_TEMPLATE = 'JOB_TEMPLATE';
 export const templatesUrl = foremanUrl('/api/v2/job_templates');
+
+export const repeatTypes = {
+  noRepeat: __('Does not repeat'),
+  cronline: __('Cronline'),
+  monthly: __('Monthly'),
+  weekly: __('Weekly'),
+  daily: __('Daily'),
+  hourly: __('Hourly'),
+};

--- a/webpack/JobWizard/steps/Schedule/QueryType.js
+++ b/webpack/JobWizard/steps/Schedule/QueryType.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { FormGroup, Radio } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { helpLabel } from '../form/FormHelpers';
+
+export const QueryType = () => {
+  const [isTypeStatic, setIsTypeStatic] = useState(true);
+  return (
+    <FormGroup
+      label={__('Query type')}
+      fieldId="query-type"
+      labelIcon={helpLabel(
+        <p>
+          {__('Type has impact on when is the query evaluated to hosts.')}
+          <br />
+          <ul>
+            <li>
+              <b>{__('Static')}</b> -{' '}
+              {__('evaluates just after you submit this form')}
+            </li>
+            <li>
+              <b>{__('Dynamic')}</b> -{' '}
+              {__(
+                "evaluates just before the execution is started, so if it's planed in future, targeted hosts set may change before it"
+              )}
+            </li>
+          </ul>
+        </p>,
+        'query-type'
+      )}
+    >
+      <Radio
+        isChecked={isTypeStatic}
+        name="query-type"
+        onChange={() => setIsTypeStatic(true)}
+        id="query-type-static"
+        label={__('Static query')}
+      />
+      <Radio
+        isChecked={!isTypeStatic}
+        name="query-type"
+        onChange={() => setIsTypeStatic(false)}
+        id="query-type-dynamic"
+        label={__('Dynamic query')}
+      />
+    </FormGroup>
+  );
+};

--- a/webpack/JobWizard/steps/Schedule/RepeatOn.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatOn.js
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { TextInput, Grid, GridItem, FormGroup } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { SelectField } from '../form/SelectField';
+import { repeatTypes } from '../../JobWizardConstants';
+
+export const RepeatOn = ({
+  repeatType,
+  setRepeatType,
+  repeatAmount,
+  setRepeatAmount,
+}) => {
+  const [repeatValidated, setRepeatValidated] = useState('default');
+  const handleRepeatInputChange = newValue => {
+    setRepeatValidated(newValue >= 1 ? 'default' : 'error');
+    setRepeatAmount(newValue);
+  };
+  return (
+    <Grid>
+      <GridItem span={6}>
+        <SelectField
+          fieldId="repeat-select"
+          options={Object.values(repeatTypes)}
+          setValue={newValue => {
+            setRepeatType(newValue);
+            if (newValue === repeatTypes.noRepeat) {
+              setRepeatValidated('default');
+            }
+          }}
+          value={repeatType}
+        />
+      </GridItem>
+      <GridItem span={1} />
+      <GridItem span={5}>
+        <FormGroup
+          isInline
+          helperTextInvalid={__('Repeat amount can only be a positive number')}
+          validated={repeatValidated}
+        >
+          <TextInput
+            isDisabled={repeatType === repeatTypes.noRepeat}
+            id="repeat-amount"
+            value={repeatAmount}
+            type="text"
+            onChange={newValue => handleRepeatInputChange(newValue)}
+            placeholder={__('Repeat N times')}
+          />
+        </FormGroup>
+      </GridItem>
+    </Grid>
+  );
+};
+
+RepeatOn.propTypes = {
+  repeatType: PropTypes.oneOf(Object.values(repeatTypes)).isRequired,
+  setRepeatType: PropTypes.func.isRequired,
+  repeatAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
+  setRepeatAmount: PropTypes.func.isRequired,
+};

--- a/webpack/JobWizard/steps/Schedule/ScheduleType.js
+++ b/webpack/JobWizard/steps/Schedule/ScheduleType.js
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { FormGroup, Radio } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const ScheduleType = () => {
+  const [isFuture, setIsFuture] = useState(false);
+  return (
+    <FormGroup label={__('Schedule type')} fieldId="schedule-type">
+      <Radio
+        isChecked={!isFuture}
+        name="schedule-type"
+        onChange={() => setIsFuture(false)}
+        id="schedule-type-now"
+        label={__('Execute now')}
+      />
+      <Radio
+        isChecked={isFuture}
+        name="schedule-type"
+        onChange={() => setIsFuture(true)}
+        id="schedule-type-future"
+        label={__('Schedule for future execution')}
+      />
+    </FormGroup>
+  );
+};

--- a/webpack/JobWizard/steps/Schedule/StartEndDates.js
+++ b/webpack/JobWizard/steps/Schedule/StartEndDates.js
@@ -1,0 +1,51 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { FormGroup, TextInput, Checkbox } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+// TODO: change to datepicker
+export const StartEndDates = ({ starts, setStarts, ends, setEnds }) => {
+  const [isNeverEnds, setIsNeverEnds] = useState(false);
+  const toggleIsNeverEnds = (checked, event) => {
+    const value = event?.target?.checked;
+    setIsNeverEnds(value);
+    setEnds('');
+  };
+  return (
+    <>
+      <FormGroup label={__('Starts')} fieldId="start-date">
+        <TextInput
+          id="start-date"
+          value={starts}
+          type="text"
+          onChange={newValue => setStarts(newValue)}
+          placeholder="mm/dd/yy, hh:mm UTC"
+        />
+      </FormGroup>
+      <FormGroup label={__('Ends')} fieldId="end-date">
+        <TextInput
+          isDisabled={isNeverEnds}
+          id="end-date"
+          value={ends}
+          type="text"
+          onChange={newValue => setEnds(newValue)}
+          placeholder="mm/dd/yy, hh:mm UTC"
+        />
+        <Checkbox
+          label={__('Never ends')}
+          isChecked={isNeverEnds}
+          onChange={toggleIsNeverEnds}
+          id="never-ends"
+          name="never-ends"
+        />
+      </FormGroup>
+    </>
+  );
+};
+
+StartEndDates.propTypes = {
+  starts: PropTypes.string.isRequired,
+  setStarts: PropTypes.func.isRequired,
+  ends: PropTypes.string.isRequired,
+  setEnds: PropTypes.func.isRequired,
+};

--- a/webpack/JobWizard/steps/Schedule/__tests__/StartEndDates.test.js
+++ b/webpack/JobWizard/steps/Schedule/__tests__/StartEndDates.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { StartEndDates } from '../StartEndDates';
+
+const setEnds = jest.fn();
+const props = {
+  starts: '',
+  setStarts: jest.fn(),
+  ends: 'some-end-date',
+  setEnds,
+};
+
+describe('StartEndDates', () => {
+  it('never ends', () => {
+    render(<StartEndDates {...props} />);
+    const neverEnds = screen.getByLabelText('Never ends', {
+      selector: 'input',
+    });
+    fireEvent.click(neverEnds);
+    expect(setEnds).toBeCalledWith('');
+  });
+});

--- a/webpack/JobWizard/steps/Schedule/index.js
+++ b/webpack/JobWizard/steps/Schedule/index.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { Title, Button, Form } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { ScheduleType } from './ScheduleType';
+import { RepeatOn } from './RepeatOn';
+import { QueryType } from './QueryType';
+import { StartEndDates } from './StartEndDates';
+import { repeatTypes } from '../../JobWizardConstants';
+
+const Schedule = () => {
+  const [repeatType, setRepeatType] = useState(repeatTypes.noRepeat);
+  const [repeatAmount, setRepeatAmount] = useState('');
+  const [starts, setStarts] = useState('');
+  const [ends, setEnds] = useState('');
+
+  return (
+    <Form className="schedule-tab">
+      <Title headingLevel="h2">{__('Schedule')}</Title>
+      <ScheduleType />
+
+      <RepeatOn
+        repeatType={repeatType}
+        setRepeatType={setRepeatType}
+        repeatAmount={repeatAmount}
+        setRepeatAmount={setRepeatAmount}
+      />
+      <StartEndDates
+        starts={starts}
+        setStarts={setStarts}
+        ends={ends}
+        setEnds={setEnds}
+      />
+      <Button variant="link" className="advanced-scheduling-button" isInline>
+        {__('Advanced scheduling')}
+      </Button>
+      <QueryType />
+    </Form>
+  );
+};
+
+export default Schedule;

--- a/webpack/JobWizard/steps/form/SelectField.js
+++ b/webpack/JobWizard/steps/form/SelectField.js
@@ -35,7 +35,7 @@ export const SelectField = ({
   );
 };
 SelectField.propTypes = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.string,
   fieldId: PropTypes.string.isRequired,
   options: PropTypes.array,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -43,6 +43,7 @@ SelectField.propTypes = {
 };
 
 SelectField.defaultProps = {
+  label: null,
   options: [],
   value: null,
 };


### PR DESCRIPTION
Only add components without the functionality and without the advanced options.
The Repeat field will be added more in depth in a different pr
~~Depends on: https://github.com/theforeman/foreman_remote_execution/pull/551~~

![Screenshot from 2020-12-13 13-08-01](https://user-images.githubusercontent.com/30431079/102010089-62d30880-3d44-11eb-9ab6-12177766844f.png)
