### PR TITLE
Fixes #32797 - Fix issue that monitor > jobs page could not render

### DIFF
--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -193,11 +193,16 @@ class JobInvocation < ApplicationRecord
   end
 
   def total_hosts_count
+    count = _('N/A')
+
     if targeting.resolved?
-      task&.main_action&.total_count || targeting.hosts.count
-    else
-      _('N/A')
+      count = if task&.main_action.respond_to?(:total_count)
+                task.main_action.total_count
+              else
+                targeting.hosts.count
+              end
     end
+    count
   end
 
   def pattern_template_invocation_for_host(host)


### PR DESCRIPTION
Monitor > Jobs page can not be rendered because total_hosts_count
fails. Unfortunately the total_hosts_count method tries to execute
total_count in ApplicableErrataInstall but this should normally done in
REX > RunHostsJob.

This happens for Jobs created with older REX plugins (< 2.3 of foreman).