### PR TITLE
Fixes #34657 - Add aria label to job wizard template select

### DIFF
--- a/webpack/JobWizard/steps/form/GroupedSelectField.js
+++ b/webpack/JobWizard/steps/form/GroupedSelectField.js
@@ -69,6 +69,8 @@ export const GroupedSelectField = ({
         className="without_select2"
         onClear={onClear}
         menuAppendTo={() => document.body}
+        aria-labelledby={fieldId}
+        toggleAriaLabel={`${label} toggle`}
         {...props}
       >
         {options}


### PR DESCRIPTION
Adding the same fields as in `SelectField`
https://github.com/theforeman/foreman_remote_execution/blob/7c73948716a099abefc2248fed3c3a10ed073bdd/webpack/JobWizard/steps/form/SelectField.js#L46-L47