### PR TITLE
Fixes #32439 - Add error state to job wizard

### DIFF
--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -1,6 +1,7 @@
 import {
   selectAPIResponse,
   selectAPIStatus,
+  selectAPIErrorMessage,
 } from 'foremanReact/redux/API/APISelectors';
 
 import { JOB_TEMPLATES, JOB_CATEGORIES } from './JobWizardConstants';
@@ -19,3 +20,9 @@ export const selectJobCategories = state =>
 
 export const selectJobCategoriesStatus = state =>
   selectAPIStatus(state, JOB_CATEGORIES);
+
+export const selectCategoryError = state =>
+  selectAPIErrorMessage(state, JOB_CATEGORIES);
+
+export const selectAllTemplatesError = state =>
+  selectAPIErrorMessage(state, JOB_TEMPLATES);

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Title, Text, TextVariants, Form } from '@patternfly/react-core';
+import { Title, Text, TextVariants, Form, Alert } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { SelectField } from '../form/SelectField';
 import { GroupedSelectField } from '../form/GroupedSelectField';
@@ -12,6 +12,7 @@ export const CategoryAndTemplate = ({
   selectedTemplateID,
   selectedCategory,
   setCategory,
+  errors,
 }) => {
   const templatesGroups = {};
   jobTemplates.forEach(template => {
@@ -35,6 +36,8 @@ export const CategoryAndTemplate = ({
     setCategory(newCategory);
     setJobTemplate(null);
   };
+  const { categoryError, allTemplatesError } = errors;
+  const isError = !!(categoryError || allTemplatesError);
   return (
     <>
       <Title headingLevel="h2">{__('Category And Template')}</Title>
@@ -46,6 +49,8 @@ export const CategoryAndTemplate = ({
           options={jobCategories}
           setValue={onSelectCategory}
           value={selectedCategory}
+          placeholderText={categoryError ? __('Error') : ''}
+          isDisabled={!!categoryError}
         />
         <GroupedSelectField
           label={__('Job template')}
@@ -53,7 +58,23 @@ export const CategoryAndTemplate = ({
           groups={Object.values(templatesGroups)}
           setSelected={setJobTemplate}
           selected={selectedTemplate}
+          isDisabled={isError}
+          placeholderText={allTemplatesError ? __('Error') : ''}
         />
+        {isError && (
+          <Alert variant="danger" title={__('Errors:')}>
+            {categoryError && (
+              <span>
+                {__('Categories list failed with:')} {categoryError}
+              </span>
+            )}
+            {allTemplatesError && (
+              <span>
+                {__('Templates list failed with:')} {allTemplatesError}
+              </span>
+            )}
+          </Alert>
+        )}
       </Form>
     </>
   );
@@ -66,12 +87,17 @@ CategoryAndTemplate.propTypes = {
   selectedTemplateID: PropTypes.number,
   setCategory: PropTypes.func.isRequired,
   selectedCategory: PropTypes.string,
+  errors: PropTypes.shape({
+    categoryError: PropTypes.string,
+    allTemplatesError: PropTypes.string,
+  }),
 };
 CategoryAndTemplate.defaultProps = {
   jobCategories: [],
   jobTemplates: [],
   selectedTemplateID: null,
   selectedCategory: null,
+  errors: {},
 };
 
 export default CategoryAndTemplate;

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.test.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.test.js
@@ -1,8 +1,14 @@
 import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
 import { CategoryAndTemplate } from './CategoryAndTemplate';
 
+const baseProps = {
+  setJobTemplate: jest.fn(),
+  selectedTemplateID: 190,
+  setCategory: jest.fn(),
+};
 const fixtures = {
   'renders with props': {
+    ...baseProps,
     jobCategories: [
       'Commands',
       'Ansible Playbook',
@@ -32,10 +38,11 @@ const fixtures = {
         snippet: false,
       },
     ],
-    setJobTemplate: jest.fn(),
-    selectedTemplateID: 190,
-    setCategory: jest.fn(),
     selectedCategory: 'I am a category',
+  },
+  'render with error': {
+    ...baseProps,
+    errors: { allTemplatesError: 'I have an error' },
   },
 };
 

--- a/webpack/JobWizard/steps/CategoryAndTemplate/__snapshots__/CategoryAndTemplate.test.js.snap
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/__snapshots__/CategoryAndTemplate.test.js.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CategoryAndTemplate rendering render with error 1`] = `
+<Fragment>
+  <Title
+    headingLevel="h2"
+  >
+    Category And Template
+  </Title>
+  <Text
+    component="p"
+  >
+    All fields are required.
+  </Text>
+  <Form>
+    <SelectField
+      fieldId="job_category"
+      isDisabled={false}
+      label="Job category"
+      options={Array []}
+      placeholderText=""
+      setValue={[Function]}
+      value={null}
+    />
+    <GroupedSelectField
+      fieldId="job_template"
+      groups={Array []}
+      isDisabled={true}
+      label="Job template"
+      placeholderText="Error"
+      selected={null}
+      setSelected={[MockFunction]}
+    />
+    <Alert
+      title="Errors:"
+      variant="danger"
+    >
+      <span>
+        Templates list failed with:
+         
+        I have an error
+      </span>
+    </Alert>
+  </Form>
+</Fragment>
+`;
+
 exports[`CategoryAndTemplate rendering renders with props 1`] = `
 <Fragment>
   <Title
@@ -15,6 +60,7 @@ exports[`CategoryAndTemplate rendering renders with props 1`] = `
   <Form>
     <SelectField
       fieldId="job_category"
+      isDisabled={false}
       label="Job category"
       options={
         Array [
@@ -24,6 +70,7 @@ exports[`CategoryAndTemplate rendering renders with props 1`] = `
           "Ansible Roles Installation",
         ]
       }
+      placeholderText=""
       setValue={[Function]}
       value="I am a category"
     />
@@ -55,7 +102,9 @@ exports[`CategoryAndTemplate rendering renders with props 1`] = `
           },
         ]
       }
+      isDisabled={false}
       label="Job template"
+      placeholderText=""
       selected="ab Run Command - SSH Default clone"
       setSelected={[MockFunction]}
     />

--- a/webpack/JobWizard/steps/CategoryAndTemplate/index.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/index.js
@@ -8,6 +8,8 @@ import {
   selectJobTemplates,
   selectJobCategoriesStatus,
   filterJobTemplates,
+  selectCategoryError,
+  selectAllTemplatesError,
 } from '../../JobWizardSelectors';
 import { CategoryAndTemplate } from './CategoryAndTemplate';
 
@@ -63,6 +65,10 @@ const ConnectedCategoryAndTemplate = ({
 
   const jobTemplates = useSelector(selectJobTemplates);
 
+  const errors = {
+    categoryError: useSelector(selectCategoryError),
+    allTemplatesError: useSelector(selectAllTemplatesError),
+  };
   return (
     <CategoryAndTemplate
       jobTemplates={jobTemplates}
@@ -71,6 +77,7 @@ const ConnectedCategoryAndTemplate = ({
       selectedTemplateID={jobTemplate}
       setCategory={setCategory}
       selectedCategory={category}
+      errors={errors}
     />
   );
 };

--- a/webpack/JobWizard/steps/form/GroupedSelectField.js
+++ b/webpack/JobWizard/steps/form/GroupedSelectField.js
@@ -14,6 +14,7 @@ export const GroupedSelectField = ({
   groups,
   selected,
   setSelected,
+  ...props
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const onSelect = selection => {
@@ -67,6 +68,7 @@ export const GroupedSelectField = ({
         selections={selected}
         className="without_select2"
         onClear={onClear}
+        {...props}
       >
         {options}
       </Select>

--- a/webpack/JobWizard/steps/form/SelectField.js
+++ b/webpack/JobWizard/steps/form/SelectField.js
@@ -2,7 +2,14 @@ import React, { useState } from 'react';
 import { FormGroup, Select, SelectOption } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
-export const SelectField = ({ label, fieldId, options, value, setValue }) => {
+export const SelectField = ({
+  label,
+  fieldId,
+  options,
+  value,
+  setValue,
+  ...props
+}) => {
   const onSelect = (event, selection) => {
     setValue(selection);
     setIsOpen(false);
@@ -17,6 +24,7 @@ export const SelectField = ({ label, fieldId, options, value, setValue }) => {
         isOpen={isOpen}
         className="without_select2"
         maxHeight="45vh"
+        {...props}
       >
         {options.map((option, index) => (
           <SelectOption key={index} value={option} />

--- a/webpack/__mocks__/foremanReact/redux/API/APISelectors.js
+++ b/webpack/__mocks__/foremanReact/redux/API/APISelectors.js
@@ -1,2 +1,3 @@
 export const selectAPIStatus = () => 'RESOLVED';
 export const selectAPIResponse = state => state;
+export const selectAPIErrorMessage = state => state.error;


### PR DESCRIPTION
When one of the api calls in job wizard fails there is now an error shown.
Currently there are only api calls to get  the categories list and templates list
![Screenshot from 2021-05-05 12-40-34](https://user-images.githubusercontent.com/30431079/117135695-fa96c900-adaf-11eb-9d17-8436f016ab29.png)
