### PR TITLE
Fixes #34790 - Improved progress reporting

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -245,6 +245,7 @@ module RemoteExecutionHelper
 
   def job_report_template
     template = ReportTemplate.where(name: Setting['remote_execution_job_invocation_report_template']).first
+    return if template.nil?
 
     template if template.template_inputs.where(name: 'job_id').exists?
   end

--- a/app/lib/foreman_remote_execution/staged_output.rb
+++ b/app/lib/foreman_remote_execution/staged_output.rb
@@ -1,0 +1,66 @@
+module ForemanRemoteExecution
+  class Stage
+    attr_reader :name, :resource
+    attr_accessor :result
+
+    def initialize(name, result, resource: nil)
+      @name = name
+      @result = result
+      @resource = resource
+    end
+  end
+
+  class StagedOutput
+    def initialize(job_invocation, host, proxy)
+      @job_invocation = job_invocation
+      @host = host
+      @proxy = proxy
+    end
+
+    def output
+      foreman = Stage.new('Foreman', 'pending')
+      proxy = Stage.new('Smart Proxy', 'pending', resource: @proxy)
+      host = Stage.new('Remote Host', 'pending', resource: @host)
+
+      sub_task = @job_invocation.sub_task_for_host(@host)
+      remote_task = sub_task&.remote_tasks&.first
+
+      case sub_task&.state
+      when nil, 'pending'
+        foreman.result = 'active'
+      when 'running'
+        case remote_task&.state
+        when nil, 'new', 'external'
+          foreman.result = 'active'
+        when 'triggered', 'parent-triggered'
+          foreman.result = proxy.result = 'done'
+          host.result = 'active'
+        else
+          foreman.result = 'done'
+          proxy.result = 'active'
+        end
+      when 'stopped'
+        if sub_task.result == 'success'
+          foreman.result = proxy.result = host.result = 'done'
+        elsif sub_task.execution_plan.errors.any? { |error| error.exception_class == ::Actions::RemoteExecution::RunHostJob::ProxySelectionFailure }
+          # Foreman failed to pick a proxy
+          foreman.result = 'done'
+          proxy.result = 'error'
+        elsif sub_task.main_action.steps.compact.count == 1
+          # The sub task has not reached its run phase
+          foreman.result = 'error'
+        elsif sub_task.main_action.exit_status == 'EXCEPTION'
+          # It started running at the proxy, but an exception was raised there
+          foreman.result = 'done'
+          proxy.result = 'error'
+        elsif sub_task.main_action.exit_status.is_a?(Integer)
+          # A numeric exit status means it actually ran on the remote host
+          foreman.result = proxy.result = 'done'
+          host.result = 'error'
+        end
+      end
+
+      [foreman, proxy, host]
+    end
+  end
+end

--- a/app/views/template_invocations/show.html.erb
+++ b/app/views/template_invocations/show.html.erb
@@ -27,8 +27,48 @@ end
     <%= button_group(template_invocation_task_buttons(@template_invocation_task, @template_invocation.job_invocation)) %>
   </div>
 </div>
-<% if @host %>
+
+<hr/>
   <% proxy_id = @template_invocation_task.input[:proxy_id] %>
+  <% proxy = SmartProxy.find_by(id: proxy_id) if proxy_id %>
+  <% so = ForemanRemoteExecution::StagedOutput.new(@template_invocation.job_invocation, @host, proxy) %>
+  <% staged_output = so.output %>
+
+<ol class="pf-c-progress-stepper pf-m-center">
+  <% staged_output.each do |stage| %>
+    <% status, icon = case stage.result
+                      when 'done'
+                        ['success', 'fa-check-circle']
+                      when 'error'
+                        ['danger', 'fa-exclamation-circle']
+                      when 'pending'
+                        ['pending', '']
+                      when 'active'
+                        ['info', 'pf-icon-in-progress']
+                      end %>
+    <li
+      class="pf-c-progress-stepper__step pf-m-<%= status %>"
+      aria-label="completed step,"
+    >
+      <div class="pf-c-progress-stepper__step-connector">
+        <span class="pf-c-progress-stepper__step-icon">
+          <i class="fas <%= icon %>" aria-hidden="true"></i>
+        </span>
+      </div>
+      <div class="pf-c-progress-stepper__step-main">
+        <div class="pf-c-progress-stepper__step-title"><%= stage.name %></div>
+        <% if stage.resource %>
+          <% link = stage.resource.is_a?(::Host::Base) ? current_host_details_path(stage.resource) : smart_proxy_path(stage.resource) %>
+          <div class="pf-c-progress-stepper__step-description">
+            <%= link_to(stage.resource.name, link) %>
+          </div>
+        <% end %>
+      </div>
+    </li>
+  <% end %>
+</ol>
+
+<% if @host %>
   <h3>
     <%= _('Target: ') %><%= link_to(@host.name, current_host_details_path(@host)) %>
     <% if proxy_id && proxy = SmartProxy.find_by(id: proxy_id) %>

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "prettier": "^1.19.1",
     "redux-mock-store": "^1.2.2",
     "graphql-tag": "^2.11.0",
-    "graphql": "^15.5.0"
+    "graphql": "^15.5.0",
+    "@patternfly/react-catalog-view-extension": "^4.8.126",
+    "@patternfly/react-core": "~4.175.4"
   },
   "peerDependencies": {
     "@theforeman/vendor": "^10.1.0"


### PR DESCRIPTION
Opening as a draft for visibility

# TODO
- [ ] expose this in API
- [ ] make the progress bar refresh as the job runs

# Pictures
Job running on host
![image](https://user-images.githubusercontent.com/7326770/164230699-709e2e71-774b-45b2-a612-9b6197bdb0ef.png)

Successful job
![image](https://user-images.githubusercontent.com/7326770/164230236-0b44ad81-b841-4fb6-ba8b-b38bb0f9dcb2.png)

Failed job
![image](https://user-images.githubusercontent.com/7326770/164230530-0caabeb4-8cc9-4a12-87d9-b0453279ddd3.png)

Rendering error
![image](https://user-images.githubusercontent.com/7326770/164230278-a758c3d7-1de5-454d-8c22-82058112e041.png)

Proxy selection failure
![image](https://user-images.githubusercontent.com/7326770/164230393-76f75906-bbcf-493f-b73f-631c9fce5a26.png)
