### PR TITLE
Fixes #31933 - Mark output as complete if task is missing

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -214,7 +214,7 @@ module Api
       end
 
       def host_output(job_invocation, host, default: nil, since: nil, raw: false)
-        refresh = true
+        refresh = !job_invocation.finished?
 
         if (task = job_invocation.sub_task_for_host(host))
           refresh = task.pending?

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -241,7 +241,7 @@ class JobInvocation < ApplicationRecord
   end
 
   def finished?
-    !task.pending?
+    !(task.nil? || task.pending?)
   end
 
   def missing_hosts_count

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -211,7 +211,7 @@ module Api
         let(:host) { @invocation.targeting.hosts.first }
 
         test 'should provide raw output for a host' do
-          JobInvocation.any_instance.expects(:task).twice.returns(OpenStruct.new(:scheduled? => false, :pending? => false))
+          JobInvocation.any_instance.expects(:task).times(3).returns(OpenStruct.new(:scheduled? => false, :pending? => false))
           JobInvocation.any_instance.expects(:sub_task_for_host).returns(fake_task)
           get :raw_output, params: { :job_invocation_id => @invocation.id, :host_id => host.id }
           result = ActiveSupport::JSON.decode(@response.body)
@@ -236,7 +236,7 @@ module Api
         end
 
         test 'should provide raw output for host without task' do
-          JobInvocation.any_instance.expects(:task).twice.returns(OpenStruct.new(:scheduled? => false, :pending? => true))
+          JobInvocation.any_instance.expects(:task).times(3).returns(OpenStruct.new(:scheduled? => false, :pending? => true))
           JobInvocation.any_instance.expects(:sub_task_for_host)
           get :raw_output, params: { :job_invocation_id => @invocation.id, :host_id => host.id }
           result = ActiveSupport::JSON.decode(@response.body)


### PR DESCRIPTION
and the job is done