### PR TITLE
fixes #31428 - making execution status clickable

### DIFF
--- a/app/models/host_status/execution_status.rb
+++ b/app/models/host_status/execution_status.rb
@@ -49,6 +49,13 @@ class HostStatus::ExecutionStatus < HostStatus::Status
     end
   end
 
+  def status_link
+    job_invocation = last_stopped_task.parent_task.job_invocations.first
+    return nil unless User.current.can?(:view_job_invocations, job_invocation)
+
+    Rails.application.routes.url_helpers.job_invocation_path(job_invocation)
+  end
+
   class ExecutionTaskStatusMapper
     attr_accessor :task
 


### PR DESCRIPTION
This PR introduces a clickable execution status at host detail page that leads to last job invocation of given host