### PR TITLE
Fixes #34900 - Make 'Schedule a job' button secondary

### DIFF
--- a/webpack/react_app/components/FeaturesDropdown/index.js
+++ b/webpack/react_app/components/FeaturesDropdown/index.js
@@ -52,7 +52,7 @@ const FeaturesDropdown = ({ hostId }) => {
       toggle={
         <DropdownToggle
           splitButtonItems={scheduleJob}
-          toggleVariant="primary"
+          toggleVariant="secondary"
           onToggle={() => setIsOpen(prev => !prev)}
           isDisabled={status === STATUS.PENDING}
           splitButtonVariant="action"


### PR DESCRIPTION
Concern was brought up at host details meeting that users are confused by having multiple primary buttons on screen (e.g. errata Apply & 'Schedule a job')

It's technically possible but difficult to make 'Schedule a job' button secondary only if there is another primary button on screen.

For simplicity it was decided instead to just make 'Schedule a job' secondary all the time.

![secondary_toggle](https://user-images.githubusercontent.com/22042343/167906441-663ad194-10c3-4875-910b-6905cc9547e8.png)
