### PR TITLE
Refs #34653 - Fix load order

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -329,8 +329,8 @@ module ForemanRemoteExecution
       require_dependency 'foreman_tasks/task'
       ForemanTasks::Task.include ForemanRemoteExecution::ForemanTasksTaskExtensions
       ForemanTasks::Cleaner.include ForemanRemoteExecution::ForemanTasksCleanerExtensions
+      RemoteExecutionProvider.register(:SSH, ::SSHExecutionProvider)
       RemoteExecutionProvider.register(:script, ::ScriptExecutionProvider)
-      RemoteExecutionProvider.register(:SSH, SSHExecutionProvider)
 
       ForemanRemoteExecution.register_rex_feature
 


### PR DESCRIPTION
Both SSHExecutionProvider and ScriptExecutionProvider live in
ssh_execution_provider.rb. When autoloading kicks in, previously it
tried to load ScriptExecutionProvider from script_execution_provider,
which failed. Switching the order in engine.rb works around this issue.