### PR TITLE
Fixes #32990 - job wizard select default template

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -6,7 +6,7 @@ class UiJobWizardController < ApplicationController
                      .select(:job_category).distinct
                      .reorder(:job_category)
                      .pluck(:job_category)
-    render :json => {:job_categories =>job_categories, :with_katello => with_katello}
+    render :json => {:job_categories => job_categories, :with_katello => with_katello, default_category: default_category, default_template: default_template&.id}
   end
 
   def template
@@ -22,6 +22,16 @@ class UiJobWizardController < ApplicationController
 
   def map_template_inputs(template_inputs_with_foreign)
     template_inputs_with_foreign.map { |input| input.attributes.merge({:resource_type_tableize => input.resource_type&.tableize }) }
+  end
+
+  def default_category
+    default_template&.job_category
+  end
+
+  def default_template
+    if (setting_value = Setting['remote_execution_form_job_template'])
+      JobTemplate.authorized(:view_job_templates).find_by :name => setting_value
+    end
   end
 
   def resource_name(nested_resource = nil)

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -96,7 +96,7 @@ export const jobTemplateResponse = {
   ],
 };
 
-export const jobCategories = ['Ansible Commands', 'Puppet', 'Services'];
+export const jobCategories = ['Services', 'Ansible Commands', 'Puppet'];
 
 export const testSetup = (selectors, api) => {
   jest.spyOn(api, 'get');
@@ -149,7 +149,12 @@ export const mockApi = api => {
   api.get.mockImplementation(({ handleSuccess, ...action }) => {
     if (action.key === 'JOB_CATEGORIES') {
       handleSuccess &&
-        handleSuccess({ data: { job_categories: jobCategories } });
+        handleSuccess({
+          data: {
+            job_categories: jobCategories,
+            default_category: 'Ansible Commands',
+          },
+        });
     } else if (action.key === 'JOB_TEMPLATE') {
       handleSuccess &&
         handleSuccess({

--- a/webpack/JobWizard/__tests__/integration.test.js
+++ b/webpack/JobWizard/__tests__/integration.test.js
@@ -22,7 +22,12 @@ describe('Job wizard fill', () => {
     api.get.mockImplementation(({ handleSuccess, ...action }) => {
       if (action.key === 'JOB_CATEGORIES') {
         handleSuccess &&
-          handleSuccess({ data: { job_categories: jobCategories } });
+          handleSuccess({
+            data: {
+              job_categories: jobCategories,
+              default_category: 'Ansible Commands',
+            },
+          });
       } else if (action.key === 'JOB_TEMPLATE') {
         handleSuccess &&
           handleSuccess({

--- a/webpack/JobWizard/steps/CategoryAndTemplate/index.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/index.js
@@ -37,8 +37,17 @@ const ConnectedCategoryAndTemplate = ({
         get({
           key: JOB_CATEGORIES,
           url: '/ui_job_wizard/categories',
-          handleSuccess: response => {
-            if (!isFeature) setCategory(response.data.job_categories[0] || '');
+          handleSuccess: ({
+            data: {
+              default_category: defaultCategory,
+              job_categories: jobCategories,
+              default_template: defaultTemplate,
+            },
+          }) => {
+            if (!isFeature) {
+              setCategory(defaultCategory || jobCategories[0] || '');
+              if (defaultTemplate) setJobTemplate(defaultTemplate);
+            }
           },
         })
       );
@@ -60,7 +69,9 @@ const ConnectedCategoryAndTemplate = ({
           handleSuccess: response => {
             if (!jobTemplate)
               setJobTemplate(
-                Number(filterJobTemplates(response?.data?.results)[0]?.id) ||
+                current =>
+                  current ||
+                  Number(filterJobTemplates(response?.data?.results)[0]?.id) ||
                   null
               );
           },


### PR DESCRIPTION
The default template is set in the Remote Execution settings
depends on: https://github.com/theforeman/foreman_remote_execution/pull/629