### PR TITLE
Fixes #33513 - Job wizard transperent menu in small screens

### DIFF
--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -3,6 +3,10 @@
     margin-bottom: 25px;
   }
 
+  .pf-c-wizard__nav.pf-m-expanded {
+    z-index: calc(var(--pf-c-wizard__footer--ZIndex) + 2); // So the small screen navigation can be shown above the select box
+  }
+
   .pf-c-wizard__main {
     overflow: visible;
     z-index: calc(


### PR DESCRIPTION
before
![Screenshot from 2021-09-17 19-23-54](https://user-images.githubusercontent.com/30431079/136090352-e8545c45-1c4a-489b-8ec9-ae8db6c2f37f.png)
after
![Screenshot from 2021-10-05 21-29-41](https://user-images.githubusercontent.com/30431079/136090306-8e860521-70cb-49a7-b9a9-805e89cda01f.png)
