### PR TITLE
Fixes #34471 - Add bookmarks to jobs targeting host

### DIFF
--- a/webpack/react_app/components/TargetingHosts/TargetingHostsConsts.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsConsts.js
@@ -1,1 +1,2 @@
 export const TARGETING_HOSTS = 'TARGETING_HOSTS';
+export const TARGETING_HOSTS_AUTOCOMPLETE = 'targeting_hosts_search';

--- a/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
@@ -7,6 +7,7 @@ import Pagination from 'foremanReact/components/Pagination';
 import { getControllerSearchProps } from 'foremanReact/constants';
 
 import TargetingHosts from './TargetingHosts';
+import { TARGETING_HOSTS_AUTOCOMPLETE } from './TargetingHostsConsts';
 import './TargetingHostsPage.scss';
 
 const TargetingHostsPage = ({
@@ -16,6 +17,7 @@ const TargetingHostsPage = ({
   items,
   totalHosts,
   handlePagination,
+  page,
 }) => (
   <div id="targeting_hosts">
     <Grid.Row>
@@ -23,24 +25,26 @@ const TargetingHostsPage = ({
         <SearchBar
           onSearch={query => handleSearch(query)}
           data={{
-            ...getControllerSearchProps('hosts'),
+            ...getControllerSearchProps('hosts', TARGETING_HOSTS_AUTOCOMPLETE),
             autocomplete: {
-              id: 'targeting_hosts_search',
+              id: TARGETING_HOSTS_AUTOCOMPLETE,
               searchQuery,
               url: '/hosts/auto_complete_search',
               useKeyShortcuts: true,
             },
-            bookmarks: {},
           }}
+          onBookmarkClick={handleSearch}
         />
       </Grid.Col>
     </Grid.Row>
     <br />
     <TargetingHosts apiStatus={apiStatus} items={items} />
     <Pagination
+      page={page}
       itemCount={totalHosts}
       onChange={args => handlePagination(args)}
       className="targeting-hosts-pagination"
+      updateParamsByUrl={false}
     />
   </div>
 );
@@ -52,6 +56,7 @@ TargetingHostsPage.propTypes = {
   items: PropTypes.array.isRequired,
   totalHosts: PropTypes.number.isRequired,
   handlePagination: PropTypes.func.isRequired,
+  page: PropTypes.number.isRequired,
 };
 
 TargetingHostsPage.defaultProps = {

--- a/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
+++ b/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
@@ -23,10 +23,16 @@ exports[`TargetingHostsPage renders 1`] = `
               "url": "/hosts/auto_complete_search",
               "useKeyShortcuts": true,
             },
-            "bookmarks": Object {},
+            "bookmarks": Object {
+              "canCreate": true,
+              "documentationUrl": "4.1.5Searching",
+              "id": "targeting_hosts_search",
+              "url": "/api/bookmarks",
+            },
             "controller": "hosts",
           }
         }
+        onBookmarkClick={[Function]}
         onChange={[Function]}
         onSearch={[Function]}
       />
@@ -56,6 +62,8 @@ exports[`TargetingHostsPage renders 1`] = `
     className="targeting-hosts-pagination"
     itemCount={1}
     onChange={[Function]}
+    page={1}
+    updateParamsByUrl={false}
   />
 </div>
 `;

--- a/webpack/react_app/components/TargetingHosts/__tests__/fixtures.js
+++ b/webpack/react_app/components/TargetingHosts/__tests__/fixtures.js
@@ -50,10 +50,7 @@ export const TargetingHostsPageFixtures = {
     apiStatus: 'RESOLVED',
     items,
     totalHosts: 1,
-    pagination: {
-      page: 1,
-      perPage: 20,
-    },
+    page: 1,
     handlePagination: () => {},
   },
 };

--- a/webpack/react_app/components/TargetingHosts/index.js
+++ b/webpack/react_app/components/TargetingHosts/index.js
@@ -89,6 +89,7 @@ const WrappedTargetingHosts = () => {
       items={items}
       totalHosts={totalHosts}
       handlePagination={handlePagination}
+      page={pagination.page}
     />
   );
 };


### PR DESCRIPTION
Uses the same hack to fill the search input text as the job wizard using `getResults`