### PR TITLE
Refs #33311 - fix recent audit card alignment

### DIFF
--- a/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
+++ b/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
@@ -21,7 +21,8 @@ const RecentJobsCard = ({ hostDetails: { name, id } }) => {
 
   return (
     <CardTemplate
-      header={__('Recent Jobs')}
+      overrideGridProps={{ xl: 8, lg: 8, md: 12 }}
+      header={__('Recent jobs')}
       dropdownItems={[
         <DropdownItem
           href={foremanUrl(`${JOB_BASE_URL}${name}`)}


### PR DESCRIPTION
In a medium-size resolution, the recent audit card becomes too small for rendering all tabs without scrolling:

before:
![old](https://user-images.githubusercontent.com/11807069/130161646-419366b6-2000-4a9e-a181-f2a05f72705d.png)


after: 
![new](https://user-images.githubusercontent.com/11807069/130161658-0ca2df03-3b2b-4c86-bf01-fc339e2407ae.png)

