### PR TITLE
Fixes #33844 - wizard multiple select closes after select

### DIFF
--- a/webpack/JobWizard/steps/form/SearchSelect.js
+++ b/webpack/JobWizard/steps/form/SearchSelect.js
@@ -93,7 +93,6 @@ export const SearchSelect = ({
         autoSearch(value || '');
       }}
       placeholderText={placeholderText}
-      onFilter={() => null} // https://github.com/patternfly/patternfly-react/issues/6321
       typeAheadAriaLabel={`${name} typeahead input`}
     >
       {selectOptions}


### PR DESCRIPTION
It shouldn't, so a user can select many items