### PR TITLE
Prevent ssh action for zypper to return 0 on failure

### DIFF
--- a/app/views/templates/ssh/package_action.erb
+++ b/app/views/templates/ssh/package_action.erb
@@ -69,8 +69,11 @@ handle_zypp_res_codes () {
 
   if [ "${ZYPP_RES_CODES[$RETVAL]}" != "" ]; then
     echo ${ZYPP_RES_CODES[$RETVAL]}
+  fi
+  if [[ $RETVAL -ge 100 && $RETVAL -le 103 ]]; then
     RETVAL=0
   fi
+
   return $RETVAL
 }
 <% end -%>


### PR DESCRIPTION
At the moment, when you want to install a non-existing package on a client with zypper, the installation of the package fails. However, in the return code evaluation of the installation, the return code is overwritten with `0` if the installation failed. This causes the whole job to be shown as successful even if it was not.

This PR removes the line of code where the return code is set to `0`, which causes the return code to be evaluated correctly in line 115/116.