### PR TITLE
Fixes #32045 - Add start-end date pickers to job wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^4.14.0",
-    "@theforeman/eslint-plugin-foreman": "^4.14.0",
-    "@theforeman/stories": "^4.14.0",
-    "@theforeman/test": "^4.14.0",
-    "@theforeman/vendor-dev": "^4.14.0",
+    "@theforeman/builder": "^8.10.0",
+    "@theforeman/eslint-plugin-foreman": "^8.10.0",
+    "@theforeman/stories": "^8.10.0",
+    "@theforeman/test": "^8.10.0",
+    "@theforeman/vendor-dev": "^8.10.0",
     "babel-eslint": "^10.0.0",
     "eslint": "^6.8.0",
     "prettier": "^1.19.1",
@@ -33,6 +33,6 @@
     "redux-mock-store": "^1.2.2"
   },
   "peerDependencies": {
-    "@theforeman/vendor": "^8.3.0"
+    "@theforeman/vendor": "^8.10.0"
   }
 }

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -6,7 +6,11 @@ import { get } from 'foremanReact/redux/API';
 import history from 'foremanReact/history';
 import CategoryAndTemplate from './steps/CategoryAndTemplate/';
 import { AdvancedFields } from './steps/AdvancedFields/AdvancedFields';
-import { JOB_TEMPLATE, WIZARD_TITLES } from './JobWizardConstants';
+import {
+  JOB_TEMPLATE,
+  WIZARD_TITLES,
+  initialScheduleState,
+} from './JobWizardConstants';
 import { selectTemplateError } from './JobWizardSelectors';
 import Schedule from './steps/Schedule/';
 import HostsAndInputs from './steps/HostsAndInputs/';
@@ -18,6 +22,7 @@ export const JobWizard = () => {
   const [advancedValues, setAdvancedValues] = useState({});
   const [templateValues, setTemplateValues] = useState({}); // TODO use templateValues in advanced fields - description https://github.com/theforeman/foreman_remote_execution/pull/605
   const [selectedHosts, setSelectedHosts] = useState(['host1', 'host2']);
+  const [scheduleValue, setScheduleValue] = useState(initialScheduleState);
   const dispatch = useDispatch();
 
   const setDefaults = useCallback(
@@ -114,7 +119,12 @@ export const JobWizard = () => {
     },
     {
       name: WIZARD_TITLES.schedule,
-      component: <Schedule />,
+      component: (
+        <Schedule
+          scheduleValue={scheduleValue}
+          setScheduleValue={setScheduleValue}
+        />
+      ),
       canJumpTo: isTemplate,
     },
     {

--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -50,13 +50,23 @@
     margin-top: 8px;
   }
   .schedule-tab {
-    input[type='radio'],
-    input[type='checkbox'] {
-      margin: 0;
-    }
     .advanced-scheduling-button {
       text-align: start;
     }
+  }
+
+  .pf-c-date-picker {
+    vertical-align: top;
+  }
+
+  .time-picker {
+    width: 150px;
+  }
+
+  input[type='radio'],
+  input[type='checkbox'] {
+    // overwriting bootstrap/_forms.scss margin: 4px 0 0;
+    margin: 0;
   }
   textarea {
     min-height: 40px;

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -22,3 +22,12 @@ export const WIZARD_TITLES = {
   schedule: __('Schedule'),
   review: __('Review Details'),
 };
+
+export const initialScheduleState = {
+  repeatType: repeatTypes.noRepeat,
+  repeatAmount: '',
+  starts: '',
+  ends: '',
+  isFuture: false,
+  isNeverEnds: false,
+};

--- a/webpack/JobWizard/steps/Schedule/ScheduleType.js
+++ b/webpack/JobWizard/steps/Schedule/ScheduleType.js
@@ -1,25 +1,28 @@
-import React, { useState } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { FormGroup, Radio } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-export const ScheduleType = () => {
-  const [isFuture, setIsFuture] = useState(false);
-  return (
-    <FormGroup label={__('Schedule type')} fieldId="schedule-type">
-      <Radio
-        isChecked={!isFuture}
-        name="schedule-type"
-        onChange={() => setIsFuture(false)}
-        id="schedule-type-now"
-        label={__('Execute now')}
-      />
-      <Radio
-        isChecked={isFuture}
-        name="schedule-type"
-        onChange={() => setIsFuture(true)}
-        id="schedule-type-future"
-        label={__('Schedule for future execution')}
-      />
-    </FormGroup>
-  );
+export const ScheduleType = ({ isFuture, setIsFuture }) => (
+  <FormGroup label={__('Schedule type')} fieldId="schedule-type">
+    <Radio
+      isChecked={!isFuture}
+      name="schedule-type"
+      onChange={() => setIsFuture(false)}
+      id="schedule-type-now"
+      label={__('Execute now')}
+    />
+    <Radio
+      isChecked={isFuture}
+      name="schedule-type"
+      onChange={() => setIsFuture(true)}
+      id="schedule-type-future"
+      label={__('Schedule for future execution')}
+    />
+  </FormGroup>
+);
+
+ScheduleType.propTypes = {
+  isFuture: PropTypes.bool.isRequired,
+  setIsFuture: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/StartEndDates.js
+++ b/webpack/JobWizard/steps/Schedule/StartEndDates.js
@@ -1,35 +1,48 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, TextInput, Checkbox } from '@patternfly/react-core';
+import { FormGroup, Checkbox } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { DateTimePicker } from '../form/DateTimePicker';
 
-// TODO: change to datepicker
-export const StartEndDates = ({ starts, setStarts, ends, setEnds }) => {
-  const [isNeverEnds, setIsNeverEnds] = useState(false);
+export const StartEndDates = ({
+  starts,
+  setStarts,
+  ends,
+  setEnds,
+  isNeverEnds,
+  setIsNeverEnds,
+}) => {
   const toggleIsNeverEnds = (checked, event) => {
     const value = event?.target?.checked;
     setIsNeverEnds(value);
-    setEnds('');
+  };
+  const validateEndDate = () => {
+    if (isNeverEnds) return 'success';
+    if (!starts || !ends) return 'success';
+    if (new Date(starts).getTime() <= new Date(ends).getTime())
+      return 'success';
+    return 'error';
   };
   return (
     <>
-      <FormGroup label={__('Starts')} fieldId="start-date">
-        <TextInput
-          id="start-date"
-          value={starts}
-          type="text"
-          onChange={newValue => setStarts(newValue)}
-          placeholder="mm/dd/yy, hh:mm UTC"
-        />
+      <FormGroup
+        className="start-date"
+        label={__('Starts')}
+        fieldId="start-date"
+      >
+        <DateTimePicker dateTime={starts} setDateTime={setStarts} />
       </FormGroup>
-      <FormGroup label={__('Ends')} fieldId="end-date">
-        <TextInput
+      <FormGroup
+        className="end-date"
+        label={__('Ends')}
+        fieldId="end-date"
+        helperTextInvalid={__('End time needs to be after start time')}
+        validated={validateEndDate()}
+      >
+        <DateTimePicker
+          dateTime={ends}
+          setDateTime={setEnds}
           isDisabled={isNeverEnds}
-          id="end-date"
-          value={ends}
-          type="text"
-          onChange={newValue => setEnds(newValue)}
-          placeholder="mm/dd/yy, hh:mm UTC"
         />
         <Checkbox
           label={__('Never ends')}
@@ -48,4 +61,6 @@ StartEndDates.propTypes = {
   setStarts: PropTypes.func.isRequired,
   ends: PropTypes.string.isRequired,
   setEnds: PropTypes.func.isRequired,
+  isNeverEnds: PropTypes.bool.isRequired,
+  setIsNeverEnds: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
+++ b/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
@@ -1,0 +1,155 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { fireEvent, screen, render, act } from '@testing-library/react';
+import * as api from 'foremanReact/redux/API';
+import { JobWizard } from '../../../JobWizard';
+import * as selectors from '../../../JobWizardSelectors';
+import { jobTemplate, jobTemplateResponse } from '../../../__tests__/fixtures';
+
+const lodash = require('lodash');
+
+lodash.debounce = fn => fn;
+jest.spyOn(api, 'get');
+jest.spyOn(selectors, 'selectJobTemplate');
+jest.spyOn(selectors, 'selectJobTemplates');
+jest.spyOn(selectors, 'selectJobCategories');
+
+const jobCategories = ['Ansible Commands', 'Puppet', 'Services'];
+
+selectors.selectJobCategories.mockImplementation(() => jobCategories);
+
+selectors.selectJobTemplates.mockImplementation(() => [
+  jobTemplate,
+  { ...jobTemplate, id: 2, name: 'template2' },
+]);
+selectors.selectJobTemplate.mockImplementation(() => jobTemplateResponse);
+api.get.mockImplementation(({ handleSuccess, ...action }) => {
+  if (action.key === 'JOB_CATEGORIES') {
+    handleSuccess && handleSuccess({ data: { job_categories: jobCategories } });
+  } else if (action.key === 'JOB_TEMPLATE') {
+    handleSuccess &&
+      handleSuccess({
+        data: jobTemplateResponse,
+      });
+  } else if (action.key === 'JOB_TEMPLATES') {
+    handleSuccess &&
+      handleSuccess({
+        data: { results: [jobTemplateResponse.job_template] },
+      });
+  }
+  return { type: 'get', ...action };
+});
+
+const mockStore = configureMockStore([]);
+const store = mockStore({});
+jest.useFakeTimers();
+
+describe('Schedule', () => {
+  it('should save date time between steps ', async () => {
+    render(
+      <Provider store={store}>
+        <JobWizard />
+      </Provider>
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Schedule'));
+    });
+    const newStartDate = '2020/03/12';
+    const newStartTime = '12:03';
+    const newEndsDate = '2030/03/12';
+    const newEndsTime = '17:34';
+    const [startsDateField, endsDateField] = screen.getAllByPlaceholderText(
+      'yyyy/mm/dd'
+    );
+    const [startsTimeField, endsTimeField] = screen.getAllByPlaceholderText(
+      'hh:mm'
+    );
+    await act(async () => {
+      await fireEvent.change(startsDateField, {
+        target: { value: newStartDate },
+      });
+      await fireEvent.change(startsTimeField, {
+        target: { value: newStartTime },
+      });
+      await fireEvent.change(endsDateField, { target: { value: newEndsDate } });
+      await fireEvent.change(endsTimeField, { target: { value: newEndsTime } });
+      jest.runAllTimers(); // to handle pf4 date picket popover useTimer
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Category and Template'));
+    });
+    expect(screen.getAllByText('Category and Template')).toHaveLength(3);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Schedule'));
+      jest.runAllTimers();
+    });
+    expect(startsDateField.value).toBe(newStartDate);
+    expect(startsTimeField.value).toBe(newStartTime);
+    expect(endsDateField.value).toBe(newEndsDate);
+    expect(endsTimeField.value).toBe(newEndsTime);
+  });
+  it('should remove start date time on execute now', async () => {
+    render(
+      <Provider store={store}>
+        <JobWizard />
+      </Provider>
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Schedule'));
+    });
+    const executeNow = screen.getByLabelText('Execute now');
+    const executeFuture = screen.getByLabelText(
+      'Schedule for future execution'
+    );
+    expect(executeNow.checked).toBeTruthy();
+    const newStartDate = '2020/03/12';
+    const newStartTime = '12:03';
+    const [startsDateField] = screen.getAllByPlaceholderText('yyyy/mm/dd');
+    const [startsTimeField] = screen.getAllByPlaceholderText('hh:mm');
+    await act(async () => {
+      await fireEvent.change(startsDateField, {
+        target: { value: newStartDate },
+      });
+      await fireEvent.change(startsTimeField, {
+        target: { value: newStartTime },
+      });
+      await jest.runOnlyPendingTimers();
+    });
+    expect(startsDateField.value).toBe(newStartDate);
+    expect(startsTimeField.value).toBe(newStartTime);
+    expect(executeFuture.checked).toBeTruthy();
+    await act(async () => {
+      await fireEvent.click(executeNow);
+    });
+    expect(executeNow.checked).toBeTruthy();
+    expect(startsDateField.value).toBe('');
+    expect(startsTimeField.value).toBe('');
+  });
+
+  it('should disable end date on never ends', async () => {
+    render(
+      <Provider store={store}>
+        <JobWizard />
+      </Provider>
+    );
+    await act(async () => {
+      await fireEvent.click(screen.getByText('Schedule'));
+      jest.runAllTimers();
+    });
+    const neverEnds = screen.getByLabelText('Never ends');
+    expect(neverEnds.checked).toBeFalsy();
+
+    const [, endsDateField] = screen.getAllByPlaceholderText('yyyy/mm/dd');
+    const [, endsTimeField] = screen.getAllByPlaceholderText('hh:mm');
+    expect(endsDateField.disabled).toBeFalsy();
+    expect(endsTimeField.disabled).toBeFalsy();
+    await act(async () => {
+      fireEvent.click(neverEnds);
+    });
+    expect(neverEnds.checked).toBeTruthy();
+    expect(endsDateField.disabled).toBeTruthy();
+    expect(endsTimeField.disabled).toBeTruthy();
+  });
+});

--- a/webpack/JobWizard/steps/Schedule/__tests__/StartEndDates.test.js
+++ b/webpack/JobWizard/steps/Schedule/__tests__/StartEndDates.test.js
@@ -1,22 +1,23 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
 import { StartEndDates } from '../StartEndDates';
 
 const setEnds = jest.fn();
+const setIsNeverEnds = jest.fn();
 const props = {
   starts: '',
   setStarts: jest.fn(),
   ends: 'some-end-date',
   setEnds,
+  setIsNeverEnds,
+  isNeverEnds: false,
 };
 
 describe('StartEndDates', () => {
-  it('never ends', () => {
-    render(<StartEndDates {...props} />);
-    const neverEnds = screen.getByLabelText('Never ends', {
-      selector: 'input',
-    });
-    fireEvent.click(neverEnds);
-    expect(setEnds).toBeCalledWith('');
+  it('never ends', async () => {
+    await act(async () => render(<StartEndDates {...props} />));
+    const neverEnds = screen.getByRole('checkbox', { name: 'Never ends' });
+    await act(async () => fireEvent.click(neverEnds));
+    expect(setIsNeverEnds).toBeCalledWith(true);
   });
 });

--- a/webpack/JobWizard/steps/Schedule/index.js
+++ b/webpack/JobWizard/steps/Schedule/index.js
@@ -1,36 +1,82 @@
-import React, { useState } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Button, Form } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { ScheduleType } from './ScheduleType';
 import { RepeatOn } from './RepeatOn';
 import { QueryType } from './QueryType';
 import { StartEndDates } from './StartEndDates';
-import { repeatTypes, WIZARD_TITLES } from '../../JobWizardConstants';
+import { WIZARD_TITLES } from '../../JobWizardConstants';
 import { WizardTitle } from '../form/WizardTitle';
 
-const Schedule = () => {
-  const [repeatType, setRepeatType] = useState(repeatTypes.noRepeat);
-  const [repeatAmount, setRepeatAmount] = useState('');
-  const [starts, setStarts] = useState('');
-  const [ends, setEnds] = useState('');
+const Schedule = ({ scheduleValue, setScheduleValue }) => {
+  const { repeatType, repeatAmount, starts, ends, isNeverEnds } = scheduleValue;
 
   return (
     <>
       <WizardTitle title={WIZARD_TITLES.schedule} />
       <Form className="schedule-tab">
-        <ScheduleType />
+        <ScheduleType
+          isFuture={scheduleValue.isFuture}
+          setIsFuture={newValue => {
+            if (!newValue) {
+              // if schedule type is execute now
+              setScheduleValue(current => ({
+                ...current,
+                starts: '',
+              }));
+            }
+            setScheduleValue(current => ({
+              ...current,
+              isFuture: newValue,
+            }));
+          }}
+        />
 
         <RepeatOn
           repeatType={repeatType}
-          setRepeatType={setRepeatType}
+          setRepeatType={newValue => {
+            setScheduleValue(current => ({
+              ...current,
+              repeatType: newValue,
+            }));
+          }}
           repeatAmount={repeatAmount}
-          setRepeatAmount={setRepeatAmount}
+          setRepeatAmount={newValue => {
+            setScheduleValue(current => ({
+              ...current,
+              repeatAmount: newValue,
+            }));
+          }}
         />
         <StartEndDates
           starts={starts}
-          setStarts={setStarts}
+          setStarts={newValue => {
+            if (!scheduleValue.isFuture) {
+              setScheduleValue(current => ({
+                ...current,
+                isFuture: true,
+              }));
+            }
+            setScheduleValue(current => ({
+              ...current,
+              starts: newValue,
+            }));
+          }}
           ends={ends}
-          setEnds={setEnds}
+          setEnds={newValue => {
+            setScheduleValue(current => ({
+              ...current,
+              ends: newValue,
+            }));
+          }}
+          isNeverEnds={isNeverEnds}
+          setIsNeverEnds={newValue => {
+            setScheduleValue(current => ({
+              ...current,
+              isNeverEnds: newValue,
+            }));
+          }}
         />
         <Button variant="link" className="advanced-scheduling-button" isInline>
           {__('Advanced scheduling')}
@@ -39,6 +85,18 @@ const Schedule = () => {
       </Form>
     </>
   );
+};
+
+Schedule.propTypes = {
+  scheduleValue: PropTypes.shape({
+    repeatType: PropTypes.string.isRequired,
+    repeatAmount: PropTypes.string,
+    starts: PropTypes.string,
+    ends: PropTypes.string,
+    isFuture: PropTypes.bool,
+    isNeverEnds: PropTypes.bool,
+  }).isRequired,
+  setScheduleValue: PropTypes.func.isRequired,
 };
 
 export default Schedule;

--- a/webpack/JobWizard/steps/form/DateTimePicker.js
+++ b/webpack/JobWizard/steps/form/DateTimePicker.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DatePicker, TimePicker } from '@patternfly/react-core';
+import { debounce } from 'lodash';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+export const DateTimePicker = ({ dateTime, setDateTime, isDisabled }) => {
+  const dateFormat = date =>
+    `${date.getFullYear()}/${(date.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}/${date
+      .getDate()
+      .toString()
+      .padStart(2, '0')}`;
+
+  const dateObject = dateTime ? new Date(dateTime) : new Date();
+  const formattedDate = dateTime ? dateFormat(dateObject) : '';
+  const dateParse = date =>
+    new Date(`${date} ${dateObject.getHours()}:${dateObject.getMinutes()}`);
+
+  const isValidDate = date => date && !Number.isNaN(date.getTime());
+
+  const isValidTime = time => {
+    if (!time) return false;
+    const split = time.split(':');
+    if (!(split[0].length === 2 && split[1].length === 2)) return false;
+    if (isValidDate(new Date(`${formattedDate} ${time}`))) return true;
+    if (!formattedDate.length && isValidDate(new Date(`01/01/2020 ${time}`))) {
+      const today = new Date();
+      today.setHours(split[0]);
+      today.setMinutes(split[1]);
+      setDateTime(today.toString());
+    }
+    return false;
+  };
+
+  const onDateChange = newDate => {
+    const parsedNewDate = new Date(newDate);
+
+    if (isValidDate(parsedNewDate)) {
+      parsedNewDate.setHours(dateObject.getHours());
+      parsedNewDate.setMinutes(dateObject.getMinutes());
+      setDateTime(parsedNewDate.toString());
+    }
+  };
+
+  const onTimeChange = newTime => {
+    if (isValidTime(newTime)) {
+      const parsedNewTime = new Date(`${formattedDate} ${newTime}`);
+      setDateTime(parsedNewTime.toString());
+    }
+  };
+  return (
+    <>
+      <DatePicker
+        value={formattedDate}
+        placeholder="yyyy/mm/dd"
+        onChange={debounce(onDateChange, 1000, {
+          leading: false,
+          trailing: true,
+        })}
+        dateFormat={dateFormat}
+        dateParse={dateParse}
+        isDisabled={isDisabled}
+        invalidFormatText={__('Invalid date')}
+      />
+      <TimePicker
+        className="time-picker"
+        time={dateTime ? dateObject.toString() : ''}
+        inputProps={dateTime ? {} : { value: '' }}
+        placeholder="hh:mm"
+        onChange={debounce(onTimeChange, 1000, {
+          leading: false,
+          trailing: true,
+        })}
+        is24Hour
+        isDisabled={isDisabled}
+        invalidFormatErrorMessage={__('Invalid time format')}
+        menuAppendTo={() => document.body}
+      />
+    </>
+  );
+};
+
+DateTimePicker.propTypes = {
+  dateTime: PropTypes.string,
+  setDateTime: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+};
+DateTimePicker.defaultProps = {
+  dateTime: null,
+  isDisabled: false,
+};


### PR DESCRIPTION
Updates vendor js to 8.4.0 in order to use datepicker and timepicker.
Depends on https://github.com/theforeman/foreman_remote_execution/pull/558