### PR TITLE
Fixes #29950 - Map Run Puppet Once template to its feature

### DIFF
--- a/app/views/templates/ssh/module_action.erb
+++ b/app/views/templates/ssh/module_action.erb
@@ -29,6 +29,7 @@ template_inputs:
   input_type: user
   required: false
   advanced: true
+feature: :katello_module_stream_action
 %>
 
 <%

--- a/app/views/templates/ssh/puppet_run_once.erb
+++ b/app/views/templates/ssh/puppet_run_once.erb
@@ -10,6 +10,7 @@ template_inputs:
   description: Additional options to pass to puppet
   input_type: user
   required: false
+feature: puppet_run_host
 %>
 <% if @host.operatingsystem.family == 'Debian' -%>
 export PATH=/opt/puppetlabs/bin:$PATH


### PR DESCRIPTION
The code we had was most likely supposed to link the feature against an
already existing template. In case the template didn't exist when the
seeds were run, nothing established the relationship.