### PR TITLE
Fixes #32594 - Add template provider inputs into scope

### DIFF
--- a/app/lib/foreman_remote_execution/renderer/scope/input.rb
+++ b/app/lib/foreman_remote_execution/renderer/scope/input.rb
@@ -5,7 +5,7 @@ module ForemanRemoteExecution
         include Foreman::Renderer::Scope::Macros::HostTemplate
         extend ApipieDSL::Class
 
-        attr_reader :template, :host, :invocation, :input_template_instance, :current_user
+        attr_reader :template, :host, :invocation, :input_template_instance, :current_user, :provider_input_values
         attr_accessor :error_message
         delegate :input, to: :input_template_instance
 

--- a/app/models/input_template_renderer.rb
+++ b/app/models/input_template_renderer.rb
@@ -41,6 +41,7 @@ class InputTemplateRenderer
         preview: @preview,
         invocation: invocation,
         input_values: @template_input_values,
+        provider_input_values: provider_values_from_invocation,
         templates_stack: templates_stack,
         input_template_instance: self,
         current_user: User.current.try(:login),
@@ -62,6 +63,11 @@ class InputTemplateRenderer
   end
 
   private
+
+  def provider_values_from_invocation
+    result = @invocation ? Hash[@invocation.provider_input_values.map { |iv| [iv.name, iv.value] }] : {}
+    result.with_indifferent_access
+  end
 
   def values_from_invocation
     input_values = @invocation ? Hash[@invocation.input_values.map { |iv| [iv.template_input.name, iv.value] }] : {}


### PR DESCRIPTION
Make sure provider template input values are available
when rendering a job template.