### PR TITLE
Fixes #32834 - job wizard ghost text in search bar

### DIFF
--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -12,6 +12,9 @@
     }
     #advanced-fields-job-template {
       .foreman-search-field {
+        .rbt-input-hint input{
+          display: none;
+        }
         // Giving pf3 search bar a pf4 look
         .search-bar {
           display: block;


### PR DESCRIPTION
depends on https://github.com/theforeman/foreman_remote_execution/pull/554/
removes the ghost text. the hint text is not visible in the text box and only visible when it's out of the text box
![Screenshot from 2021-06-18 11-40-56](https://user-images.githubusercontent.com/30431079/123451001-f6d03780-d5e5-11eb-9d16-e153cd1b1473.png)