### PR TITLE
Fixes #34452 - Allow hosts to have no execution interface

### DIFF
--- a/app/models/concerns/foreman_remote_execution/nic_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/nic_extensions.rb
@@ -3,17 +3,10 @@ module ForemanRemoteExecution
     extend ActiveSupport::Concern
 
     included do
-      before_validation :set_execution_flag
       validate :exclusive_execution_interface
     end
 
     private
-
-    def set_execution_flag
-      return unless primary? && host.present?
-
-      self.execution = true if host.interfaces.detect(&:execution).nil?
-    end
 
     def exclusive_execution_interface
       if host && self.execution?

--- a/app/models/concerns/foreman_remote_execution/nic_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/nic_extensions.rb
@@ -4,9 +4,18 @@ module ForemanRemoteExecution
 
     included do
       validate :exclusive_execution_interface
+      before_validation :move_execution_flag
     end
 
     private
+
+    def move_execution_flag
+      return unless host && self.execution?
+
+      host.interfaces
+          .select { |i| i.execution? && i != self }
+          .each { |i| i.execution = false }
+    end
 
     def exclusive_execution_interface
       if host && self.execution?

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -67,7 +67,8 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
     it 'should only have one execution interface' do
       host.interfaces << FactoryBot.build(:nic_managed)
       host.interfaces.each { |interface| interface.execution = true }
-      _(host).wont_be :valid?
+      _(host).must_be :valid?
+      _(host.interfaces.count(&:execution?)).must_equal 1
     end
 
     it 'returns the execution interface' do


### PR DESCRIPTION
Previously we required each host to have exactly one execution interface. There
was a mechanism in place which would ensure host had at least one execution
interface by marking the primary interface as execution if the host had none.
However this wasn't 100% reliable.

This loosens the requirement from exactly one to 0 or 1 and removes the
mechanism enforcing host has at least 1 execution interface.

This is arguably more correct alternative to https://github.com/theforeman/hammer_cli_foreman_remote_execution/pull/43