### PR TITLE
Fixes #33822 - job wizard add validation for repeat types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^8.10.0",
-    "@theforeman/eslint-plugin-foreman": "^8.10.0",
-    "@theforeman/stories": "^8.10.0",
-    "@theforeman/test": "^8.10.0",
-    "@theforeman/vendor-dev": "^8.10.0",
+    "@theforeman/builder": "^8.16.0",
+    "@theforeman/eslint-plugin-foreman": "^8.16.0",
+    "@theforeman/stories": "^8.16.0",
+    "@theforeman/test": "^8.16.0",
+    "@theforeman/vendor-dev": "^8.16.0",
     "babel-eslint": "^10.0.0",
     "eslint": "^6.8.0",
     "prettier": "^1.19.1",
@@ -33,6 +33,6 @@
     "redux-mock-store": "^1.2.2"
   },
   "peerDependencies": {
-    "@theforeman/vendor": "^8.10.0"
+    "@theforeman/vendor": "^8.16.0"
   }
 }

--- a/webpack/JobWizard/steps/Schedule/RepeatCron.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatCron.js
@@ -1,38 +1,53 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { TextInput, FormGroup } from '@patternfly/react-core';
+import { TextInput, FormGroup, ValidatedOptions } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { helpLabel } from '../form/FormHelpers';
 
-export const RepeatCron = ({ repeatData, setRepeatData }) => (
-  <FormGroup
-    label={__('Cron line')}
-    labelIcon={helpLabel(
-      <div>
-        {__("Cron line format 'a b c d e', where:")}
-        <br />
-        <ol>
-          <li>{__('is minute (range: 0-59)')}</li>
-          <li>{__('is hour (range: 0-23)')}</li>
-          <li>{__('is day of month (range: 1-31)')}</li>
-          <li>{__('is month (range: 1-12)')}</li>
-          <li>{__('is day of week (range: 0-6)')}</li>
-        </ol>
-      </div>
-    )}
-  >
-    <TextInput
-      aria-label="cronline"
-      placeholder="* * * * *"
-      type="text"
-      value={repeatData.cronline || ''}
-      onChange={newTime => {
-        setRepeatData({ cronline: newTime });
-      }}
-    />
-  </FormGroup>
-);
+export const RepeatCron = ({ repeatData, setRepeatData, setValid }) => {
+  const { cronline } = repeatData;
+  useEffect(() => {
+    if (cronline) {
+      setValid(true);
+    } else {
+      setValid(false);
+    }
+    return () => setValid(true);
+  }, [setValid, cronline]);
+  return (
+    <FormGroup
+      label={__('Cron line')}
+      labelIcon={helpLabel(
+        <div>
+          {__("Cron line format 'a b c d e', where:")}
+          <br />
+          <ol>
+            <li>{__('is minute (range: 0-59)')}</li>
+            <li>{__('is hour (range: 0-23)')}</li>
+            <li>{__('is day of month (range: 1-31)')}</li>
+            <li>{__('is month (range: 1-12)')}</li>
+            <li>{__('is day of week (range: 0-6)')}</li>
+          </ol>
+        </div>
+      )}
+      isRequired
+    >
+      <TextInput
+        isRequired
+        validated={cronline ? ValidatedOptions.noval : ValidatedOptions.error}
+        aria-label="cronline"
+        placeholder="* * * * *"
+        type="text"
+        value={cronline || ''}
+        onChange={newTime => {
+          setRepeatData({ cronline: newTime });
+        }}
+      />
+    </FormGroup>
+  );
+};
 RepeatCron.propTypes = {
   repeatData: PropTypes.object.isRequired,
   setRepeatData: PropTypes.func.isRequired,
+  setValid: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/RepeatDaily.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatDaily.js
@@ -1,25 +1,37 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, TimePicker } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-export const RepeatDaily = ({ repeatData, setRepeatData }) => (
-  <FormGroup label={__('At')}>
-    <TimePicker
-      aria-label="repeat-at"
-      className="time-picker"
-      time={repeatData.at}
-      placeholder="hh:mm"
-      onChange={newTime => {
-        setRepeatData({ ...repeatData, at: newTime });
-      }}
-      is24Hour
-      invalidFormatErrorMessage={__('Invalid time format')}
-    />
-  </FormGroup>
-);
+export const RepeatDaily = ({ repeatData, setRepeatData, setValid }) => {
+  const { at } = repeatData;
+  useEffect(() => {
+    if (at) {
+      setValid(true);
+    } else {
+      setValid(false);
+    }
+    return () => setValid(true);
+  }, [setValid, at]);
+  return (
+    <FormGroup label={__('At')} isRequired>
+      <TimePicker
+        aria-label="repeat-at"
+        className="time-picker"
+        time={repeatData.at}
+        placeholder="hh:mm"
+        onChange={newTime => {
+          setRepeatData({ ...repeatData, at: newTime });
+        }}
+        is24Hour
+        invalidFormatErrorMessage={__('Invalid time format')}
+      />
+    </FormGroup>
+  );
+};
 
 RepeatDaily.propTypes = {
   repeatData: PropTypes.object.isRequired,
   setRepeatData: PropTypes.func.isRequired,
+  setValid: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/RepeatHour.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatHour.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   FormGroup,
@@ -9,10 +9,19 @@ import {
 import { range } from 'lodash';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-export const RepeatHour = ({ repeatData, setRepeatData }) => {
+export const RepeatHour = ({ repeatData, setRepeatData, setValid }) => {
+  const { minute } = repeatData;
+  useEffect(() => {
+    if (minute) {
+      setValid(true);
+    } else {
+      setValid(false);
+    }
+    return () => setValid(true);
+  }, [setValid, minute]);
   const [minuteOpen, setMinuteOpen] = useState(false);
   return (
-    <FormGroup label={__('At minute')}>
+    <FormGroup label={__('At minute')} isRequired>
       <Select
         id="repeat-on-hourly"
         variant={SelectVariant.typeahead}
@@ -21,16 +30,18 @@ export const RepeatHour = ({ repeatData, setRepeatData }) => {
           setRepeatData({ minute: selection });
           setMinuteOpen(false);
         }}
-        selections={repeatData.minute || ''}
+        selections={minute || ''}
         onToggle={toggle => {
           setMinuteOpen(toggle);
         }}
         isOpen={minuteOpen}
         width={85}
         menuAppendTo={() => document.querySelector('.pf-c-form.schedule-tab')}
+        toggleAriaLabel="select minute toggle"
+        validated={minute ? 'success' : 'error'}
       >
-        {range(60).map(minute => (
-          <SelectOption key={minute} value={`${minute}`} />
+        {range(60).map(minuteNumber => (
+          <SelectOption key={minuteNumber} value={`${minuteNumber}`} />
         ))}
       </Select>
     </FormGroup>
@@ -39,4 +50,5 @@ export const RepeatHour = ({ repeatData, setRepeatData }) => {
 RepeatHour.propTypes = {
   repeatData: PropTypes.object.isRequired,
   setRepeatData: PropTypes.func.isRequired,
+  setValid: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/RepeatMonth.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatMonth.js
@@ -1,27 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { TextInput, FormGroup } from '@patternfly/react-core';
+import { TextInput, FormGroup, ValidatedOptions } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { RepeatDaily } from './RepeatDaily';
+import { noop } from '../../../helpers';
 
-export const RepeatMonth = ({ repeatData, setRepeatData }) => (
-  <>
-    <FormGroup label={__('Days')}>
-      <TextInput
-        aria-label="days"
-        placeholder="1,2..."
-        type="text"
-        value={repeatData.days || ''}
-        onChange={newTime => {
-          setRepeatData({ ...repeatData, days: newTime });
-        }}
+export const RepeatMonth = ({ repeatData, setRepeatData, setValid }) => {
+  const { days, at } = repeatData;
+  useEffect(() => {
+    if (days && at) {
+      setValid(true);
+    } else {
+      setValid(false);
+    }
+    return () => setValid(true);
+  }, [setValid, days, at]);
+  return (
+    <>
+      <FormGroup label={__('Days')} isRequired>
+        <TextInput
+          isRequired
+          validated={days ? ValidatedOptions.noval : ValidatedOptions.error}
+          aria-label="days"
+          placeholder="1,2..."
+          type="text"
+          value={repeatData.days || ''}
+          onChange={newTime => {
+            setRepeatData({ ...repeatData, days: newTime });
+          }}
+        />
+      </FormGroup>
+      <RepeatDaily
+        repeatData={repeatData}
+        setRepeatData={setRepeatData}
+        setValid={noop}
       />
-    </FormGroup>
-    <RepeatDaily repeatData={repeatData} setRepeatData={setRepeatData} />
-  </>
-);
+    </>
+  );
+};
 
 RepeatMonth.propTypes = {
   repeatData: PropTypes.object.isRequired,
   setRepeatData: PropTypes.func.isRequired,
+  setValid: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/RepeatOn.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatOn.js
@@ -17,6 +17,7 @@ export const RepeatOn = ({
   setRepeatAmount,
   repeatData,
   setRepeatData,
+  setValid,
 }) => {
   const [repeatValidated, setRepeatValidated] = useState('default');
   const handleRepeatInputChange = newValue => {
@@ -28,23 +29,43 @@ export const RepeatOn = ({
     switch (repeatType) {
       case repeatTypes.cronline:
         return (
-          <RepeatCron repeatData={repeatData} setRepeatData={setRepeatData} />
+          <RepeatCron
+            repeatData={repeatData}
+            setRepeatData={setRepeatData}
+            setValid={setValid}
+          />
         );
       case repeatTypes.monthly:
         return (
-          <RepeatMonth repeatData={repeatData} setRepeatData={setRepeatData} />
+          <RepeatMonth
+            repeatData={repeatData}
+            setRepeatData={setRepeatData}
+            setValid={setValid}
+          />
         );
       case repeatTypes.weekly:
         return (
-          <RepeatWeek repeatData={repeatData} setRepeatData={setRepeatData} />
+          <RepeatWeek
+            repeatData={repeatData}
+            setRepeatData={setRepeatData}
+            setValid={setValid}
+          />
         );
       case repeatTypes.daily:
         return (
-          <RepeatDaily repeatData={repeatData} setRepeatData={setRepeatData} />
+          <RepeatDaily
+            repeatData={repeatData}
+            setRepeatData={setRepeatData}
+            setValid={setValid}
+          />
         );
       case repeatTypes.hourly:
         return (
-          <RepeatHour repeatData={repeatData} setRepeatData={setRepeatData} />
+          <RepeatHour
+            repeatData={repeatData}
+            setRepeatData={setRepeatData}
+            setValid={setValid}
+          />
         );
       case repeatTypes.noRepeat:
       default:
@@ -99,4 +120,5 @@ RepeatOn.propTypes = {
   setRepeatAmount: PropTypes.func.isRequired,
   repeatData: PropTypes.object.isRequired,
   setRepeatData: PropTypes.func.isRequired,
+  setValid: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/RepeatWeek.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatWeek.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, Checkbox } from '@patternfly/react-core';
 import { translate as __, documentLocale } from 'foremanReact/common/I18n';
 import { RepeatDaily } from './RepeatDaily';
+import { noop } from '../../../helpers';
 
 const getWeekDays = () => {
   const locale = documentLocale().replace(/-/g, '_');
@@ -19,7 +20,16 @@ const getWeekDays = () => {
   return weekDays;
 };
 
-export const RepeatWeek = ({ repeatData, setRepeatData }) => {
+export const RepeatWeek = ({ repeatData, setRepeatData, setValid }) => {
+  const { daysOfWeek, at } = repeatData;
+  useEffect(() => {
+    if (daysOfWeek && Object.values(daysOfWeek).includes(true) && at) {
+      setValid(true);
+    } else {
+      setValid(false);
+    }
+    return () => setValid(true);
+  }, [setValid, daysOfWeek, at]);
   const days = getWeekDays();
   const handleChangeDays = (checked, { target: { name } }) => {
     setRepeatData({
@@ -29,12 +39,13 @@ export const RepeatWeek = ({ repeatData, setRepeatData }) => {
   };
   return (
     <>
-      <FormGroup label={__('Days of week')}>
+      <FormGroup label={__('Days of week')} isRequired>
         <div id="repeat-on-weekly">
           {days.map((day, index) => (
             <Checkbox
+              aria-label={`${day} checkbox`}
               key={index}
-              isChecked={repeatData.daysOfWeek?.[index]}
+              isChecked={daysOfWeek?.[index]}
               name={index}
               id={`repeat-on-day-${index}`}
               onChange={handleChangeDays}
@@ -43,11 +54,17 @@ export const RepeatWeek = ({ repeatData, setRepeatData }) => {
           ))}
         </div>
       </FormGroup>
-      <RepeatDaily repeatData={repeatData} setRepeatData={setRepeatData} />
+
+      <RepeatDaily
+        repeatData={repeatData}
+        setRepeatData={setRepeatData}
+        setValid={noop}
+      />
     </>
   );
 };
 RepeatWeek.propTypes = {
   repeatData: PropTypes.object.isRequired,
   setRepeatData: PropTypes.func.isRequired,
+  setValid: PropTypes.func.isRequired,
 };

--- a/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
+++ b/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
@@ -180,6 +180,7 @@ describe('Schedule', () => {
     expect(
       screen.getByPlaceholderText('Repeat N times').hasAttribute('disabled')
     ).toBeTruthy();
+    expect(screen.getByText('Review Details').disabled).toBeFalsy();
     await act(async () => {
       fireEvent.click(
         screen.getByLabelText('Does not repeat', { selector: 'button' })
@@ -189,8 +190,7 @@ describe('Schedule', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Cronline'));
     });
-    fireEvent.click(screen.getAllByText('Schedule')[0]); // to remove focus
-
+    expect(screen.getByText('Review Details').disabled).toBeTruthy();
     const newRepeatTimes = '3';
     const repeatNTimes = screen.getByPlaceholderText('Repeat N times');
     expect(repeatNTimes.value).toBe('');
@@ -210,6 +210,7 @@ describe('Schedule', () => {
       });
     });
     expect(cronline.value).toBe(newCronline);
+    expect(screen.getByText('Review Details').disabled).toBeFalsy();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Category and Template'));
@@ -220,7 +221,6 @@ describe('Schedule', () => {
       fireEvent.click(screen.getByText('Schedule'));
       jest.runAllTimers();
     });
-    fireEvent.click(screen.getAllByText('Schedule')[0]); // to remove focus
     expect(screen.queryAllByText('Schedule')).toHaveLength(3);
     expect(repeatNTimes.value).toBe(newRepeatTimes);
     expect(cronline.value).toBe(newCronline);
@@ -230,6 +230,7 @@ describe('Schedule', () => {
       fireEvent.click(screen.getByText('Monthly'));
     });
 
+    expect(screen.getByText('Review Details').disabled).toBeTruthy();
     const newDays = '1,2,3';
     const days = screen.getByLabelText('days');
     expect(days.value).toBe('');
@@ -237,9 +238,11 @@ describe('Schedule', () => {
       fireEvent.change(days, {
         target: { value: newDays },
       });
+      fireEvent.click(repeatNTimes);
     });
     expect(days.value).toBe(newDays);
 
+    expect(screen.getByText('Review Details').disabled).toBeTruthy();
     const newAtMonthly = '13:07';
     const at = () => screen.getByLabelText('repeat-at');
     expect(at().value).toBe('');
@@ -250,19 +253,25 @@ describe('Schedule', () => {
     });
     expect(at().value).toBe(newAtMonthly);
 
+    expect(screen.getByText('Review Details').disabled).toBeFalsy();
     fireEvent.click(screen.getByText('Monthly'));
     await act(async () => {
       fireEvent.click(screen.getByText('Weekly'));
     });
-    const dayTue = screen.getByLabelText('Tue');
-    const daySat = screen.getByLabelText('Sat');
+
+    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    const dayTue = screen.getByLabelText('Tue checkbox');
+    const daySat = screen.getByLabelText('Sat checkbox');
     expect(dayTue.checked).toBe(false);
     expect(daySat.checked).toBe(false);
     await act(async () => {
+      fireEvent.click(dayTue);
       fireEvent.change(dayTue, {
         target: { checked: true },
       });
-
+    });
+    await act(async () => {
+      fireEvent.click(daySat);
       fireEvent.change(daySat, {
         target: { checked: true },
       });
@@ -277,33 +286,46 @@ describe('Schedule', () => {
       });
     });
     expect(at().value).toBe(newAtWeekly);
+
+    expect(screen.getByText('Review Details').disabled).toBeFalsy();
     fireEvent.click(screen.getByText('Weekly'));
     await act(async () => {
       fireEvent.click(screen.getByText('Daily'));
     });
 
+    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    await act(async () => {
+      fireEvent.change(at(), {
+        target: { value: '' },
+      });
+    });
+    expect(screen.getByText('Review Details').disabled).toBeTruthy();
     const newAtDaily = '17:07';
-    expect(at().value).toBe(newAtWeekly);
+    expect(at().value).toBe('');
     await act(async () => {
       fireEvent.change(at(), {
         target: { value: newAtDaily },
       });
     });
     expect(at().value).toBe(newAtDaily);
+    expect(screen.getByText('Review Details').disabled).toBeFalsy();
 
     fireEvent.click(screen.getByText('Daily'));
     await act(async () => {
       fireEvent.click(screen.getByText('Hourly'));
     });
 
-    const newMinutes = '15';
+    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    const newMinutes = '6';
     const atHourly = screen.getByLabelText('repeat-at-minute-typeahead');
     expect(atHourly.value).toBe('');
     await act(async () => {
-      fireEvent.change(atHourly, {
-        target: { value: newMinutes },
-      });
+      fireEvent.click(screen.getByLabelText('select minute toggle'));
     });
+    await act(async () => {
+      fireEvent.click(screen.getByText(newMinutes));
+    });
+    expect(screen.getByText('Review Details').disabled).toBeFalsy();
     expect(atHourly.value).toBe(newMinutes);
   });
   it('should show invalid error on start date after end', async () => {

--- a/webpack/JobWizard/steps/Schedule/index.js
+++ b/webpack/JobWizard/steps/Schedule/index.js
@@ -22,10 +22,11 @@ const Schedule = ({ scheduleValue, setScheduleValue, setValid }) => {
     isTypeStatic,
     purpose,
   } = scheduleValue;
-
   const [validEnd, setValidEnd] = useState(true);
+  const [repeatValid, setRepeatValid] = useState(true);
+
   useEffect(() => {
-    if (!validEnd) {
+    if (!validEnd || !repeatValid) {
       setValid(false);
     } else if (isFuture && (startsAt.length || startsBefore.length)) {
       setValid(true);
@@ -35,7 +36,7 @@ const Schedule = ({ scheduleValue, setScheduleValue, setValid }) => {
       setValid(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [startsAt, startsBefore, isFuture, validEnd]);
+  }, [startsAt, startsBefore, isFuture, validEnd, repeatValid]);
   return (
     <>
       <WizardTitle title={WIZARD_TITLES.schedule} />
@@ -84,6 +85,7 @@ const Schedule = ({ scheduleValue, setScheduleValue, setValid }) => {
               repeatAmount: newValue,
             }));
           }}
+          setValid={setRepeatValid}
         />
         <StartEndDates
           startsAt={startsAt}


### PR DESCRIPTION
Updates foreman-js to use `toggleAriaLabel`. another pr that updates it to the same version is https://github.com/theforeman/foreman_remote_execution/pull/663