### PR TITLE
Fixes #33388 - disable template related fields when loading

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -21,6 +21,7 @@ import {
   selectJobTemplate,
   selectIsSubmitting,
   selectRouterSearch,
+  selectIsLoading,
 } from './JobWizardSelectors';
 import Schedule from './steps/Schedule/';
 import HostsAndInputs from './steps/HostsAndInputs/';
@@ -130,9 +131,14 @@ export const JobWizard = () => {
   const templateError = !!useSelector(selectTemplateError);
   const templateResponse = useSelector(selectJobTemplate);
   const isSubmitting = useSelector(selectIsSubmitting);
+  const isTemplatesLoading = useSelector(state =>
+    selectIsLoading(state, JOB_TEMPLATE)
+  );
   const isTemplate =
-    !templateError && !!jobTemplateID && templateResponse.job_template;
-
+    !isTemplatesLoading &&
+    !templateError &&
+    !!jobTemplateID &&
+    templateResponse.job_template;
   const steps = [
     {
       name: WIZARD_TITLES.categoryAndTemplate,

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { Text, TextVariants, Form, Alert } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { SelectField } from '../form/SelectField';
 import { GroupedSelectField } from '../form/GroupedSelectField';
 import { WizardTitle } from '../form/WizardTitle';
-import { WIZARD_TITLES } from '../../JobWizardConstants';
+import { WIZARD_TITLES, JOB_TEMPLATES } from '../../JobWizardConstants';
+import { selectIsLoading } from '../../JobWizardSelectors';
 
 export const CategoryAndTemplate = ({
   jobCategories,
@@ -17,18 +19,23 @@ export const CategoryAndTemplate = ({
   errors,
 }) => {
   const templatesGroups = {};
-  jobTemplates.forEach(template => {
-    if (templatesGroups[template.provider_type]?.options)
-      templatesGroups[template.provider_type].options.push({
-        label: template.name,
-        value: template.id,
-      });
-    else
-      templatesGroups[template.provider_type] = {
-        options: [{ label: template.name, value: template.id }],
-        groupLabel: template.provider_type,
-      };
-  });
+  const isTemplatesLoading = useSelector(state =>
+    selectIsLoading(state, JOB_TEMPLATES)
+  );
+  if (!isTemplatesLoading) {
+    jobTemplates.forEach(template => {
+      if (templatesGroups[template.provider_type]?.options)
+        templatesGroups[template.provider_type].options.push({
+          label: template.name,
+          value: template.id,
+        });
+      else
+        templatesGroups[template.provider_type] = {
+          options: [{ label: template.name, value: template.id }],
+          groupLabel: template.provider_type,
+        };
+    });
+  }
 
   const selectedTemplate = jobTemplates.find(
     template => template.id === selectedTemplateID
@@ -60,8 +67,10 @@ export const CategoryAndTemplate = ({
           fieldId="job_template"
           groups={Object.values(templatesGroups)}
           setSelected={setJobTemplate}
-          selected={selectedTemplate}
-          isDisabled={!!(categoryError || allTemplatesError)}
+          selected={isTemplatesLoading ? [] : selectedTemplate}
+          isDisabled={
+            !!(categoryError || allTemplatesError || isTemplatesLoading)
+          }
           placeholderText={allTemplatesError ? __('Error') : ''}
         />
         {isError && (

--- a/webpack/JobWizard/steps/form/GroupedSelectField.js
+++ b/webpack/JobWizard/steps/form/GroupedSelectField.js
@@ -81,7 +81,11 @@ GroupedSelectField.propTypes = {
   label: PropTypes.string.isRequired,
   fieldId: PropTypes.string.isRequired,
   groups: PropTypes.array,
-  selected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  selected: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.array,
+  ]),
   setSelected: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
when loading template list template selection is disabled and the selected template is shown as empty.
after selecting a template, until the template is loading all the steps are disabled