### PR TITLE
Fixes #33662 - Job wizard allow unselecting template inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^8.10.0",
-    "@theforeman/eslint-plugin-foreman": "^8.10.0",
-    "@theforeman/stories": "^8.10.0",
-    "@theforeman/test": "^8.10.0",
-    "@theforeman/vendor-dev": "^8.10.0",
+    "@theforeman/builder": "^8.16.0",
+    "@theforeman/eslint-plugin-foreman": "^8.16.0",
+    "@theforeman/stories": "^8.16.0",
+    "@theforeman/test": "^8.16.0",
+    "@theforeman/vendor-dev": "^8.16.0",
     "babel-eslint": "^10.0.0",
     "eslint": "^6.8.0",
     "prettier": "^1.19.1",
@@ -33,6 +33,6 @@
     "redux-mock-store": "^1.2.2"
   },
   "peerDependencies": {
-    "@theforeman/vendor": "^8.10.0"
+    "@theforeman/vendor": "^8.16.0"
   }
 }

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -100,7 +100,7 @@ describe('AdvancedFields', () => {
     const textField = screen.getByLabelText('adv plain hidden', {
       selector: 'textarea',
     });
-    const selectField = screen.getByText('option 1');
+    const selectField = screen.getByLabelText('adv plain select toggle');
     const resourceSelectField = screen.getByLabelText(
       'adv resource select toggle'
     );

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
@@ -53,6 +53,7 @@ export const CategoryAndTemplate = ({
           value={selectedCategory}
           placeholderText={categoryError ? __('Error') : ''}
           isDisabled={!!categoryError}
+          isRequired
         />
         <GroupedSelectField
           label={__('Job template')}

--- a/webpack/JobWizard/steps/HostsAndInputs/index.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/index.js
@@ -135,6 +135,7 @@ const HostsAndInputs = ({
         <FormGroup fieldId="host_selection" id="host-selection">
           <InputGroup>
             <SelectField
+              isRequired
               className="target-method-select"
               toggleIcon={<FilterIcon />}
               fieldId="host_methods"

--- a/webpack/JobWizard/steps/Schedule/RepeatOn.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatOn.js
@@ -56,6 +56,7 @@ export const RepeatOn = ({
       <Grid>
         <GridItem span={6}>
           <SelectField
+            isRequired
             fieldId="repeat-select"
             options={Object.values(repeatTypes)}
             setValue={newValue => {

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -91,7 +91,6 @@ export const formatter = (input, values, setValue) => {
     const options = input.options.split(/\r?\n/).map(option => option.trim());
     return (
       <SelectField
-        aria-label={name}
         key={id}
         isRequired={required}
         label={name}

--- a/webpack/JobWizard/steps/form/SelectField.js
+++ b/webpack/JobWizard/steps/form/SelectField.js
@@ -32,6 +32,9 @@ export const SelectField = ({
         className="without_select2"
         maxHeight="45vh"
         menuAppendTo={() => document.body}
+        placeholderText=" " // To prevent showing first option as selected
+        aria-labelledby={fieldId}
+        toggleAriaLabel={`${label} toggle`}
         {...props}
       >
         {options.map((option, index) => (

--- a/webpack/JobWizard/steps/form/SelectField.js
+++ b/webpack/JobWizard/steps/form/SelectField.js
@@ -17,6 +17,16 @@ export const SelectField = ({
     setIsOpen(false);
   };
   const [isOpen, setIsOpen] = useState(false);
+  const selectOptions = [
+    !isRequired && (
+      <SelectOption key={0} value="">
+        <p> </p>
+      </SelectOption>
+    ),
+    ...options.map((option, index) => (
+      <SelectOption key={index + 1} value={option} />
+    )),
+  ];
   return (
     <FormGroup
       label={label}
@@ -37,9 +47,7 @@ export const SelectField = ({
         toggleAriaLabel={`${label} toggle`}
         {...props}
       >
-        {options.map((option, index) => (
-          <SelectOption key={index} value={option} />
-        ))}
+        {selectOptions.filter(option => option)}
       </Select>
     </FormGroup>
   );


### PR DESCRIPTION
if the template input is not required there should be an empty option
depends on https://github.com/theforeman/foreman_remote_execution/pull/663