### PR TITLE
Refs #27770 - Add support for ed25519 keys with net-ssh ~> 4.2.0 

### DIFF
--- a/foreman_remote_execution_core.gemspec
+++ b/foreman_remote_execution_core.gemspec
@@ -22,4 +22,6 @@ DESC
   s.add_runtime_dependency('ed25519')
   s.add_runtime_dependency('foreman-tasks-core', '>= 0.3.1')
   s.add_runtime_dependency('net-ssh')
+  s.add_runtime_dependency('rbnacl', '>= 3.2', '< 5.0')
+  s.add_runtime_dependency('rbnacl-libsodium')
 end


### PR DESCRIPTION
Note, keys have to be in PEM format, otherwise opening a connection will
fail with the following trace.

```
2021-07-19T13:14:19  [E] Error initializing command - RuntimeError No digester supplied:
net-ssh-4.2.0/lib/net/ssh/transport/key_expander.rb:15:in `expand_key'
net-ssh-4.2.0/lib/net/ssh/transport/cipher_factory.rb:67:in `get'
net-ssh-4.2.0/lib/net/ssh/authentication/ed25519.rb:111:in `initialize'
net-ssh-4.2.0/lib/net/ssh/authentication/ed25519.rb:152:in `new'
net-ssh-4.2.0/lib/net/ssh/authentication/ed25519.rb:152:in `read'
net-ssh-4.2.0/lib/net/ssh/key_factory.rb:113:in `block in classify_key'
net-ssh-4.2.0/lib/net/ssh/key_factory.rb:60:in `load_data_private_key'
net-ssh-4.2.0/lib/net/ssh/key_factory.rb:43:in `load_private_key'
net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:142:in `sign'
net-ssh-4.2.0/lib/net/ssh/authentication/methods/publickey.rb:62:in `authenticate_with'
net-ssh-4.2.0/lib/net/ssh/authentication/methods/publickey.rb:20:in `block in authenticate'
net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:122:in `block in each_identity'
net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:119:in `each'
net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:119:in `each_identity'
net-ssh-4.2.0/lib/net/ssh/authentication/methods/publickey.rb:19:in `authenticate'
net-ssh-4.2.0/lib/net/ssh/authentication/session.rb:80:in `block in authenticate'
net-ssh-4.2.0/lib/net/ssh/authentication/session.rb:66:in `each'
net-ssh-4.2.0/lib/net/ssh/authentication/session.rb:66:in `authenticate'
net-ssh-4.2.0/lib/net/ssh.rb:241:in `start'
```