### PR TITLE
Improve handling of nil attributes in tests

### DIFF
--- a/app/models/remote_execution_feature.rb
+++ b/app/models/remote_execution_feature.rb
@@ -50,12 +50,13 @@ class RemoteExecutionFeature < ApplicationRecord
                    :proxy_selector_override => options[:proxy_selector_override],
                    :notification_builder => builder }
     # in case DB does not have the attribute created yet but plugin initializer registers the feature, we need to skip this attribute
-    attrs = [ :host_action_button, :notification_builder ]
-    attrs.each do |attr|
+    [:host_action_button, :notification_builder].each do |attr|
       unless self.attribute_names.include?(attr.to_s)
         attributes.delete(attr)
       end
     end
+    # do not let to set attributes with nil constraint and use default value
+    [:host_action_button].each { |attr| attributes.delete(attr) if attributes[attr].nil? }
 
     self.without_auditing do
       if feature.nil?


### PR DESCRIPTION
I was getting:

https://gist.github.com/lzap/b30edc8aa25fddeef9b1abe4e75435a8

From time to time, not sure what is going on but apparently nil was passed into create method and that attribute cannot be nil.