### PR TITLE
Fixes #33007 - Handle taxonomies gracefully on output endpoints

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -162,6 +162,15 @@ module Api
         render :json => { :outputs => outputs }
       end
 
+      def resource_name(resource = controller_name)
+        case resource
+        when 'organization', 'location'
+          nil
+        else
+          'job_invocation'
+        end
+      end
+
       private
 
       def allowed_nested_id

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -181,6 +181,11 @@ module Api
                                  host_id: FactoryBot.create(:host).id }
           assert_response :missing
         end
+
+        test 'should not break when taxonomy parameters are provided' do
+          get :output, params: { :job_invocation_id => @invocation.id, :host_id => host.id, :organization_id => host.organization_id, :location_id => host.location_id }
+          assert_response :success
+        end
       end
 
       describe '#outputs' do
@@ -230,6 +235,11 @@ module Api
           result = ActiveSupport::JSON.decode(@response.body)
           assert_equal result['complete'], true
           assert_equal result['output'], (1..5).map(&:to_s).join("\n") + "\n"
+          assert_response :success
+        end
+
+        test 'should not break when taxonomy parameters are provided' do
+          get :raw_output, params: { :job_invocation_id => @invocation.id, :host_id => host.id, :organization_id => host.organization_id, :location_id => host.location_id }
           assert_response :success
         end
 


### PR DESCRIPTION
When organization_id or location_id parameters were supplied, the nested
resource handling machinery resolved the organization (or location) to
be the parent resource instead of the expected job invocation.