### PR TITLE
Fixes #34132 - change default template to the new template name

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -152,7 +152,7 @@ module ForemanRemoteExecution
             setting 'remote_execution_job_invocation_report_template',
               type: :string,
               description: N_('Select a report template used for generating a report for a particular remote execution job'),
-              default: 'Jobs - Invocation report template',
+              default: 'Job invocation - report template',
               full_name: N_('Job Invocation Report Template'),
               collection: proc { ForemanRemoteExecution.job_invocation_report_templates_select }
           end

--- a/test/unit/job_invocation_report_template_test.rb
+++ b/test/unit/job_invocation_report_template_test.rb
@@ -9,7 +9,7 @@ class JobReportTemplateTest < ActiveSupport::TestCase
 
   context 'with valid job invocation report template' do
     let(:job_invocation_template) do
-      file_path = File.read(File.expand_path(Rails.root + "app/views/unattended/report_templates/jobs_-_invocation_report_template.erb"))
+      file_path = File.read(File.expand_path(Rails.root + "app/views/unattended/report_templates/job_invocation_-_report_template.erb"))
       template = ReportTemplate.import_without_save("Job Invocation Report Template", file_path)
       template.save!
       template


### PR DESCRIPTION
We've changed the name of the default template in core, so we also need to change the default.