### PR TITLE
Add feature to skip proxy determination

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -30,10 +30,14 @@ module Actions
         raise _('Could not use any template used in the job invocation') if template_invocation.blank?
 
         provider = template_invocation.template.provider
-        proxy_selector = provider.required_proxy_selector_for(template_invocation.template) || proxy_selector
 
-        provider_type = template_invocation.template.provider_type.to_s
-        proxy = determine_proxy!(proxy_selector, provider_type, host)
+        if job_invoation.skip_determination_of_proxy
+          proxy = host
+        else
+          proxy_selector = provider.required_proxy_selector_for(template_invocation.template) || proxy_selector
+          provider_type = template_invocation.template.provider_type.to_s
+          proxy = determine_proxy!(proxy_selector, provider_type, host)
+        end
 
         renderer = InputTemplateRenderer.new(template_invocation.template, host, template_invocation)
         script = renderer.render

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -349,6 +349,7 @@ class JobInvocationComposer
     job_invocation.password = params[:password]
     job_invocation.key_passphrase = params[:key_passphrase]
     job_invocation.effective_user_password = params[:effective_user_password]
+    job_invocation.skip_determination_of_proxy = params[:skip_determination_of_proxy]
 
     if @reruns && job_invocation.targeting.static?
       job_invocation.targeting.host_ids = JobInvocation.find(@reruns).targeting.host_ids


### PR DESCRIPTION
If the right proxy was already selected on which a job should run,
the REX plugin shouldn't do this again.