### PR TITLE
Fixes #34032 - Make proxy used for REX more easily discoverable

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -42,6 +42,8 @@ module Actions
 
         provider_type = template_invocation.template.provider_type.to_s
         proxy = determine_proxy!(proxy_selector, provider_type, host)
+        link!(proxy)
+        input[:proxy_id] = proxy.id
 
         renderer = InputTemplateRenderer.new(template_invocation.template, host, template_invocation)
         script = renderer.render

--- a/app/views/template_invocations/show.html.erb
+++ b/app/views/template_invocations/show.html.erb
@@ -28,7 +28,13 @@ end
   </div>
 </div>
 <% if @host %>
-  <h3><%= _('Target: ') %><%= link_to(@host.name, host_path(@host)) %></h3>
+  <% proxy_id = @template_invocation_task.input[:proxy_id] %>
+  <h3>
+    <%= _('Target: ') %><%= link_to(@host.name, host_path(@host)) %>
+    <% if proxy_id && proxy = SmartProxy.find_by(id: proxy_id) %>
+      <%= _('using Smart Proxy') %> <%= link_to(proxy.name, smart_proxy_path(proxy)) %>
+    <% end %>
+  </h3>
 
   <div class="preview hidden">
     <%= preview_box(@template_invocation, @host) %>


### PR DESCRIPTION
Adds a link to used foreman proxy to template invocation detail page
![image](https://user-images.githubusercontent.com/7326770/143902779-f9bd2503-b22e-4483-9b5a-ac8974c25871.png)

Also links the per-host task against the proxy, making the proxy appear in Locks tab in task's details
![image](https://user-images.githubusercontent.com/7326770/143903006-74df3332-30e4-4625-adf8-7465f80cb5b6.png)
