### PR TITLE
Fixes #32677 - Remove refresh tooltip after form refresh

### DIFF
--- a/app/views/job_invocations/refresh.js.erb
+++ b/app/views/job_invocations/refresh.js.erb
@@ -1,3 +1,4 @@
 $('form#job_invocation_form').replaceWith("<%=j render :partial => 'form' %>");
 $('#job_invocation_form').find('a[rel="popover"]').popover();
 $('#job_invocation_form select:not(.without_select2)').select2({ allowClear: true });
+$('div.tooltip').remove();


### PR DESCRIPTION
When a user clicks the refresh button, the browser does a request in background
and replaces the entire form with the response it receives. However, the tooltip
is rendered directly in body and therefore was left around when the form was
replaced. This change simply removes all currently displayed tooltips once the
refresh is performed.