### PR TITLE
Fixes #34653 - Rename SSH provider to script

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -1,6 +1,6 @@
 module RemoteExecutionHelper
   def providers_options
-    RemoteExecutionProvider.providers.map { |key, provider| [ key, _(provider.humanized_name) ] }
+    RemoteExecutionProvider.providers.reject { |key, _provider| key == 'SSH' }.map { |key, provider| [ key, _(provider.humanized_name) ] }
   end
 
   def job_hosts_authorizer

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -40,7 +40,7 @@ module Actions
         provider = template_invocation.template.provider
         proxy_selector = provider.required_proxy_selector_for(template_invocation.template) || proxy_selector
 
-        provider_type = template_invocation.template.provider_type.to_s
+        provider_type = provider.proxy_feature
         proxy = determine_proxy!(proxy_selector, provider_type, host)
         link!(proxy)
         input[:proxy_id] = proxy.id

--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -7,6 +7,15 @@ class RemoteExecutionProvider
       providers[type.to_s] || providers[:script]
     end
 
+    def registered_name
+      klass = self
+      providers.key(klass)
+    end
+
+    def proxy_feature
+      registered_name
+    end
+
     def providers
       @providers ||= { }.with_indifferent_access
     end

--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -4,7 +4,7 @@ class RemoteExecutionProvider
 
   class << self
     def provider_for(type)
-      providers[type.to_s] || providers[:SSH]
+      providers[type.to_s] || providers[:script]
     end
 
     def providers

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -1,4 +1,4 @@
-class SSHExecutionProvider < RemoteExecutionProvider
+class ScriptExecutionProvider < RemoteExecutionProvider
   class << self
     def proxy_command_options(template_invocation, host)
       super.merge(:ssh_user => ssh_user(host),
@@ -9,7 +9,7 @@ class SSHExecutionProvider < RemoteExecutionProvider
     end
 
     def humanized_name
-      _('SSH')
+      _('Script')
     end
 
     def supports_effective_user?
@@ -64,3 +64,5 @@ class SSHExecutionProvider < RemoteExecutionProvider
     end
   end
 end
+
+SSHExecutionProvider = ScriptExecutionProvider

--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -53,6 +53,10 @@ class ScriptExecutionProvider < RemoteExecutionProvider
       Setting[:remote_execution_cockpit_url] % { :host => host } if Setting[:remote_execution_cockpit_url].present?
     end
 
+    def proxy_feature
+      'SSH'
+    end
+
     private
 
     def ssh_user(host)

--- a/app/views/templates/script/check_update.erb
+++ b/app/views/templates/script/check_update.erb
@@ -1,10 +1,10 @@
 <%#
 kind: job_template
-name: Check Update - SSH Default
+name: Check Update - Script Default
 model: JobTemplate
 job_category: Packages
 description_format: "Check for package updates"
-provider_type: SSH
+provider_type: script
 %>
 
 <%

--- a/app/views/templates/script/module_action.erb
+++ b/app/views/templates/script/module_action.erb
@@ -1,10 +1,10 @@
 <%#
 kind: job_template
-name: Module Action - SSH Default
+name: Module Action - Script Default
 model: JobTemplate
 job_category: Modules
 description_format: "Module %{action} %{module_spec}"
-provider_type: SSH
+provider_type: script
 template_inputs:
 - name: pre_script
   description: A script to run prior to the module action

--- a/app/views/templates/script/package_action.erb
+++ b/app/views/templates/script/package_action.erb
@@ -1,10 +1,10 @@
 <%#
 kind: job_template
-name: Package Action - SSH Default
+name: Package Action - Script Default
 model: JobTemplate
 job_category: Packages
 description_format: "%{action} package(s) %{package}"
-provider_type: SSH
+provider_type: script
 template_inputs:
 - name: pre_script
   description: A script to run prior to the package action

--- a/app/views/templates/script/power_action.erb
+++ b/app/views/templates/script/power_action.erb
@@ -1,10 +1,10 @@
 <%#
 kind: job_template
-name: Power Action - SSH Default
+name: Power Action - Script Default
 model: JobTemplate
 job_category: Power
 description_format: '%{action} host'
-provider_type: SSH
+provider_type: script
 template_inputs:
 - name: action
   description: Action to perform on the service

--- a/app/views/templates/script/puppet_agent_disable.erb
+++ b/app/views/templates/script/puppet_agent_disable.erb
@@ -1,5 +1,5 @@
 <%#
-name: Puppet Agent Disable - SSH Default
+name: Puppet Agent Disable - Script Default
 model: JobTemplate
 job_category: Puppet
 description_format: Disable Puppet agent
@@ -10,7 +10,7 @@ template_inputs:
   input_type: user
   description: Reason for disabling the Puppet agent
   advanced: false
-provider_type: SSH
+provider_type: script
 kind: job_template
 -%>
 <% if @host.operatingsystem.family == 'Debian' -%>

--- a/app/views/templates/script/puppet_agent_enable.erb
+++ b/app/views/templates/script/puppet_agent_enable.erb
@@ -1,10 +1,10 @@
 <%#
-name: Puppet Agent Enable - SSH Default
+name: Puppet Agent Enable - Script Default
 model: JobTemplate
 job_category: Puppet
 description_format: Enable Puppet agent
 snippet: false
-provider_type: SSH
+provider_type: script
 kind: job_template
 -%>
 <% if @host.operatingsystem.family == 'Debian' -%>

--- a/app/views/templates/script/puppet_install_modules_from_forge.erb
+++ b/app/views/templates/script/puppet_install_modules_from_forge.erb
@@ -1,5 +1,5 @@
 <%#
-name: Puppet Module - Install from forge - SSH Default
+name: Puppet Module - Install from forge - Script Default
 model: JobTemplate
 job_category: Puppet
 description_format: Install Puppet Module "%{puppet_module}" from forge
@@ -30,7 +30,7 @@ template_inputs:
   input_type: user
   description: Do not attempt to install dependencies. Type "true" to ignore dependencies.
   advanced: true
-provider_type: SSH
+provider_type: script
 kind: job_template
 -%>
 <% if @host.operatingsystem.family == 'Debian' -%>

--- a/app/views/templates/script/puppet_install_modules_from_git.erb
+++ b/app/views/templates/script/puppet_install_modules_from_git.erb
@@ -1,5 +1,5 @@
 <%#
-name: Puppet Module - Install from git - SSH Default
+name: Puppet Module - Install from git - Script Default
 model: JobTemplate
 job_category: Puppet
 description_format: Install Puppet Module "%{puppet_module}" from git
@@ -15,7 +15,7 @@ template_inputs:
   input_type: user
   description: For example, '/etc/puppetlabs/code/environments/production/modules/puppet'.
   advanced: false
-provider_type: SSH
+provider_type: script
 kind: job_template
 -%>
 git clone <%= input('git_repository') %> <%= input('target_dir') %>

--- a/app/views/templates/script/puppet_run_once.erb
+++ b/app/views/templates/script/puppet_run_once.erb
@@ -1,10 +1,10 @@
 <%#
 kind: job_template
-name: Puppet Run Once - SSH Default
+name: Puppet Run Once - Script Default
 model: JobTemplate
 job_category: Puppet
 description_format: 'Run Puppet once with "%{puppet_options}"'
-provider_type: SSH
+provider_type: script
 template_inputs:
 - name: puppet_options
   description: Additional options to pass to puppet

--- a/app/views/templates/script/run_command.erb
+++ b/app/views/templates/script/run_command.erb
@@ -1,10 +1,10 @@
 <%#
 kind: job_template
-name: Run Command - SSH Default
+name: Run Command - Script Default
 model: JobTemplate
 job_category: Commands
 description_format: "Run %{command}"
-provider_type: SSH
+provider_type: script
 template_inputs:
 - name: command
   description: Command to run on the host

--- a/app/views/templates/script/service_action.erb
+++ b/app/views/templates/script/service_action.erb
@@ -1,10 +1,10 @@
 <%#
 kind: job_template
-name: Service Action - SSH Default
+name: Service Action - Script Default
 model: JobTemplate
 job_category: Services
 description_format: '%{action} service %{service}'
-provider_type: SSH
+provider_type: script
 template_inputs:
 - name: action
   description: Action to perform on the service

--- a/db/migrate/20220321101835_rename_ssh_provider_to_script.rb
+++ b/db/migrate/20220321101835_rename_ssh_provider_to_script.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class RenameSshProviderToScript < ActiveRecord::Migration[6.0]
+
+  def do_change(from, to, from_re, new_label)
+    setting = Setting.find_by(:name => 'remote_execution_form_job_template')
+    default_template = nil
+
+    Template.where(:provider_type => from).each do |t|
+      default_template = t if t.name == setting&.value
+      t.provider_type = to
+      t.name = t.name.gsub(from_re, new_label)
+      t.save!
+    end
+
+    if default_template
+      setting.value = default_template.name
+      setting.save!
+    end
+  end
+
+  def up
+    do_change 'SSH', 'script', /SSH Default$/, 'Script Default'
+  end
+
+  def down
+    do_change 'script', 'SSH', /Script Default$/, 'SSH Default'
+  end
+end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -146,7 +146,7 @@ module ForemanRemoteExecution
             setting 'remote_execution_form_job_template',
               type: :string,
               description: N_('Choose a job template that is pre-selected in job invocation form'),
-              default: 'Run Command - SSH Default',
+              default: 'Run Command - Script Default',
               full_name: N_('Form Job Template'),
               collection: proc { Hash[JobTemplate.unscoped.map { |template| [template.name, template.name] }] }
             setting 'remote_execution_job_invocation_report_template',
@@ -328,6 +328,7 @@ module ForemanRemoteExecution
       require_dependency 'foreman_tasks/task'
       ForemanTasks::Task.include ForemanRemoteExecution::ForemanTasksTaskExtensions
       ForemanTasks::Cleaner.include ForemanRemoteExecution::ForemanTasksCleanerExtensions
+      RemoteExecutionProvider.register(:script, ::ScriptExecutionProvider)
       RemoteExecutionProvider.register(:SSH, SSHExecutionProvider)
 
       ForemanRemoteExecution.register_rex_feature

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -6,9 +6,11 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
     it { _(providers).must_be_kind_of HashWithIndifferentAccess }
     it 'makes providers accessible using symbol' do
       _(providers[:SSH]).must_equal SSHExecutionProvider
+      _(providers[:script]).must_equal ScriptExecutionProvider
     end
     it 'makes providers accessible using string' do
       _(providers['SSH']).must_equal SSHExecutionProvider
+      _(providers['script']).must_equal ScriptExecutionProvider
     end
   end
 


### PR DESCRIPTION
Currently the new provider is just an alias to the SSH provider to make
the transition easier and not require making this change across all
dependenat plugins at once.