### PR TITLE
Refs #34260 - fix the 'schedule a job' button in new host

### DIFF
--- a/webpack/react_app/components/FeaturesDropdown/index.js
+++ b/webpack/react_app/components/FeaturesDropdown/index.js
@@ -23,6 +23,7 @@ const FeaturesDropdown = ({ hostId }) => {
     response: { results: features },
     status,
   } = useAPI('get', foremanUrl(REX_FEATURES_API));
+
   const dispatch = useDispatch();
   const dropdownItems = features
     ?.filter(feature => feature.host_action_button)
@@ -64,7 +65,7 @@ const FeaturesDropdown = ({ hostId }) => {
 };
 
 FeaturesDropdown.propTypes = {
-  hostId: PropTypes.string,
+  hostId: PropTypes.number,
 };
 FeaturesDropdown.defaultProps = {
   hostId: undefined,


### PR DESCRIPTION
The `scedule a job` button redirects to the new job page, but it isn't linked to the current host. 