### PR TITLE
Fixes #33242 - Allow false boolean parameters to override true settings

### DIFF
--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -89,7 +89,8 @@ class RemoteExecutionProvider
     end
 
     def host_setting(host, setting)
-      host.host_param(setting.to_s) || Setting[setting]
+      param_value = host.host_param(setting.to_s)
+      param_value.nil? ? Setting[setting] : param_value
     end
 
     def ssh_password(_host)

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -50,6 +50,18 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
     end
   end
 
+  describe '.host_setting' do
+    let(:host) { FactoryBot.create(:host) }
+
+    it 'honors falsey values set as a host parameter' do
+      key = 'remote_execution_connect_by_ip'
+      Setting[key] = true
+      host.parameters << HostParameter.new(name: key, value: false)
+
+      refute RemoteExecutionProvider.host_setting(host, key)
+    end
+  end
+
   describe SSHExecutionProvider do
     before { User.current = FactoryBot.build(:user, :admin) }
     after { User.current = nil }


### PR DESCRIPTION
Previously we treated explicitly set to false and unset as the same thing.