### PR TITLE
Fixes #27769 - Catch exception when using ed25519 algorithm

### DIFF
--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -155,7 +155,7 @@ module ForemanRemoteExecutionCore
       script = initialization_script
       logger.debug("executing script:\n#{indent_multiline(script)}")
       trigger(script)
-    rescue => e
+    rescue StandardError, NotImplementedError => e
       logger.error("error while initalizing command #{e.class} #{e.message}:\n #{e.backtrace.join("\n")}")
       publish_exception('Error initializing command', e)
     end


### PR DESCRIPTION
Catch exception when user generates ssh key with ed25519 algorithm and task will fail with proper error message.