### PR TITLE
Revert "Refs #27770 - Add support for ed25519 keys with net-ssh ~> 4.…

### DIFF
--- a/foreman_remote_execution_core.gemspec
+++ b/foreman_remote_execution_core.gemspec
@@ -22,6 +22,4 @@ DESC
   s.add_runtime_dependency('ed25519')
   s.add_runtime_dependency('foreman-tasks-core', '>= 0.3.1')
   s.add_runtime_dependency('net-ssh')
-  s.add_runtime_dependency('rbnacl', '>= 3.2', '< 5.0')
-  s.add_runtime_dependency('rbnacl-libsodium')
 end


### PR DESCRIPTION
…2.0 (#621)"

This reverts commit b794b906f64c025f79c71021f3dd3eee1f486b82.

The additional optional dependencies will be added in packaging.