### PR TITLE
Fixes #32107 - job invocation create API should work with the feature param

### DIFF
--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -1,5 +1,6 @@
 class JobInvocationComposer
   class JobTemplateNotFound < StandardError; end
+
   class FeatureNotFound < StandardError; end
 
   class UiParams

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -1,6 +1,6 @@
 class JobInvocationComposer
-  class JobTemplateNotFound < StandardError; end;
-  class FeatureNotFound < StandardError; end;
+  class JobTemplateNotFound < StandardError; end
+  class FeatureNotFound < StandardError; end
 
   class UiParams
     attr_reader :ui_params
@@ -273,11 +273,11 @@ class JobInvocationComposer
 
     def initialize(input)
       case input
-      when Bookmark then
+      when Bookmark
         @bookmark = input
-      when Host::Base then
+      when Host::Base
         @hosts = [input]
-      when Array then
+      when Array
         @hosts = input.map do |id|
           Host::Managed.authorized.friendly.find(id)
         end

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -114,10 +114,23 @@ module Api
             assert_response :success
           end
 
-          test 'search_query' do
+          test 'host ids as search_query' do
             @attrs[:host_ids] = 'name = testfqdn'
             post :create, params: { job_invocation: @attrs }
             assert_response :success
+          end
+
+          test 'with search_query param' do
+            @attrs[:targeting_type] = 'static_query'
+            @attrs[:search_query] = 'name = testfqdn'
+            post :create, params: { job_invocation: @attrs }
+            assert_response :success
+          end
+
+          test 'with job_template_id param' do
+            @attrs[:job_template_id] = 12345
+            post :create, params: { job_invocation: @attrs }
+            assert_response :error
           end
         end
       end

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -128,7 +128,7 @@ module Api
           end
 
           test 'with job_template_id param' do
-            @attrs[:job_template_id] = 12345
+            @attrs[:job_template_id] = 12_345
             post :create, params: { job_invocation: @attrs }
             assert_response :error
           end


### PR DESCRIPTION
I'll need someone to verify the correctness of the change I made here. The tests I removed assert that the job invocations API should take `host_ids` as an input but that param  is undocumented. I think those tests were meant to describe the behavior of `JobInvocationComposer.for_feature` so I updated the tests accordingly, while also updating the controller to correctly pass the `search_query` param into `for_feature`