### PR TITLE
Fixes #33368 - job wizard fake auto select template values

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^8.10.0",
-    "@theforeman/eslint-plugin-foreman": "^8.10.0",
-    "@theforeman/stories": "^8.10.0",
-    "@theforeman/test": "^8.10.0",
-    "@theforeman/vendor-dev": "^8.10.0",
+    "@theforeman/builder": "^8.16.0",
+    "@theforeman/eslint-plugin-foreman": "^8.16.0",
+    "@theforeman/stories": "^8.16.0",
+    "@theforeman/test": "^8.16.0",
+    "@theforeman/vendor-dev": "^8.16.0",
     "babel-eslint": "^10.0.0",
     "eslint": "^6.8.0",
     "prettier": "^1.19.1",
@@ -33,6 +33,6 @@
     "redux-mock-store": "^1.2.2"
   },
   "peerDependencies": {
-    "@theforeman/vendor": "^8.10.0"
+    "@theforeman/vendor": "^8.16.0"
   }
 }

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -100,7 +100,7 @@ describe('AdvancedFields', () => {
     const textField = screen.getByLabelText('adv plain hidden', {
       selector: 'textarea',
     });
-    const selectField = screen.getByText('option 1');
+    const selectField = screen.getByLabelText('adv plain select toggle');
     const resourceSelectField = screen.getByLabelText(
       'adv resource select toggle'
     );

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -91,7 +91,6 @@ export const formatter = (input, values, setValue) => {
     const options = input.options.split(/\r?\n/).map(option => option.trim());
     return (
       <SelectField
-        aria-label={name}
         key={id}
         isRequired={required}
         label={name}

--- a/webpack/JobWizard/steps/form/SelectField.js
+++ b/webpack/JobWizard/steps/form/SelectField.js
@@ -32,6 +32,9 @@ export const SelectField = ({
         className="without_select2"
         maxHeight="45vh"
         menuAppendTo={() => document.body}
+        placeholderText=" " // To prevent showing first option as selected
+        aria-labelledby={fieldId}
+        toggleAriaLabel={`${label} toggle`}
         {...props}
       >
         {options.map((option, index) => (


### PR DESCRIPTION
When there is a select template input the ui is showing the first result as selected but it's value is not selected in the templateValues state