### PR TITLE
Fixes #31705 - Handle timezones when scheduling jobs through API

### DIFF
--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -209,7 +209,7 @@ class JobInvocationComposer
     def format_datetime(datetime)
       return datetime if datetime.blank?
 
-      Time.parse(datetime).strftime('%Y-%m-%d %H:%M')
+      Time.parse(datetime).utc.strftime('%Y-%m-%d %H:%M')
     end
   end
 


### PR DESCRIPTION
We claimed to have support for iso8601 timestamps, but in reality we
discarded timezone information and assumed the timestamp to be in UTC.