### PR TITLE
Fixes #34269 - remove outdated README

### DIFF
--- a/app/views/templates/README.md
+++ b/app/views/templates/README.md
@@ -1,6 +1,0 @@
-# Job Templates
-
-**IMPORTANT** Do not submit pull requests here, these templates are only
-updated during the release process.  The
-[community-templates](https://github.com/theforeman/community-templates) repos
-is the canonical source for job templates.


### PR DESCRIPTION
This removes the outdated README.md file which was referencing the community templates repo.