### PR TITLE
Fixes #32742 - Ensure job rerun through api works with invalid hosts

### DIFF
--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -405,7 +405,7 @@ class JobInvocationComposer
     job_invocation.effective_user_password = params[:effective_user_password]
 
     if @reruns && job_invocation.targeting.static?
-      job_invocation.targeting.host_ids = JobInvocation.find(@reruns).targeting.host_ids
+      job_invocation.targeting.assign_host_ids(JobInvocation.find(@reruns).targeting.host_ids)
       job_invocation.targeting.mark_resolved!
     end
 

--- a/app/models/targeting.rb
+++ b/app/models/targeting.rb
@@ -46,9 +46,13 @@ class Targeting < ApplicationRecord
     #   pluck(:id) returns duplicate results for HostCollections
     host_ids = User.as(user.login) { Host.authorized(RESOLVE_PERMISSION, Host).search_for(search_query).order(:name, :id).pluck(:id).uniq }
     host_ids.shuffle!(random: Random.new) if randomized_ordering
+    self.assign_host_ids(host_ids)
+    self.save(:validate => false)
+  end
+
+  def assign_host_ids(host_ids)
     # this can be optimized even more, by introducing bulk insert
     self.targeting_hosts.build(host_ids.map { |id| { :host_id => id } })
-    self.save(:validate => false)
   end
 
   def dynamic?


### PR DESCRIPTION
When a job is rerun through the UI, we take out selected fields from the
old job, render the form and then submit it. Essentially it behaves like
running a new job with some fields pre-populated.

When rerunning a job through the api, there is no form middle step. We
just take the old job, run it through job composer, get a new job out of
it and then link the new job's targeting against old job's hosts. This
step was triggering validations on the hosts.
