### PR TITLE
Fixes #34835 - Open Cockpit console in a new tab

### DIFF
--- a/webpack/react_app/components/HostKebab/KebabItems.js
+++ b/webpack/react_app/components/HostKebab/KebabItems.js
@@ -13,7 +13,12 @@ const HostKebabItems = () => {
 
   if (!consoleUrl) return null;
   return (
-    <DropdownItem icon={<CodeIcon />} href={consoleUrl}>
+    <DropdownItem
+      icon={<CodeIcon />}
+      href={consoleUrl}
+      target="_blank"
+      rel="noreferrer"
+    >
       {__('Web Console')}
     </DropdownItem>
   );


### PR DESCRIPTION
I could probably use `<Link>` from PF4, but just to be consistent with the core I've used this way.