### PR TITLE
 Fixes #33125 - autofill wizard with feature and inputs

### DIFF
--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -58,3 +58,4 @@ export const HOSTS_TO_PREVIEW_AMOUNT = 20;
 
 export const DEBOUNCE_HOST_COUNT = 700;
 export const HOST_IDS = 'HOST_IDS';
+export const REX_FEATURE = 'REX_FEATURE';

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -165,6 +165,11 @@ export const mockApi = api => {
         handleSuccess({
           data: { results: [{ name: 'host1' }, { name: 'host3' }] },
         });
+    } else if (action.key === 'REX_FEATURE') {
+      handleSuccess &&
+        handleSuccess({
+          data: { job_template_id: 178 },
+        });
     }
     return { type: 'get', ...action };
   });

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Title, Divider } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
@@ -28,12 +27,6 @@ const JobWizardPage = () => {
       </React.Fragment>
     </PageLayout>
   );
-};
-
-JobWizardPage.propTypes = {
-  location: PropTypes.shape({
-    search: PropTypes.string,
-  }).isRequired,
 };
 
 export default JobWizardPage;

--- a/webpack/JobWizard/steps/CategoryAndTemplate/index.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/index.js
@@ -25,6 +25,7 @@ const ConnectedCategoryAndTemplate = ({
   setJobTemplate,
   category,
   setCategory,
+  isFeature,
 }) => {
   const dispatch = useDispatch();
 
@@ -36,12 +37,14 @@ const ConnectedCategoryAndTemplate = ({
         get({
           key: JOB_CATEGORIES,
           url: '/ui_job_wizard/categories',
-          handleSuccess: response =>
-            setCategory(response.data.job_categories[0] || ''),
+          handleSuccess: response => {
+            if (!isFeature) setCategory(response.data.job_categories[0] || '');
+          },
         })
       );
     }
-  }, [jobCategoriesStatus, dispatch, setCategory]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jobCategoriesStatus]);
 
   const jobCategories = useSelector(selectJobCategories);
   useEffect(() => {
@@ -55,14 +58,17 @@ const ConnectedCategoryAndTemplate = ({
             per_page: 'all',
           }),
           handleSuccess: response => {
-            setJobTemplate(
-              Number(filterJobTemplates(response?.data?.results)[0]?.id) || null
-            );
+            if (!jobTemplate)
+              setJobTemplate(
+                Number(filterJobTemplates(response?.data?.results)[0]?.id) ||
+                  null
+              );
           },
         })
       );
     }
-  }, [category, dispatch, setJobTemplate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [category, dispatch]);
 
   const jobTemplates = useSelector(selectJobTemplates);
 
@@ -89,6 +95,7 @@ ConnectedCategoryAndTemplate.propTypes = {
   setJobTemplate: PropTypes.func.isRequired,
   category: PropTypes.string.isRequired,
   setCategory: PropTypes.func.isRequired,
+  isFeature: PropTypes.bool.isRequired,
 };
 ConnectedCategoryAndTemplate.defaultProps = { jobTemplate: null };
 

--- a/webpack/JobWizard/steps/HostsAndInputs/__tests__/HostsAndInputs.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/__tests__/HostsAndInputs.test.js
@@ -148,4 +148,32 @@ describe('Hosts', () => {
     });
     expect(screen.queryAllByText('os=gnome')).toHaveLength(1);
   });
+
+  it('input fill from url', async () => {
+    const inputText = 'test text';
+    routerSelectors.selectRouterLocation.mockImplementation(() => ({
+      search: `feature=test_feature&inputs[plain hidden]=${inputText}`,
+    }));
+    render(
+      <MockedProvider mocks={gqlMock} addTypename={false}>
+        <Provider store={store}>
+          <JobWizard />
+        </Provider>
+      </MockedProvider>
+    );
+    api.get.mock.calls.forEach(call => {
+      if (call[0].key === 'REX_FEATURE') {
+        expect(call[0].url).toEqual(
+          '/api/remote_execution_features/test_feature'
+        );
+      }
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Target hosts and inputs'));
+    });
+    const textField = screen.getByLabelText('plain hidden', {
+      selector: 'textarea',
+    });
+    expect(textField.value).toBe(inputText);
+  });
 });


### PR DESCRIPTION
depends on: https://github.com/theforeman/foreman_remote_execution/pull/626
example url: `?feature=ansible_run_playbook&inputs[playbook]=hello`
There are some changes in the use effect of selecting category and template.
workflow should be:
No feature in url? select first category -> get categories templates -> select first template
feature in url? select the template -> select the templates category -> get categories templates -> use effect sees that there is a feature in the url and doesnt select the first template. Also deletes the feature so if a user selects a different category the first template of the category will be selected.
