### PR TITLE
Fixes #33397 - Propagate validation errors from triggering

### DIFF
--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -441,8 +441,11 @@ class JobInvocationComposer
   end
 
   def valid?
-    targeting.valid? & job_invocation.valid? & !pattern_template_invocations.map(&:valid?).include?(false) &
-      triggering.valid?
+    unless triggering.valid?
+      job_invocation.errors.add(:triggering, 'is invalid')
+      return false
+    end
+    targeting.valid? & job_invocation.valid? & !pattern_template_invocations.map(&:valid?).include?(false)
   end
 
   def save

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -82,6 +82,14 @@ module Api
           assert_response :success
         end
 
+        test 'should propagate errors from triggering' do
+          @attrs[:recurrence] = { cron_line: 'foo' }
+          post :create, params: { job_invocation: @attrs }
+          invocation = ActiveSupport::JSON.decode(@response.body)
+          assert_match(/foo is not valid format of cron line/, invocation['error']['message'])
+          assert_response 500
+        end
+
         test 'should create with schedule' do
           @attrs[:scheduling] = { start_at: Time.now.to_s }
           post :create, params: { job_invocation: @attrs }


### PR DESCRIPTION
A minimal solution leveraging the existing errors flattener.