### PR TITLE
Fixes #33441 - Fixes bad explanation for "Connect by IP" setting

### DIFF
--- a/app/models/setting/remote_execution.rb
+++ b/app/models/setting/remote_execution.rb
@@ -39,7 +39,7 @@ class Setting::RemoteExecution < Setting
       self.set('remote_execution_connect_by_ip',
         N_('Should the ip addresses on host interfaces be preferred over the fqdn? '\
         'It is useful when DNS not resolving the fqdns properly. You may override this per host by setting a parameter called remote_execution_connect_by_ip. '\
-        'This setting only applies to IPv4. When the host has only an IPv6 address on the interface used for remote execution, hostname will be used even if this setting is set to true.'),
+        'This setting only applies to IPv4. When the host has only an IPv6 address on the interface used for remote execution, hostname will be used even if this setting is set to Yes.'),
         false,
         N_('Connect by IP')),
       self.set('remote_execution_ssh_password',


### PR DESCRIPTION
The explanation of "Connect by IP" setting relied on the true value. However, there is only "Yes" or "No" available.