### PR TITLE
Fixes #32209 - Try to require task launcher registry in advance

### DIFF
--- a/lib/foreman_remote_execution_core.rb
+++ b/lib/foreman_remote_execution_core.rb
@@ -73,6 +73,10 @@ module ForemanRemoteExecutionCore
     require 'foreman_remote_execution_core/dispatcher'
     require 'foreman_remote_execution_core/actions'
 
+    begin
+      require 'smart_proxy_dynflow_core/task_launcher_registry'
+    rescue; end
+
     if defined?(::SmartProxyDynflowCore)
       SmartProxyDynflowCore::TaskLauncherRegistry.register('ssh', ForemanTasksCore::TaskLauncher::Batch)
     end

--- a/lib/foreman_remote_execution_core.rb
+++ b/lib/foreman_remote_execution_core.rb
@@ -73,9 +73,12 @@ module ForemanRemoteExecutionCore
     require 'foreman_remote_execution_core/dispatcher'
     require 'foreman_remote_execution_core/actions'
 
+    # rubocop:disable Lint/SuppressedException
     begin
       require 'smart_proxy_dynflow_core/task_launcher_registry'
-    rescue; end
+    rescue LoadError
+    end
+    # rubocop:enable Lint/SuppressedException
 
     if defined?(::SmartProxyDynflowCore)
       SmartProxyDynflowCore::TaskLauncherRegistry.register('ssh', ForemanTasksCore::TaskLauncher::Batch)


### PR DESCRIPTION
There is no guarantee that it was loaded by something else at the point where we try to use it. It is safer to try loading it.