### PR TITLE
Fixes #33002 - Do not use deprecated net-ssh options

### DIFF
--- a/foreman_remote_execution_core.gemspec
+++ b/foreman_remote_execution_core.gemspec
@@ -21,5 +21,5 @@ DESC
   s.add_runtime_dependency('bcrypt_pbkdf')
   s.add_runtime_dependency('ed25519')
   s.add_runtime_dependency('foreman-tasks-core', '>= 0.3.1')
-  s.add_runtime_dependency('net-ssh')
+  s.add_runtime_dependency('net-ssh', '>= 4.2.0')
 end

--- a/lib/foreman_remote_execution_core/script_runner.rb
+++ b/lib/foreman_remote_execution_core/script_runner.rb
@@ -105,6 +105,8 @@ module ForemanRemoteExecutionCore
     EXPECTED_POWER_ACTION_MESSAGES = ['restart host', 'shutdown host'].freeze
     DEFAULT_REFRESH_INTERVAL = 1
     MAX_PROCESS_RETRIES = 4
+    VERIFY_HOST_KEY = Gem::Version.create(Net::SSH::Version::STRING) < Gem::Version.create('5.0.0') ||
+                      :accept_new_or_local_tunnel
 
     def initialize(options, user_method, suspended_action: nil)
       super suspended_action: suspended_action
@@ -278,7 +280,7 @@ module ForemanRemoteExecutionCore
       ssh_options[:keys_only] = true
       # if the host public key is contained in the known_hosts_file,
       # verify it, otherwise, if missing, import it and continue
-      ssh_options[:paranoid] = true
+      ssh_options[:verify_host_key] = VERIFY_HOST_KEY
       ssh_options[:auth_methods] = available_authentication_methods
       ssh_options[:user_known_hosts_file] = prepare_known_hosts if @host_public_key
       ssh_options[:number_of_password_prompts] = 1


### PR DESCRIPTION
Backport of https://github.com/theforeman/smart_proxy_remote_execution_ssh/pull/62