### PR TITLE
Fixes #32675 - Perform host cancel without following the link

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -113,12 +113,14 @@ module RemoteExecutionHelper
         :class => 'btn btn-danger',
         :title => _('Try to cancel the job on a host'),
         :disabled => !task.cancellable?,
-        :method => :post)
+        :method => :post,
+        :remote => true)
       buttons << link_to(_('Abort Job'), abort_foreman_tasks_task_path(task),
         :class => 'btn btn-danger',
         :title => _('Try to abort the job on a host without waiting for its result'),
         :disabled => !task.cancellable?,
-        :method => :post)
+        :method => :post,
+        :remote => true)
     end
     buttons
   end


### PR DESCRIPTION
Cancelling and aborting a job from the template invocation details does
a POST to foreman_tasks. Before this change, it followed the link and
displayed a JSON response provided by the controller. After this change
the request is done in background without leaving the current page.