### PR TITLE
Fixes #35077 - Cant run job wizard with weekly

### DIFF
--- a/webpack/JobWizard/steps/Schedule/RepeatWeek.js
+++ b/webpack/JobWizard/steps/Schedule/RepeatWeek.js
@@ -7,7 +7,7 @@ import { noop } from '../../../helpers';
 
 const getWeekDays = () => {
   const locale = documentLocale().replace(/-/g, '_');
-  const baseDate = new Date(Date.UTC(2017, 0, 2)); // just a Monday
+  const baseDate = new Date(Date.UTC(2017, 0, 1)); // just a Sunday
   const weekDays = [];
   for (let i = 0; i < 7; i++) {
     try {

--- a/webpack/JobWizard/submit.js
+++ b/webpack/JobWizard/submit.js
@@ -44,8 +44,13 @@ export const submit = ({
         return repeatData.cronline;
       case repeatTypes.monthly:
         return `${minute} ${hour} ${repeatData.days} * *`;
-      case repeatTypes.weekly:
-        return `${minute} ${hour} * * ${repeatData.daysOfWeek}`;
+      case repeatTypes.weekly: {
+        const daysKeys = Object.keys(repeatData.daysOfWeek).filter(
+          k => repeatData.daysOfWeek[k]
+        );
+        const days = daysKeys.join(',');
+        return `${minute} ${hour} * * ${days}`;
+      }
       case repeatTypes.daily:
         return `${minute} ${hour} * * *`;
       case repeatTypes.hourly:


### PR DESCRIPTION
When selecting weekly recurrence in the job wizard and running the job, this error will show: 
`"cronline":["00 13 * * [object Object] is not valid format of cron line"]`
fixes also an issue where Monday was treated as 0 day when it should be sunday.