### PR TITLE
Fixes #31564 - add email notification

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -220,6 +220,7 @@ Naming/FileName:
     - 'db/seeds.d/60-ssh_proxy_feature.rb'
     - 'db/seeds.d/70-job_templates.rb'
     - 'db/seeds.d/90-bookmarks.rb'
+    - 'db/seeds.d/95-mail_notifications.rb'
 
 # Offense count: 1
 # Configuration parameters: ForbiddenDelimiters.

--- a/app/mailers/rex_job_mailer.rb
+++ b/app/mailers/rex_job_mailer.rb
@@ -1,0 +1,15 @@
+class RexJobMailer < ApplicationMailer
+  add_template_helper(ApplicationHelper)
+
+  def job_finished(job, opts = {})
+    @job = job
+    @subject = opts[:subject] || _('REX job has finished - %s') % @job.to_s
+
+    if @job.user.nil?
+      Rails.logger.warn 'Job user no longer exist, skipping email notification'
+      return
+    end
+
+    mail(to: @job.user.mail, subject: @subject)
+  end
+end

--- a/app/models/rex_mail_notification.rb
+++ b/app/models/rex_mail_notification.rb
@@ -1,0 +1,13 @@
+class RexMailNotification < MailNotification
+  FAILED_JOBS = N_("Subscribe to my failed jobs")
+  SUCCEEDED_JOBS = N_("Subscribe to my succeeded jobs")
+  ALL_JOBS = N_("Subscribe to all my jobs")
+
+  def subscription_options
+    [
+      FAILED_JOBS,
+      SUCCEEDED_JOBS,
+      ALL_JOBS,
+    ]
+  end
+end

--- a/app/services/ui_notifications/remote_execution_jobs/base_job_finish.rb
+++ b/app/services/ui_notifications/remote_execution_jobs/base_job_finish.rb
@@ -20,7 +20,8 @@ module UINotifications
       end
 
       def blueprint
-        @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => 'rex_job_succeeded')
+        blueprint = @subject.status == HostStatus::ExecutionStatus::ERROR ? 'rex_job_failed' : 'rex_job_succeeded'
+        @blueprint ||= NotificationBlueprint.unscoped.find_by(:name => blueprint)
       end
 
       def message

--- a/app/views/rex_job_mailer/job_finished.html.erb
+++ b/app/views/rex_job_mailer/job_finished.html.erb
@@ -1,0 +1,24 @@
+<p>
+  <%= _("A job '%{job_name}' has %{status} at %{time}") % {
+      :job_name => @job.to_s, :status => @job.status_label, :time => date_time_absolute_value(@job.task.ended_at)
+  } %>
+</p>
+
+<div class="dashboard">
+  <table>
+    <tr>
+      <td width="18%" class="hosts-rows"><b><%= _("Job result") %></b></td>
+      <td width="82%" class="hosts-rows"><%= @job.status_label %></td>
+    </tr>
+    <tr>
+      <td width="18%" class="hosts-rows"><b><%= _("Total hosts") %></b></td>
+      <td width="82%" class="hosts-rows"><%= @job.total_hosts_count %></td>
+    </tr>
+    <tr>
+      <td width="18%" class="hosts-rows"><b><%= _("Failed hosts") %></b></td>
+      <td width="82%" class="hosts-rows"><%= @job.failed_hosts.count %></td>
+    </tr>
+  </table>
+</div>
+
+<%= link_to 'More details', job_invocation_url(@job) %>

--- a/app/views/rex_job_mailer/job_finished.text.erb
+++ b/app/views/rex_job_mailer/job_finished.text.erb
@@ -1,0 +1,9 @@
+<%= _("A job '%{job_name}' has %{status} at %{time}") % {
+    :job_name => @job.to_s, :status => @job.status_label, :time => date_time_absolute_value(@job.task.ended_at)
+} %>
+
+<%= _('Job result') %>: <%= @job.status_label %>
+<%= _('Total hosts') %>: <%= @job.total_hosts_count %>
+<%= _('Failed hosts') %>: <%= @job.failed_hosts.count %>
+
+<%= _('See more details at %s') % job_invocation_url(@job) %>

--- a/db/seeds.d/50-notification_blueprints.rb
+++ b/db/seeds.d/50-notification_blueprints.rb
@@ -13,6 +13,20 @@ blueprints = [
       ],
     },
   },
+  {
+    group: N_('Jobs'),
+      name: 'rex_job_failed',
+      message: N_("A job '%{subject}' has failed"),
+      level: 'error',
+      actions:
+          {
+            links:
+                [
+                  path_method: :job_invocation_path,
+                    title: N_('Job Details'),
+                ],
+          },
+  },
 ]
 
 blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }

--- a/db/seeds.d/95-mail_notifications.rb
+++ b/db/seeds.d/95-mail_notifications.rb
@@ -1,0 +1,24 @@
+N_('Remote execution job')
+
+notifications = [
+  {
+    :name               => 'remote_execution_job',
+    :description        => N_('A notification when a job finishes'),
+    :mailer             => 'RexJobMailer',
+    :method             => 'job_finished',
+    :subscription_type  => 'alert',
+  },
+]
+
+notifications.each do |notification|
+  if (mail = RexMailNotification.find_by(name: notification[:name]))
+    mail.attributes = notification
+    mail.save! if mail.changed?
+  else
+    created_notification = RexMailNotification.create(notification)
+    if created_notification.nil? || created_notification.errors.any?
+      raise ::Foreman::Exception.new(N_("Unable to create mail notification: %s"),
+        format_errors(created_notification))
+    end
+  end
+end


### PR DESCRIPTION
User can subscribe to either all job notifications, successful jobs or
failed jobs or no notifications. The user who runs the job would then be
notified based on the subscription. It supports both plain text and html
emails.

Since now we have a way to run the notification even on failure, the
notification drawer notification has been also added in case the job
fails.