### PR TITLE
Fixes #32793 - unambigous result field on index query

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -67,7 +67,7 @@ class JobInvocationsController < ApplicationController
   end
 
   def index
-    @job_invocations = resource_base_search_and_page.with_task.order('job_invocations.id DESC')
+    @job_invocations = resource_base_search_and_page.preload(:task).order('job_invocations.id DESC')
   end
 
   # refreshes the form

--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -67,7 +67,7 @@ class JobInvocationsController < ApplicationController
   end
 
   def index
-    @job_invocations = resource_base_search_and_page.preload(:task).order('job_invocations.id DESC')
+    @job_invocations = resource_base_search_and_page.preload(:task, :targeting).order('job_invocations.id DESC')
   end
 
   # refreshes the form

--- a/app/models/host_status/execution_status.rb
+++ b/app/models/host_status/execution_status.rb
@@ -64,11 +64,11 @@ class HostStatus::ExecutionStatus < HostStatus::Status
 
       case status
         when OK
-          [ "foreman_tasks_tasks.state = 'stopped' AND result = 'success'" ]
+          [ "foreman_tasks_tasks.state = 'stopped' AND foreman_tasks_tasks.result = 'success'" ]
         when CANCELLED
-          [ "foreman_tasks_tasks.state = 'stopped' AND result = 'cancelled'" ]
+          [ "foreman_tasks_tasks.state = 'stopped' AND foreman_tasks_tasks.result = 'cancelled'" ]
         when ERROR
-          [ "foreman_tasks_tasks.state = 'stopped' AND (result = 'error' OR result = 'warning')" ]
+          [ "foreman_tasks_tasks.state = 'stopped' AND (foreman_tasks_tasks.result = 'error' OR foreman_tasks_tasks.result = 'warning')" ]
         when QUEUED
           [ "foreman_tasks_tasks.state = 'scheduled' OR foreman_tasks_tasks.state IS NULL" ]
         when RUNNING

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -65,8 +65,6 @@ class JobInvocation < ApplicationRecord
   scoped_search :on => 'pattern_template_name', :rename => 'pattern_template_name', :operators => ['= '],
     :complete_value => false, :only_explicit => true, :ext_method => :search_by_pattern_template
 
-  scope :with_task, -> { references(:task) }
-
   scoped_search :relation => :recurring_logic, :on => 'id', :rename => 'recurring_logic.id'
 
   scoped_search :relation => :recurring_logic, :on => 'id', :rename => 'recurring',
@@ -99,7 +97,7 @@ class JobInvocation < ApplicationRecord
   def self.search_by_status(key, operator, value)
     conditions = HostStatus::ExecutionStatus::ExecutionTaskStatusMapper.sql_conditions_for(value)
     conditions[0] = "NOT (#{conditions[0]})" if operator == '<>'
-    { :conditions => sanitize_sql_for_conditions(conditions), :include => :task }
+    { :conditions => sanitize_sql_for_conditions(conditions), :joins => :task }
   end
 
   def self.search_by_recurring_logic(key, operator, value)

--- a/app/views/job_invocations/index.html.erb
+++ b/app/views/job_invocations/index.html.erb
@@ -21,7 +21,7 @@
     <% @job_invocations.each do |invocation| %>
       <tr>
         <td class="text_warp"><%= link_to_if_authorized invocation_description(invocation), hash_for_job_invocation_path(invocation).merge(:auth_object => invocation, :permission => :view_job_invocations, :authorizer => authorizer) %></td>
-        <td><%= trunc_with_tooltip(invocation&.targeting&.search_query, 15) %></td>
+        <td><%= trunc_with_tooltip(invocation.targeting.search_query, 15) %></td>
         <td><%= link_to_invocation_task_if_authorized(invocation) %></td>
         <td><%= invocation_result(invocation, :success_count) %></td>
         <td><%= invocation_result(invocation, :failed_count) %></td>

--- a/test/unit/job_invocation_test.rb
+++ b/test/unit/job_invocation_test.rb
@@ -10,7 +10,7 @@ class JobInvocationTest < ActiveSupport::TestCase
     end
 
     it 'is able to perform search through job invocations' do
-      found_jobs = JobInvocation.search_for(%{job_category = "#{job_invocation.job_category}"}).paginate(:page => 1).with_task.order('job_invocations.id DESC')
+      found_jobs = JobInvocation.search_for(%{job_category = "#{job_invocation.job_category}"}).paginate(:page => 1).order('job_invocations.id DESC')
       _(found_jobs).must_equal [job_invocation]
     end
 


### PR DESCRIPTION
This fixes an issue of AmbigousColumn result in JobInvocation query.

It addresses two issues that lead to the error together.

1. We've joined tasks table in two ways, which was not necessary and
   caused double join on foreman_tasks table.
2. We've not referenced table name in the result mapper, which caused
   Ambigous column even when the tasks table was properly aliased.

Also fixing N+1 query introduced by 8f0ba81e3634c2f015814ee77e1b303f77ef3faa. That should probably be a separate PR, but it would have conflicts with this one, so I thought we can do it at once, the resulting history should be fine.