### PR TITLE
Fixes #33094 - auto fill job wizard with hosts

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -15,6 +15,7 @@ import { selectTemplateError, selectJobTemplate } from './JobWizardSelectors';
 import Schedule from './steps/Schedule/';
 import HostsAndInputs from './steps/HostsAndInputs/';
 import { useValidation } from './validation';
+import { useAutoFill } from './autofill';
 import './JobWizard.scss';
 
 export const JobWizard = () => {
@@ -94,6 +95,10 @@ export const JobWizard = () => {
   const [valid, setValid] = useValidation({
     advancedValues,
     templateValues,
+  });
+  useAutoFill({
+    setSelectedTargets,
+    setHostsSearchQuery,
   });
   const templateError = !!useSelector(selectTemplateError);
   const templateResponse = useSelector(selectJobTemplate);

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -53,3 +53,4 @@ export const dataName = {
 export const HOSTS_TO_PREVIEW_AMOUNT = 20;
 
 export const DEBOUNCE_HOST_COUNT = 700;
+export const HOST_IDS = 'HOST_IDS';

--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -1,9 +1,11 @@
+import URI from 'urijs';
 import {
   selectAPIResponse,
   selectAPIStatus,
   selectAPIErrorMessage,
 } from 'foremanReact/redux/API/APISelectors';
 import { STATUS } from 'foremanReact/constants';
+import { selectRouterLocation } from 'foremanReact/routes/RouterSelector';
 
 import {
   JOB_TEMPLATES,
@@ -65,3 +67,8 @@ export const selectResponse = selectAPIResponse;
 
 export const selectIsLoading = (state, key) =>
   selectAPIStatus(state, key) === STATUS.PENDING;
+
+export const selectRouterSearch = state => {
+  const { search } = selectRouterLocation(state);
+  return URI.parseQuery(search);
+};

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -160,12 +160,17 @@ export const mockApi = api => {
         handleSuccess({
           data: { results: [jobTemplate] },
         });
+    } else if (action.key === 'HOST_IDS') {
+      handleSuccess &&
+        handleSuccess({
+          data: { results: [{ name: 'host1' }, { name: 'host3' }] },
+        });
     }
     return { type: 'get', ...action };
   });
 };
 
-export const qglMock = [
+export const gqlMock = [
   {
     request: {
       query: hostsQuery,

--- a/webpack/JobWizard/__tests__/integration.test.js
+++ b/webpack/JobWizard/__tests__/integration.test.js
@@ -12,7 +12,7 @@ import {
   mockApi,
   jobCategories,
   jobTemplateResponse as jobTemplate,
-  qglMock,
+  gqlMock,
 } from './fixtures';
 
 const store = testSetup(selectors, api);
@@ -68,7 +68,7 @@ describe('Job wizard fill', () => {
     mockApi(api);
 
     render(
-      <MockedProvider mocks={qglMock} addTypename={false}>
+      <MockedProvider mocks={gqlMock} addTypename={false}>
         <Provider store={store}>
           <JobWizard />
         </Provider>

--- a/webpack/JobWizard/__tests__/validation.test.js
+++ b/webpack/JobWizard/__tests__/validation.test.js
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 import * as api from 'foremanReact/redux/API';
 import { JobWizard } from '../JobWizard';
 import * as selectors from '../JobWizardSelectors';
-import { testSetup, mockApi, jobTemplateResponse, qglMock } from './fixtures';
+import { testSetup, mockApi, jobTemplateResponse, gqlMock } from './fixtures';
 import { WIZARD_TITLES } from '../JobWizardConstants';
 
 const store = testSetup(selectors, api);
@@ -30,7 +30,7 @@ describe('Job wizard validation', () => {
   });
   it('requeried', async () => {
     render(
-      <MockedProvider mocks={qglMock} addTypename={false}>
+      <MockedProvider mocks={gqlMock} addTypename={false}>
         <Provider store={store}>
           <JobWizard />
         </Provider>
@@ -75,7 +75,7 @@ describe('Job wizard validation', () => {
 
   it('advanced number', async () => {
     render(
-      <MockedProvider mocks={qglMock} addTypename={false}>
+      <MockedProvider mocks={gqlMock} addTypename={false}>
         <Provider store={store}>
           <JobWizard />
         </Provider>

--- a/webpack/JobWizard/autofill.js
+++ b/webpack/JobWizard/autofill.js
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { get } from 'foremanReact/redux/API';
+import { HOST_IDS } from './JobWizardConstants';
+import { selectRouterSearch } from './JobWizardSelectors';
+import './JobWizard.scss';
+
+export const useAutoFill = ({ setSelectedTargets, setHostsSearchQuery }) => {
+  const fills = useSelector(selectRouterSearch);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (Object.keys(fills).length) {
+      if (fills['host_ids[]']) {
+        dispatch(
+          get({
+            key: HOST_IDS,
+            url: '/api/hosts',
+            params: { search: `id = ${fills['host_ids[]'].join(' or id = ')}` },
+            handleSuccess: ({ data }) => {
+              setSelectedTargets(currentTargets => ({
+                ...currentTargets,
+                hosts: (data.results || []).map(({ name }) => ({
+                  id: name,
+                  name,
+                })),
+              }));
+            },
+          })
+        );
+      }
+      if (fills.search) {
+        setHostsSearchQuery(fills.search);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Title, Divider } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
@@ -27,6 +28,12 @@ const JobWizardPage = () => {
       </React.Fragment>
     </PageLayout>
   );
+};
+
+JobWizardPage.propTypes = {
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }).isRequired,
 };
 
 export default JobWizardPage;

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -13,7 +13,7 @@ import {
   testSetup,
   mockApi,
   jobCategories,
-  qglMock,
+  gqlMock,
 } from '../../../__tests__/fixtures';
 import { WIZARD_TITLES } from '../../../JobWizardConstants';
 
@@ -28,7 +28,7 @@ selectors.selectEffectiveUser.mockImplementation(
 describe('AdvancedFields', () => {
   it('should save data between steps for advanced fields', async () => {
     const wrapper = mount(
-      <MockedProvider mocks={qglMock} addTypename={false}>
+      <MockedProvider mocks={gqlMock} addTypename={false}>
         <Provider store={store}>
           <JobWizard />
         </Provider>
@@ -85,7 +85,7 @@ describe('AdvancedFields', () => {
   });
   it('fill template fields', async () => {
     render(
-      <MockedProvider mocks={qglMock} addTypename={false}>
+      <MockedProvider mocks={gqlMock} addTypename={false}>
         <Provider store={store}>
           <JobWizard />
         </Provider>
@@ -155,7 +155,7 @@ describe('AdvancedFields', () => {
   });
   it('fill defaults into fields', async () => {
     render(
-      <MockedProvider mocks={qglMock} addTypename={false}>
+      <MockedProvider mocks={gqlMock} addTypename={false}>
         <Provider store={store}>
           <JobWizard />
         </Provider>

--- a/webpack/JobWizard/steps/HostsAndInputs/SelectedChips.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/SelectedChips.js
@@ -12,9 +12,9 @@ const SelectedChip = ({ selected, setSelected, categoryName }) => {
   };
   return (
     <ChipGroup className="hosts-chip-group" categoryName={categoryName}>
-      {selected.map(({ name, id }) => (
+      {selected.map(({ name, id }, index) => (
         <Chip
-          key={name}
+          key={index}
           id={id}
           onClick={() => deleteItem(id)}
           closeBtnAriaLabel={`Close ${name}`}

--- a/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
@@ -5,7 +5,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import * as api from 'foremanReact/redux/API';
 import { JobWizard } from '../../../JobWizard';
 import * as selectors from '../../../JobWizardSelectors';
-import { testSetup, mockApi, qglMock } from '../../../__tests__/fixtures';
+import { testSetup, mockApi, gqlMock } from '../../../__tests__/fixtures';
 import { WIZARD_TITLES } from '../../../JobWizardConstants';
 
 const store = testSetup(selectors, api);
@@ -14,7 +14,7 @@ mockApi(api);
 describe('TemplateInputs', () => {
   it('should save data between steps for template input fields', async () => {
     render(
-      <MockedProvider mocks={qglMock} addTypename={false}>
+      <MockedProvider mocks={gqlMock} addTypename={false}>
         <Provider store={store}>
           <JobWizard />
         </Provider>

--- a/webpack/__mocks__/foremanReact/routes/RouterSelector.js
+++ b/webpack/__mocks__/foremanReact/routes/RouterSelector.js
@@ -1,0 +1,1 @@
+export const selectRouterLocation = jest.fn(() => ({}));


### PR DESCRIPTION
url example to get fill: 
`/experimental/job_wizard?host_ids%5B%5D=100&host_ids%5B%5D=67`
`/experimental/job_wizard?search=os+%3D+CentOS`
depends on: https://github.com/theforeman/foreman_remote_execution/pull/578