### PR TITLE
Fixes #32032 - proxy batch sizing per provider

### DIFF
--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -31,7 +31,8 @@ module Actions
         set_up_concurrency_control job_invocation
         input.update(:job_category => job_invocation.job_category)
         plan_self(:job_invocation_id => job_invocation.id)
-        input[:proxy_batch_size] ||= Setting['foreman_tasks_proxy_batch_size']
+        provider = job_invocation.pattern_template_invocations.first&.template&.provider
+        input[:proxy_batch_size] ||= provider&.proxy_batch_size || Setting['foreman_tasks_proxy_batch_size']
         trigger_action = plan_action(Actions::TriggerProxyBatch, batch_size: proxy_batch_size, total_count: hosts.count)
         input[:trigger_run_step_id] = trigger_action.run_step_id
       end

--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -122,6 +122,10 @@ class RemoteExecutionProvider
       'Proxy::RemoteExecution::Ssh::Actions::RunScript'
     end
 
+    def proxy_batch_size
+      Setting['foreman_tasks_proxy_batch_size']
+    end
+
     # Return a specific proxy selector to use for running a given template
     # Returns either nil to use the default selector or an instance of a (sub)class of ::ForemanTasks::ProxySelector
     def required_proxy_selector_for(template)

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -104,6 +104,22 @@ module ForemanRemoteExecution
       planned # To make the expectations happy
     end
 
+    describe '#proxy_batch_size' do
+      it 'defaults to Setting[foreman_tasks_proxy_batch_size]' do
+        Setting.expects(:[]).with('foreman_tasks_proxy_batch_size').returns(14)
+        planned
+        _(planned.proxy_batch_size).must_equal 14
+      end
+
+      it 'gets the provider value' do
+        provider = mock('provider')
+        provider.expects(:proxy_batch_size).returns(15)
+        JobTemplate.any_instance.expects(:provider).returns(provider)
+
+        _(planned.proxy_batch_size).must_equal 15
+      end
+    end
+
     describe 'concurrency control' do
       let(:level) { 5 }
       let(:span) { 60 }


### PR DESCRIPTION
Allow number of HostTasks to be send to proxy in one batch to be tweaked
per every provider. If provider won't supply value, we still default to
`Setting['foreman_tasks_proxy_batch_size']`

- [x] https://github.com/theforeman/foreman-tasks/pull/640
- [x] #601