### PR TITLE
Fixes #34001 - remove usage of deprecated auto_complete_search

### DIFF
--- a/app/views/job_templates/_custom_tabs.html.erb
+++ b/app/views/job_templates/_custom_tabs.html.erb
@@ -1,14 +1,9 @@
 <div class="tab-pane" id="template_job">
 
-  <%= field(f, :job_category, :label => _('Job category')) do %>
-    <%= auto_complete_search(:job_category,
-                             f.object.job_category,
-                             :placeholder => _("Job category") + ' ...',
-                             :name => 'job_template[job_category]',
-                             :id => 'search',
-                             :disabled => @template.locked?) %>
-  <% end %>
-
+  <%= autocomplete_f(f, :job_category,
+        :search_query => '',
+        :placeholder => _("Job category") + ' ...',
+        :disabled => @template.locked?) %>
   <%= text_f f, :description_format,
              :disabled => @template.locked?,
              :label_help => description_format_help %>


### PR DESCRIPTION
This method will go away from foreman core, we need to replace it.

The https://github.com/theforeman/foreman/pull/8951 removes this deprecated method.