### PR TITLE
Fixes #32907 - Check permission for job wizard

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -82,6 +82,7 @@ export const JobWizard = () => {
       canJumpTo: isTemplate,
     },
   ];
+
   return (
     <Wizard
       onClose={() => history.goBack()}

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Title, Divider } from '@patternfly/react-core';
-import { translate as __ } from 'foremanReact/common/I18n';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
+import { useForemanUser } from 'foremanReact/Root/Context/ForemanContext';
+import EmptyState from 'foremanReact/components/common/EmptyState/EmptyStatePattern';
 import { JobWizard } from './JobWizard';
 
 const JobWizardPage = () => {
@@ -12,6 +14,29 @@ const JobWizardPage = () => {
       { caption: title },
     ],
   };
+  const createPermission = 'create_job_invocations';
+
+  const { admin, createPermissions } = useForemanUser();
+
+  if (
+    !admin &&
+    !createPermissions.find(permission => permission === createPermission)
+  ) {
+    return (
+      <EmptyState
+        iconType="fa"
+        icon="lock"
+        header={__('Permission denied')}
+        description={sprintf(
+          __(
+            'You are not authorized to perform this action. Please request one of the required permissions listed below from a Foreman administrator: %s'
+          ),
+          createPermission
+        )}
+      />
+    );
+  }
+
   return (
     <PageLayout
       header={title}


### PR DESCRIPTION
cc @MariaAga

Needs https://github.com/theforeman/foreman/pull/8628

A rough sketch that depends on whether we have the permissions in context. This could be even handled in `AppSwitcher` if routes registered with permissions:

```js
const ForemanREXRoutes = [
  {
    path: '/experimental/job_wizard',
    exact: true,
    render: props => <JobWizardPage {...props} />,
    permission: 'create_job_invocations'
  },
]
```