### PR TITLE
Fixes #35084 - Add rerun to job wizard

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -62,7 +62,7 @@ class UiJobWizardController < ApplicationController
     job = JobInvocation.authorized.find(params[:id])
     composer = JobInvocationComposer.from_job_invocation(job, params).params
     job_template_inputs = JobTemplate.authorized.find(composer[:template_invocations][0][:template_id]).template_inputs_with_foreign
-    inputs = Hash[job_template_inputs.map{ |input| ["inputs[#{input[:name]}]", (composer[:template_invocations][0][:input_values].select {|value| value[:template_input_id]== input[:id]})[0][:value]] } ]
+    inputs = Hash[job_template_inputs.map { |input| ["inputs[#{input[:name]}]", (composer[:template_invocations][0][:input_values].find { |value| value[:template_input_id] == input[:id] })[:value]] }]
     job_organization = Taxonomy.find_by(id: job.task.input[:current_organization_id])
     job_location = Taxonomy.find_by(id: job.task.input[:current_location_id])
     render :json => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,8 +46,10 @@ Rails.application.routes.draw do
   get 'ui_job_wizard/categories', to: 'ui_job_wizard#categories'
   get 'ui_job_wizard/template/:id', to: 'ui_job_wizard#template'
   get 'ui_job_wizard/resources', to: 'ui_job_wizard#resources'
+  get 'ui_job_wizard/job_invocation', to: 'ui_job_wizard#job_invocation'
 
-  match '/experimental/job_wizard', to: 'react#index', :via => [:get]
+  match '/experimental/job_wizard/new', to: 'react#index', :via => [:get]
+  match '/experimental/job_wizard/:id/rerun', to: 'react#index', :via => [:get]
 
   namespace :api, :defaults => {:format => 'json'} do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -242,7 +242,7 @@ module ForemanRemoteExecution
           url_hash: { controller: 'job_wizard', action: :index },
           caption: N_('Job wizard'),
           parent: :lab_features_menu,
-          url: '/experimental/job_wizard',
+          url: '/experimental/job_wizard/new',
           after: :host_wizard
 
         register_custom_status HostStatus::ExecutionStatus

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -164,7 +164,7 @@ module ForemanRemoteExecution
                                             :'api/v2/job_templates' => [:index, :show, :revision, :export],
                                             :'api/v2/template_inputs' => [:index, :show],
                                             :'api/v2/foreign_input_sets' => [:index, :show],
-                                            :ui_job_wizard => [:categories, :template, :resources]}, :resource_type => 'JobTemplate'
+                                            :ui_job_wizard => [:categories, :template, :resources, :job_invocation]}, :resource_type => 'JobTemplate'
           permission :create_job_templates, { :job_templates => [:new, :create, :clone_template, :import],
                                               :'api/v2/job_templates' => [:create, :clone, :import] }, :resource_type => 'JobTemplate'
           permission :edit_job_templates, { :job_templates => [:edit, :update],
@@ -181,7 +181,7 @@ module ForemanRemoteExecution
           permission :view_job_invocations, { :job_invocations => [:index, :chart, :show, :auto_complete_search], :template_invocations => [:show],
                                               'api/v2/job_invocations' => [:index, :show, :output, :raw_output, :outputs] }, :resource_type => 'JobInvocation'
           permission :view_template_invocations, { :template_invocations => [:show],
-                                                   'api/v2/template_invocations' => [:template_invocations] }, :resource_type => 'TemplateInvocation'
+                                                   'api/v2/template_invocations' => [:template_invocations], :ui_job_wizard => [:job_invocation] }, :resource_type => 'TemplateInvocation'
           permission :create_template_invocations, {}, :resource_type => 'TemplateInvocation'
           permission :execute_jobs_on_infrastructure_hosts, {}, :resource_type => 'JobInvocation'
           permission :cancel_job_invocations, { :job_invocations => [:cancel], 'api/v2/job_invocations' => [:cancel] }, :resource_type => 'JobInvocation'

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -37,8 +37,10 @@ import { submit } from './submit';
 import './JobWizard.scss';
 
 export const JobWizard = ({ rerunData }) => {
-  const [jobTemplateID, setJobTemplateID] = useState(null);
-  const [category, setCategory] = useState('');
+  const [jobTemplateID, setJobTemplateID] = useState(
+    rerunData?.template_invocations?.[0]?.template_id
+  );
+  const [category, setCategory] = useState(rerunData?.job_category || '');
   const [advancedValues, setAdvancedValues] = useState({ templateValues: {} });
   const [templateValues, setTemplateValues] = useState({}); // TODO use templateValues in advanced fields - description https://github.com/theforeman/foreman_remote_execution/pull/605
   const [scheduleValue, setScheduleValue] = useState(initialScheduleState);
@@ -49,7 +51,14 @@ export const JobWizard = ({ rerunData }) => {
   });
   const [hostsSearchQuery, setHostsSearchQuery] = useState('');
   const routerSearch = useSelector(selectRouterSearch);
-  const [fills, setFills] = useState(rerunData ? {} : routerSearch);
+  const [fills, setFills] = useState(
+    rerunData
+      ? {
+          search: rerunData?.targeting?.search_query,
+          ...rerunData.inputs,
+        }
+      : routerSearch
+  );
   const dispatch = useDispatch();
 
   const setDefaults = useCallback(
@@ -118,8 +127,6 @@ export const JobWizard = ({ rerunData }) => {
   );
   useEffect(() => {
     if (rerunData) {
-      setCategory(rerunData.job_category);
-      setJobTemplateID(rerunData.template_invocations[0].template_id);
       setDefaults({
         data: {
           effective_user: {
@@ -133,13 +140,8 @@ export const JobWizard = ({ rerunData }) => {
           concurrency_control: rerunData.concurrency_control,
         },
       });
-      setFills({
-        search: rerunData.targeting.search_query,
-        ...rerunData.inputs,
-      });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rerunData]);
+  }, [rerunData, setDefaults]);
   useEffect(() => {
     if (jobTemplateID) {
       dispatch(

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -48,7 +48,8 @@ export const JobWizard = ({ rerunData }) => {
     hostGroups: [],
   });
   const [hostsSearchQuery, setHostsSearchQuery] = useState('');
-  const [fills, setFills] = useState(useSelector(selectRouterSearch));
+  const routerSearch = useSelector(selectRouterSearch);
+  const [fills, setFills] = useState(rerunData ? {} : routerSearch);
   const dispatch = useDispatch();
 
   const setDefaults = useCallback(

--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -146,3 +146,8 @@
     font-size: var(--pf-c-radio__label--FontSize);
   }
 }
+
+.job-wizard-alert.pf-c-alert.pf-m-warning {
+  margin-bottom: 10px;
+  margin-top: 10px;
+}

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -67,3 +67,5 @@ export const HOSTS_TO_PREVIEW_AMOUNT = 20;
 export const DEBOUNCE_HOST_COUNT = 700;
 export const HOST_IDS = 'HOST_IDS';
 export const REX_FEATURE = 'REX_FEATURE';
+
+export const JOB_API_KEY = 'JOB_API_KEY';

--- a/webpack/JobWizard/JobWizardPageRerun.js
+++ b/webpack/JobWizard/JobWizardPageRerun.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import URI from 'urijs';
 import { Alert, Title, Divider, Skeleton } from '@patternfly/react-core';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
@@ -16,10 +17,15 @@ const JobWizardPageRerun = ({
   match: {
     params: { id },
   },
+  location: { search },
 }) => {
+  const uri = new URI(search);
+  const { failed_only: failedOnly } = uri.search(true);
   const { response, status } = useAPI(
     'get',
-    `/ui_job_wizard/job_invocation?id=${id}`,
+    `/ui_job_wizard/job_invocation?id=${id}${
+      failedOnly ? '&failed_only=1' : ''
+    }`,
     JOB_API_KEY
   );
   const title = __('Run job');
@@ -34,6 +40,7 @@ const JobWizardPageRerun = ({
   const jobLocation = response.job_location;
   const currentOrganization = useForemanOrganization();
   const currentLocation = useForemanLocation();
+
   return (
     <PageLayout
       header={title}
@@ -53,7 +60,7 @@ const JobWizardPageRerun = ({
           </div>
         ) : (
           <React.Fragment>
-            {jobOrganization !== currentOrganization && (
+            {jobOrganization?.id !== currentOrganization?.id && (
               <Alert
                 className="job-wizard-alert"
                 variant="warning"
@@ -66,7 +73,7 @@ const JobWizardPageRerun = ({
                 )}
               />
             )}
-            {jobLocation !== currentLocation && (
+            {jobLocation?.id !== currentLocation?.id && (
               <Alert
                 className="job-wizard-alert"
                 variant="warning"
@@ -95,5 +102,11 @@ JobWizardPageRerun.propTypes = {
       id: PropTypes.string.isRequired,
     }),
   }).isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }),
+};
+JobWizardPageRerun.defaultProps = {
+  location: { search: '' },
 };
 export default JobWizardPageRerun;

--- a/webpack/JobWizard/JobWizardPageRerun.js
+++ b/webpack/JobWizard/JobWizardPageRerun.js
@@ -66,7 +66,7 @@ const JobWizardPageRerun = ({
                 variant="warning"
                 title={sprintf(
                   __(
-                    "Current organization %s is different from job's organization %s.",
+                    "Current organization %s is different from job's organization %s. This job may run on different hosts than before.",
                     currentOrganization,
                     jobOrganization
                   )
@@ -79,7 +79,7 @@ const JobWizardPageRerun = ({
                 variant="warning"
                 title={sprintf(
                   __(
-                    "Current location %s is different from job's location %s.",
+                    "Current location %s is different from job's location %s. This job may run on different hosts than before.",
                     currentLocation,
                     jobLocation
                   )

--- a/webpack/JobWizard/JobWizardPageRerun.js
+++ b/webpack/JobWizard/JobWizardPageRerun.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Title, Divider, Skeleton } from '@patternfly/react-core';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
+import { STATUS } from 'foremanReact/constants';
+import {
+  useForemanOrganization,
+  useForemanLocation,
+} from 'foremanReact/Root/Context/ForemanContext';
+import { JobWizard } from './JobWizard';
+import { JOB_API_KEY } from './JobWizardConstants';
+
+const JobWizardPageRerun = ({
+  match: {
+    params: { id },
+  },
+}) => {
+  const { response, status } = useAPI(
+    'get',
+    `/ui_job_wizard/job_invocation?id=${id}`,
+    JOB_API_KEY
+  );
+  const title = __('Run job');
+  const breadcrumbOptions = {
+    breadcrumbItems: [
+      { caption: __('Jobs'), url: `/jobs` },
+      { caption: title },
+    ],
+  };
+
+  const jobOrganization = response.job_organization;
+  const jobLocation = response.job_location;
+  const currentOrganization = useForemanOrganization();
+  const currentLocation = useForemanLocation();
+  return (
+    <PageLayout
+      header={title}
+      breadcrumbOptions={breadcrumbOptions}
+      searchable={false}
+    >
+      <React.Fragment>
+        <Title headingLevel="h2" size="2xl">
+          {title}
+        </Title>
+        {!status || status === STATUS.PENDING ? (
+          <div style={{ height: '400px' }}>
+            <Skeleton
+              height="100%"
+              screenreaderText="Loading large rectangle contents"
+            />
+          </div>
+        ) : (
+          <React.Fragment>
+            {jobOrganization !== currentOrganization && (
+              <Alert
+                className="job-wizard-alert"
+                variant="warning"
+                title={sprintf(
+                  __(
+                    "Current organization %s is different from job's organization %s.",
+                    currentOrganization,
+                    jobOrganization
+                  )
+                )}
+              />
+            )}
+            {jobLocation !== currentLocation && (
+              <Alert
+                className="job-wizard-alert"
+                variant="warning"
+                title={sprintf(
+                  __(
+                    "Current location %s is different from job's location %s.",
+                    currentLocation,
+                    jobLocation
+                  )
+                )}
+              />
+            )}
+            <Divider component="div" />
+            <JobWizard
+              rerunData={{ ...response?.job, inputs: response?.inputs } || null}
+            />
+          </React.Fragment>
+        )}
+      </React.Fragment>
+    </PageLayout>
+  );
+};
+JobWizardPageRerun.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
+};
+export default JobWizardPageRerun;

--- a/webpack/JobWizard/__tests__/JobWizardPageRerun.test.js
+++ b/webpack/JobWizard/__tests__/JobWizardPageRerun.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+
+import * as APIHooks from 'foremanReact/common/hooks/API/APIHooks';
+import * as api from 'foremanReact/redux/API';
+import JobWizardPageRerun from '../JobWizardPageRerun';
+import * as selectors from '../JobWizardSelectors';
+import { testSetup, mockApi, gqlMock, jobInvocation } from './fixtures';
+
+const store = testSetup(selectors, api);
+mockApi(api);
+jest.spyOn(APIHooks, 'useAPI');
+APIHooks.useAPI.mockImplementation((action, url) => {
+  if (url === '/ui_job_wizard/job_invocation?id=57') {
+    return { response: jobInvocation, status: 'RESOLVED' };
+  }
+  return {};
+});
+
+describe('Job wizard fill', () => {
+  it('fill defaults into fields', async () => {
+    render(
+      <MockedProvider mocks={gqlMock} addTypename={false}>
+        <Provider store={store}>
+          <JobWizardPageRerun
+            match={{
+              params: { id: '57' },
+            }}
+          />
+        </Provider>
+      </MockedProvider>
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText('Target hosts and inputs'));
+    });
+    await screen.findByLabelText('plain hidden', {
+      selector: 'textarea',
+    });
+
+    expect(
+      screen.getByLabelText('plain hidden', {
+        selector: 'textarea',
+      }).value
+    ).toBe('test command');
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Advanced fields'));
+    });
+
+    expect(
+      screen.getByLabelText('ssh user', {
+        selector: 'input',
+      }).value
+    ).toBe('ssh user');
+    expect(
+      screen.getByLabelText('effective user', {
+        selector: 'input',
+      }).value
+    ).toBe('Effective user');
+    expect(
+      screen.getByLabelText('timeout to kill', {
+        selector: 'input',
+      }).value
+    ).toBe('1');
+
+    expect(
+      screen.getByLabelText('Concurrency level', {
+        selector: 'input',
+      }).value
+    ).toBe('6');
+    expect(
+      screen.getByLabelText('Time span', {
+        selector: 'input',
+      }).value
+    ).toBe('4');
+  });
+});

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -106,6 +106,7 @@ export const testSetup = (selectors, api) => {
   jest.spyOn(selectors, 'selectJobCategories');
   jest.spyOn(selectors, 'selectJobCategoriesStatus');
   jest.spyOn(selectors, 'selectWithKatello');
+  jest.spyOn(selectors, 'selectEffectiveUser');
 
   jest.spyOn(selectors, 'selectTemplateInputs');
   jest.spyOn(selectors, 'selectAdvancedTemplateInputs');
@@ -122,6 +123,10 @@ export const testSetup = (selectors, api) => {
     { ...jobTemplate, id: 2, name: 'template2' },
   ]);
   selectors.selectJobTemplate.mockImplementation(() => jobTemplateResponse);
+
+  selectors.selectEffectiveUser.mockImplementation(
+    () => jobTemplateResponse.effective_user
+  );
   const mockStore = configureMockStore([]);
   const store = mockStore({
     ForemanTasksTask: {
@@ -224,3 +229,71 @@ export const gqlMock = [
     },
   },
 ];
+
+export const jobInvocation = {
+  job: {
+    job_category: 'Ansible Commands',
+    targeting: {
+      user_id: 4,
+      search_query: 'name ~ *',
+      bookmark_id: null,
+      targeting_type: 'static_query',
+      randomized_ordering: true,
+    },
+    triggering: {
+      mode: 'immediate',
+      start_at: null,
+      start_before: null,
+    },
+    ssh_user: 'ssh user',
+    description_format: null,
+    concurrency_control: {
+      level: 6,
+      time_span: 4,
+    },
+    execution_timeout_interval: 1,
+    remote_execution_feature_id: null,
+    template_invocations: [
+      {
+        template_id: 263,
+        effective_user: 'Effective user',
+        input_values: [
+          {
+            template_input_id: 162,
+            value: 'test command',
+          },
+        ],
+      },
+    ],
+    reruns: 57,
+  },
+  job_organization: {
+    id: 5,
+    name: 'ana-praley',
+    created_at: '2021-08-26T13:47:35.655+02:00',
+    updated_at: '2021-08-26T13:48:21.435+02:00',
+    ignore_types: [],
+    description: null,
+    label: 'ana-praley',
+    ancestry: null,
+    title: 'ana-praley',
+    manifest_refreshed_at: null,
+    created_in_katello: true,
+  },
+  job_location: {
+    id: 2,
+    name: 'Default Location',
+    created_at: '2021-08-24T15:32:18.830+02:00',
+    updated_at: '2021-08-24T15:32:18.830+02:00',
+    ignore_types: ['ProvisioningTemplate', 'Hostgroup'],
+    description: null,
+    label: null,
+    ancestry: null,
+    title: 'Default Location',
+    manifest_refreshed_at: null,
+    created_in_katello: false,
+  },
+  inputs: {
+    'inputs[plain hidden]': 'test command',
+  },
+};

--- a/webpack/JobWizard/autofill.js
+++ b/webpack/JobWizard/autofill.js
@@ -11,6 +11,7 @@ export const useAutoFill = ({
   setHostsSearchQuery,
   setJobTemplateID,
   setTemplateValues,
+  setAdvancedValues,
 }) => {
   const dispatch = useDispatch();
 
@@ -49,15 +50,21 @@ export const useAutoFill = ({
             },
           })
         );
+      }
+      if (rest) {
         Object.keys(rest).forEach(key => {
           const re = /inputs\[(?<input>.*)\]/g;
           const input = re.exec(key)?.groups?.input;
           if (input) {
             setTemplateValues(prev => ({ ...prev, [input]: rest[key] }));
+            setAdvancedValues(prev => ({
+              ...prev,
+              templateValues: { ...prev.templateValues, [input]: rest[key] },
+            }));
           }
         });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [fills]);
 };

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -23,12 +23,8 @@ lodash.debounce = fn => fn;
 const store = testSetup(selectors, api);
 mockApi(api);
 
-jest.spyOn(selectors, 'selectEffectiveUser');
 jest.useFakeTimers();
 
-selectors.selectEffectiveUser.mockImplementation(
-  () => jobTemplateResponse.effective_user
-);
 describe('AdvancedFields', () => {
   it('should save data between steps for advanced fields', async () => {
     const wrapper = mount(

--- a/webpack/JobWizard/steps/CategoryAndTemplate/index.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/index.js
@@ -25,7 +25,7 @@ const ConnectedCategoryAndTemplate = ({
   setJobTemplate,
   category,
   setCategory,
-  isFeature,
+  isCategoryPreselected,
 }) => {
   const dispatch = useDispatch();
 
@@ -44,7 +44,7 @@ const ConnectedCategoryAndTemplate = ({
               default_template: defaultTemplate,
             },
           }) => {
-            if (!isFeature) {
+            if (!isCategoryPreselected) {
               setCategory(defaultCategory || jobCategories[0] || '');
               if (defaultTemplate) setJobTemplate(defaultTemplate);
             }
@@ -106,7 +106,7 @@ ConnectedCategoryAndTemplate.propTypes = {
   setJobTemplate: PropTypes.func.isRequired,
   category: PropTypes.string.isRequired,
   setCategory: PropTypes.func.isRequired,
-  isFeature: PropTypes.bool.isRequired,
+  isCategoryPreselected: PropTypes.bool.isRequired,
 };
 ConnectedCategoryAndTemplate.defaultProps = { jobTemplate: null };
 

--- a/webpack/Routes/routes.js
+++ b/webpack/Routes/routes.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import JobWizardPage from '../JobWizard';
+import JobWizardPageRerun from '../JobWizard/JobWizardPageRerun';
 
 const ForemanREXRoutes = [
   {
-    path: '/experimental/job_wizard',
+    path: '/experimental/job_wizard/new',
     exact: true,
-    render: props => <JobWizardPage {...props} />,
+    render: () => <JobWizardPage />,
+  },
+  {
+    path: '/experimental/job_wizard/:id/rerun',
+    exact: true,
+    render: props => <JobWizardPageRerun {...props} />,
   },
 ];
 

--- a/webpack/__mocks__/foremanReact/common/hooks/API/APIHooks.js
+++ b/webpack/__mocks__/foremanReact/common/hooks/API/APIHooks.js
@@ -1,0 +1,1 @@
+export const useAPI = jest.fn();


### PR DESCRIPTION
changed the menu url to `experimental/job_wizard/new`
to use this pr go to `experimental/job_wizard/_ID_/rerun` as its experimental.
UI changes are adding the org/location alerts.
Patternfly guidelines say `If an alert message applies globally to the content on a page, place the alert in the page header area just below the title.`
![Screenshot from 2022-06-20 11-59-18](https://user-images.githubusercontent.com/30431079/174616346-069fa058-536f-427b-a495-c2d46b7cce24.png)
