### PR TITLE
Fixes #32104 - Retain tasks used for errata reporting for longer time

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -172,6 +172,10 @@ module Actions
         @host ||= ::Host.authorized.find(host_id)
       end
 
+      def self.cleanup_after
+        '90d'
+      end
+
       private
 
       def update_host_status

--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -153,6 +153,10 @@ module Actions
         input[:proxy_batch_size]
       end
 
+      def self.cleanup_after
+        '90d'
+      end
+
       private
 
       def mail_notification_preference


### PR DESCRIPTION
Companion to https://github.com/Katello/katello/pull/10096