### PR TITLE
Fixes #34799 - New host detail page sentence case fixes

### DIFF
--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -19,9 +19,9 @@ export const repeatTypes = {
 export const WIZARD_TITLES = {
   categoryAndTemplate: __('Category and Template'),
   hostsAndInputs: __('Target hosts and inputs'),
-  advanced: __('Advanced Fields'),
+  advanced: __('Advanced fields'),
   schedule: __('Schedule'),
-  review: __('Review Details'),
+  review: __('Review details'),
 };
 
 export const initialScheduleState = {

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -143,7 +143,7 @@ describe('AdvancedFields', () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Advanced Fields'));
+      fireEvent.click(screen.getByText('Advanced fields'));
     });
     expect(textField.value).toBe(textValue);
     expect(searchField.value).toBe(searchValue);
@@ -162,7 +162,7 @@ describe('AdvancedFields', () => {
       </MockedProvider>
     );
     await act(async () => {
-      fireEvent.click(screen.getByText('Advanced Fields'));
+      fireEvent.click(screen.getByText('Advanced fields'));
     });
 
     expect(

--- a/webpack/JobWizard/steps/ReviewDetails/index.js
+++ b/webpack/JobWizard/steps/ReviewDetails/index.js
@@ -72,7 +72,7 @@ const ReviewDetails = ({
   };
   const [isAdvancedShown, setIsAdvancedShown] = useState(false);
   const detailsFirstHalf = [
-    { label: __('Job Category'), value: jobCategory },
+    { label: __('Job category'), value: jobCategory },
     { label: __('Job template'), value: jobTemplate },
     { label: __('Target hosts'), value: stringHosts() },
     ...templateInputs.map(({ name }) => ({

--- a/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
+++ b/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
@@ -186,7 +186,7 @@ describe('Schedule', () => {
     expect(
       screen.getByPlaceholderText('Repeat N times').hasAttribute('disabled')
     ).toBeTruthy();
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
     await act(async () => {
       fireEvent.click(
         screen.getByLabelText('Does not repeat', { selector: 'button' })
@@ -196,7 +196,7 @@ describe('Schedule', () => {
     await act(async () => {
       fireEvent.click(screen.getByText('Cronline'));
     });
-    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    expect(screen.getByText('Review details').disabled).toBeTruthy();
     const newRepeatTimes = '3';
     const repeatNTimes = screen.getByPlaceholderText('Repeat N times');
     expect(repeatNTimes.value).toBe('');
@@ -216,7 +216,7 @@ describe('Schedule', () => {
       });
     });
     expect(cronline.value).toBe(newCronline);
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
 
     await act(async () => {
       fireEvent.click(screen.getByText('Category and Template'));
@@ -236,7 +236,7 @@ describe('Schedule', () => {
       fireEvent.click(screen.getByText('Monthly'));
     });
 
-    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    expect(screen.getByText('Review details').disabled).toBeTruthy();
     const newDays = '1,2,3';
     const days = screen.getByLabelText('days');
     expect(days.value).toBe('');
@@ -248,7 +248,7 @@ describe('Schedule', () => {
     });
     expect(days.value).toBe(newDays);
 
-    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    expect(screen.getByText('Review details').disabled).toBeTruthy();
     const newAtMonthly = '13:07';
     const at = () => screen.getByLabelText('repeat-at');
     expect(at().value).toBe('');
@@ -259,13 +259,13 @@ describe('Schedule', () => {
     });
     expect(at().value).toBe(newAtMonthly);
 
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
     fireEvent.click(screen.getByText('Monthly'));
     await act(async () => {
       fireEvent.click(screen.getByText('Weekly'));
     });
 
-    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    expect(screen.getByText('Review details').disabled).toBeTruthy();
     const dayTue = screen.getByLabelText('Tue checkbox');
     const daySat = screen.getByLabelText('Sat checkbox');
     expect(dayTue.checked).toBe(false);
@@ -293,19 +293,19 @@ describe('Schedule', () => {
     });
     expect(at().value).toBe(newAtWeekly);
 
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
     fireEvent.click(screen.getByText('Weekly'));
     await act(async () => {
       fireEvent.click(screen.getByText('Daily'));
     });
 
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
     await act(async () => {
       fireEvent.change(at(), {
         target: { value: '' },
       });
     });
-    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    expect(screen.getByText('Review details').disabled).toBeTruthy();
     const newAtDaily = '17:07';
     expect(at().value).toBe('');
     await act(async () => {
@@ -314,14 +314,14 @@ describe('Schedule', () => {
       });
     });
     expect(at().value).toBe(newAtDaily);
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
 
     fireEvent.click(screen.getByText('Daily'));
     await act(async () => {
       fireEvent.click(screen.getByText('Hourly'));
     });
 
-    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    expect(screen.getByText('Review details').disabled).toBeTruthy();
     const newMinutes = '6';
     const atHourly = screen.getByLabelText('repeat-at-minute-typeahead');
     expect(atHourly.value).toBe('');
@@ -331,7 +331,7 @@ describe('Schedule', () => {
     await act(async () => {
       fireEvent.click(screen.getByText(newMinutes));
     });
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
     expect(atHourly.value).toBe(newMinutes);
   });
   it('should show invalid error on start date after end', async () => {
@@ -353,7 +353,7 @@ describe('Schedule', () => {
     expect(
       screen.queryAllByText('End time needs to be after start time')
     ).toHaveLength(0);
-    expect(screen.getByText('Review Details').disabled).toBeFalsy();
+    expect(screen.getByText('Review details').disabled).toBeFalsy();
     await act(async () => {
       await fireEvent.change(startsDateField, {
         target: { value: '2020/10/15' },
@@ -368,7 +368,7 @@ describe('Schedule', () => {
       screen.queryAllByText('End time needs to be after start time')
     ).toHaveLength(1);
 
-    expect(screen.getByText('Review Details').disabled).toBeTruthy();
+    expect(screen.getByText('Review details').disabled).toBeTruthy();
   });
   it('purpose and ends should be disabled when no reaccurence ', async () => {
     render(

--- a/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
+++ b/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
@@ -28,7 +28,7 @@ const RecentJobsCard = ({ hostDetails: { name, id } }) => {
           href={foremanUrl(`${JOB_BASE_URL}${name}`)}
           key="link-to-all"
         >
-          {__('View All Jobs')}
+          {__('View all jobs')}
         </DropdownItem>,
         <DropdownItem
           href={foremanUrl(
@@ -36,19 +36,19 @@ const RecentJobsCard = ({ hostDetails: { name, id } }) => {
           )}
           key="link-to-finished"
         >
-          {__('View Finished Jobs')}
+          {__('View finished jobs')}
         </DropdownItem>,
         <DropdownItem
           href={foremanUrl(`${JOB_BASE_URL}${name}+and+status+%3D+running`)}
           key="link-to-running"
         >
-          {__('View Running Jobs')}
+          {__('View running jobs')}
         </DropdownItem>,
         <DropdownItem
           href={foremanUrl(`${JOB_BASE_URL}${name}+and+status+%3D+queued`)}
           key="link-to-scheduled"
         >
-          {__('View Scheduled Jobs')}
+          {__('View scheduled jobs')}
         </DropdownItem>,
       ]}
     >


### PR DESCRIPTION
Corrects Overview tab - Host detail page - incorrect use of sentence case

Job card - actions in the kebab should be;
“View all jobs”
“View finished jobs”
“View running jobs”
“View scheduled jobs”

and a couple more I found.