### PR TITLE
Fixes #33737 - Add bookmarks to templates in job wizard

### DIFF
--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -103,4 +103,9 @@
       margin-left: 10px;
     }
   }
+  .foreman-search-field {
+    .autocomplete-search-btn {
+      display: none;
+    }
+  }
 }

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -47,7 +47,7 @@ export const hostMethods = {
   searchQuery: __('Search query'),
 };
 
-export const hostQuerySearchID = 'searchBar'; // until https://projects.theforeman.org/issues/33737 is used
+export const hostQuerySearchID = 'mainHostQuery';
 export const hostsController = 'hosts';
 
 export const dataName = {

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -69,6 +69,7 @@ export const jobTemplateResponse = {
       default: '',
       hidden_value: false,
       url: 'foreman_tasks/tasks',
+      resource_type_tableize: 'hosts',
     },
     {
       name: 'adv date',

--- a/webpack/JobWizard/steps/HostsAndInputs/HostSearch.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/HostSearch.js
@@ -10,7 +10,7 @@ import { noop } from '../../../helpers';
 
 export const HostSearch = ({ value, setValue }) => {
   const searchQuery = useSelector(
-    state => state.autocomplete?.hostsSearch?.searchQuery
+    state => state.autocomplete?.[hostQuerySearchID]?.searchQuery
   );
   useEffect(() => {
     setValue(searchQuery || '');

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -1,9 +1,11 @@
 import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { FormGroup, TextInput, TextArea } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import SearchBar from 'foremanReact/components/SearchBar';
 import { getControllerSearchProps } from 'foremanReact/constants';
+import { TRIGGERS } from 'foremanReact/components/AutoComplete/AutoCompleteConstants';
+import { getResults } from 'foremanReact/components/AutoComplete/AutoCompleteActions';
 import { helpLabel } from './FormHelpers';
 import { SelectField } from './SelectField';
 import { ResourceSelectAPI } from './ResourceSelect';
@@ -22,12 +24,25 @@ const TemplateSearchField = ({
   const searchQuery = useSelector(
     state => state.autocomplete?.[name]?.searchQuery
   );
+  const dispatch = useDispatch();
   useEffect(() => {
     setValue({ ...values, [name]: searchQuery });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery]);
   const id = name.replace(/ /g, '-');
   const props = getControllerSearchProps(controller.replace('/', '_'), name);
+
+  const setSearch = newSearchQuery => {
+    dispatch(
+      getResults({
+        url,
+        searchQuery: newSearchQuery,
+        controller,
+        trigger: TRIGGERS.INPUT_CHANGE,
+        id: name,
+      })
+    );
+  };
   return (
     <FormGroup
       label={name}
@@ -45,9 +60,9 @@ const TemplateSearchField = ({
             url,
             useKeyShortcuts: true,
           },
-          bookmarks: null,
         }}
         onSearch={noop}
+        onBookmarkClick={search => setSearch(search)}
       />
     </FormGroup>
   );
@@ -152,7 +167,7 @@ export const formatter = (input, values, setValue) => {
         key={id}
         name={name}
         defaultValue={value}
-        controller={resourceType}
+        controller={controller}
         url={`/${controller}/auto_complete_search`}
         labelText={labelText}
         required={required}

--- a/webpack/__mocks__/foremanReact/constants.js
+++ b/webpack/__mocks__/foremanReact/constants.js
@@ -17,6 +17,7 @@ export const getControllerSearchProps = (
     useKeyShortcuts: true,
   },
   bookmarks: {
+    id,
     url: '/api/bookmarks',
     canCreate,
     documentationUrl: `4.1.5Searching`,


### PR DESCRIPTION
Now when a user has a search input field in the template they can use it's bookmarks.
(Before the foreman fix the new bookmark modal will choose only the last text entered as the value so we can only had one bookmark button perpage)
![Screenshot from 2021-12-22 19-01-31](https://user-images.githubusercontent.com/30431079/147135811-a2bcf746-4040-4a88-849b-554ee60a47e0.png)
