### PR TITLE
Fixes #32496 - Append usual paths to the end of PATH for power action

### DIFF
--- a/app/views/templates/ssh/power_action.erb
+++ b/app/views/templates/ssh/power_action.erb
@@ -13,6 +13,8 @@ template_inputs:
   required: true
 %>
 
+PATH="$PATH:/usr/sbin:/sbin"
+
 echo <%= input('action') %> host && sleep 3
 <%= case input('action')
       when 'restart'


### PR DESCRIPTION
Prevents errors like shutdown: command not found