### PR TITLE
Fixes #34600 - add web/cockpit console to host's kebab

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -46,6 +46,10 @@ module ForemanRemoteExecution
       end
     end
 
+    def cockpit_url
+      SSHExecutionProvider.cockpit_url_for_host(self.name)
+    end
+
     def execution_status(options = {})
       @execution_status ||= get_status(HostStatus::ExecutionStatus).to_status(options)
     end

--- a/app/views/api/v2/host/main.rabl
+++ b/app/views/api/v2/host/main.rabl
@@ -1,0 +1,1 @@
+attributes :cockpit_url

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -265,6 +265,7 @@ module ForemanRemoteExecution
         extend_rabl_template 'api/v2/smart_proxies/main', 'api/v2/smart_proxies/pubkey'
         extend_rabl_template 'api/v2/interfaces/main', 'api/v2/interfaces/execution_flag'
         extend_rabl_template 'api/v2/subnets/show', 'api/v2/subnets/remote_execution_proxies'
+        extend_rabl_template 'api/v2/hosts/main', 'api/v2/host/main'
         parameter_filter ::Subnet, :remote_execution_proxy_ids
         describe_host { overview_buttons_provider :host_overview_buttons }
 

--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -3,6 +3,7 @@ import routes from './Routes/routes';
 import fillregistrationAdvanced from './react_app/extend/fillregistrationAdvanced';
 import fillRecentJobsCard from './react_app/extend/fillRecentJobsCard';
 import fillFeaturesDropdown from './react_app/extend/fillRexFeaturesDropdown';
+import fillKebabItems from './react_app/extend/fillKebabItems';
 import registerReducers from './react_app/extend/reducers';
 
 registerReducers();
@@ -10,3 +11,4 @@ registerRoutes('foreman_remote_execution', routes);
 fillFeaturesDropdown();
 fillRecentJobsCard();
 fillregistrationAdvanced();
+fillKebabItems();

--- a/webpack/react_app/components/HostKebab/KebabItems.js
+++ b/webpack/react_app/components/HostKebab/KebabItems.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { DropdownItem } from '@patternfly/react-core';
+import { CodeIcon } from '@patternfly/react-icons';
+import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { HOST_DETAILS_KEY } from 'foremanReact/components/HostDetails/consts';
+
+const HostKebabItems = () => {
+  const { cockpit_url: consoleUrl } = useSelector(state =>
+    selectAPIResponse(state, HOST_DETAILS_KEY)
+  );
+
+  if (!consoleUrl) return null;
+  return (
+    <DropdownItem icon={<CodeIcon />} href={consoleUrl}>
+      {__('Web Console')}
+    </DropdownItem>
+  );
+};
+
+export default HostKebabItems;

--- a/webpack/react_app/extend/fillKebabItems.js
+++ b/webpack/react_app/extend/fillKebabItems.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { addGlobalFill } from 'foremanReact/components/common/Fill/GlobalFill';
+import KebabItems from '../components/HostKebab/KebabItems';
+
+export default () =>
+  addGlobalFill(
+    'host-details-kebab',
+    'rex-host-details-kebab-job',
+    <KebabItems key="rex-host-details-kebab-job" />,
+    100
+  );


### PR DESCRIPTION
This adds the missing `web console` button from the legacy host page.