### PR TITLE
Fixes #34297 - replace dropped Rails method

### DIFF
--- a/app/mailers/rex_job_mailer.rb
+++ b/app/mailers/rex_job_mailer.rb
@@ -1,5 +1,5 @@
 class RexJobMailer < ApplicationMailer
-  add_template_helper(ApplicationHelper)
+  helper ApplicationHelper
 
   def job_finished(job, opts = {})
     @job = job


### PR DESCRIPTION
We were using private Rails method `ActionMailer::Base#add_template_helper` that was never ment to be used.
This method is dropped by Rails 6.1 in https://github.com/rails/rails/commit/cb3b37b37975ceb1d38bec9f02305ff5c14ba8e9 and we need to stop using it.
This simply replaces it by supported `helper` is enough.