### PR TITLE
Fixes #33143 - hide rex buttons for unpriviledged

### DIFF
--- a/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
+++ b/app/helpers/concerns/foreman_remote_execution/hosts_helper_extensions.rb
@@ -7,7 +7,9 @@ module ForemanRemoteExecution
     end
 
     def multiple_actions
-      super + [ [_('Schedule Remote Job'), new_job_invocation_path, false] ]
+      res = super
+      res += [ [_('Schedule Remote Job'), new_job_invocation_path, false] ] if authorized_for(controller: :job_invocations, action: :new)
+      res
     end
 
     def schedule_job_multi_button(*args)
@@ -21,12 +23,14 @@ module ForemanRemoteExecution
     end
 
     def rex_host_features(*args)
+      return unless authorized_for(controller: :job_invocations, action: :create)
       RemoteExecutionFeature.with_host_action_button.order(:label).map do |feature|
         link_to(_('%s') % feature.name, job_invocations_path(:host_ids => [args.first.id], :feature => feature.label), :method => :post)
       end
     end
 
     def schedule_job_button(*args)
+      return unless authorized_for(controller: :job_invocations, action: :new)
       link_to(_('Schedule Remote Job'), new_job_invocation_path(:host_ids => [args.first.id]), :id => :run_button, :class => 'btn btn-default')
     end
 


### PR DESCRIPTION
Users who can't run the Host REX jobs should not see the REX buttons.