### PR TITLE
Fixes #35218 - Store job outputs outside of tasks

### DIFF
--- a/app/lib/actions/remote_execution/proxy_action.rb
+++ b/app/lib/actions/remote_execution/proxy_action.rb
@@ -1,0 +1,48 @@
+module Actions
+  module RemoteExecution
+    class ProxyAction < ::Actions::ProxyAction
+      include Actions::RemoteExecution::TemplateInvocationProgressLogging
+
+      def on_data(data, meta = {})
+        super
+        process_proxy_data(output[:proxy_output])
+      end
+
+      def run(event = nil)
+        with_template_invocation_error_logging { super }
+      end
+
+      private
+
+      def get_proxy_data(response)
+        data = super
+        process_proxy_data(data)
+        data
+      end
+
+      def process_proxy_data(data)
+        newest = template_invocation.template_invocation_events.where.not(event_type: 'debug').last&.timestamp
+        events = data['result'].map do |update|
+          {
+            template_invocation_id: template_invocation.id,
+            event: update['output'],
+            timestamp: Time.at(update['timestamp']),
+            event_type: update['output_type'],
+          }
+        end
+        if data['exit_status']
+          events << {
+            template_invocation_id: template_invocation.id,
+            event: data['exit_status'],
+            timestamp: events.last[:timestamp] + 0.0001,
+            event_type: 'exit',
+          }
+        end
+        events.select! { |event| newest.nil? || event[:timestamp] > newest }
+        events.each_slice(1000) do |batch|
+          TemplateInvocationEvent.insert_all(batch)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/remote_execution/proxy_action.rb
+++ b/app/lib/actions/remote_execution/proxy_action.rb
@@ -26,7 +26,7 @@ module Actions
           {
             template_invocation_id: template_invocation.id,
             event: update['output'],
-            timestamp: Time.at(update['timestamp']),
+            timestamp: Time.at(update['timestamp']).getlocal,
             event_type: update['output_type'],
           }
         end
@@ -40,7 +40,7 @@ module Actions
         end
         events.select! { |event| newest.nil? || event[:timestamp] > newest }
         events.each_slice(1000) do |batch|
-          TemplateInvocationEvent.insert_all(batch)
+          TemplateInvocationEvent.insert_all(batch) # rubocop:disable Rails/SkipsModelValidations
         end
       end
     end

--- a/app/lib/actions/remote_execution/template_invocation_progress_logging.rb
+++ b/app/lib/actions/remote_execution/template_invocation_progress_logging.rb
@@ -1,0 +1,27 @@
+module Actions
+  module RemoteExecution
+    module TemplateInvocationProgressLogging
+      def template_invocation
+        @template_invocation ||= TemplateInvocation.find_by(:run_host_job_task_id => task.id)
+      end
+
+      def log_template_invocation_exception(e)
+        template_invocation.template_invocation_events.create!(
+          :event_type => 'debug',
+          :event => "#{e.class}: #{e.message}",
+          :timestamp => Time.zone.now
+        )
+      end
+
+      def with_template_invocation_error_logging
+        unless catch(::Dynflow::Action::ERROR) { yield; true }
+          log_template_invocation_exception(error.exception)
+          throw ::Dynflow::Action::ERROR
+        end
+      rescue => e
+        log_template_invocation_exception(e)
+        raise e
+      end
+    end
+  end
+end

--- a/app/lib/actions/remote_execution/template_invocation_progress_logging.rb
+++ b/app/lib/actions/remote_execution/template_invocation_progress_logging.rb
@@ -5,20 +5,20 @@ module Actions
         @template_invocation ||= TemplateInvocation.find_by(:run_host_job_task_id => task.id)
       end
 
-      def log_template_invocation_exception(e)
+      def log_template_invocation_exception(exception)
         template_invocation.template_invocation_events.create!(
           :event_type => 'debug',
-          :event => "#{e.class}: #{e.message}",
+          :event => "#{exception.class}: #{exception.message}",
           :timestamp => Time.zone.now
         )
       end
 
       def with_template_invocation_error_logging
-        unless catch(::Dynflow::Action::ERROR) { yield; true }
+        unless catch(::Dynflow::Action::ERROR) { yield || true }
           log_template_invocation_exception(error.exception)
           throw ::Dynflow::Action::ERROR
         end
-      rescue => e
+      rescue => e # rubocop:disable Style/RescueStandardError
         log_template_invocation_exception(e)
         raise e
       end

--- a/app/models/template_invocation.rb
+++ b/app/models/template_invocation.rb
@@ -17,7 +17,7 @@ class TemplateInvocation < ApplicationRecord
   has_one :host_group, :through => :host, :source => :hostgroup
   belongs_to :run_host_job_task, :class_name => 'ForemanTasks::Task'
   has_many :remote_execution_features, :through => :template
-  has_many :template_invocation_events
+  has_many :template_invocation_events, :dependent => :destroy
 
   validates_associated :input_values
   validate :provides_required_input_values

--- a/app/models/template_invocation.rb
+++ b/app/models/template_invocation.rb
@@ -17,6 +17,7 @@ class TemplateInvocation < ApplicationRecord
   has_one :host_group, :through => :host, :source => :hostgroup
   belongs_to :run_host_job_task, :class_name => 'ForemanTasks::Task'
   has_many :remote_execution_features, :through => :template
+  has_many :template_invocation_events
 
   validates_associated :input_values
   validate :provides_required_input_values

--- a/app/models/template_invocation_event.rb
+++ b/app/models/template_invocation_event.rb
@@ -1,0 +1,11 @@
+class TemplateInvocationEvent < ActiveRecord::Base
+  belongs_to :template_invocation
+
+  def as_raw_continuous_output
+    raw = attributes
+    raw['output_type'] = raw.delete('event_type')
+    raw['output'] = raw.delete('event')
+    raw['timestamp'] = raw['timestamp'].to_f
+    raw
+  end
+end

--- a/app/models/template_invocation_event.rb
+++ b/app/models/template_invocation_event.rb
@@ -1,4 +1,4 @@
-class TemplateInvocationEvent < ActiveRecord::Base
+class TemplateInvocationEvent < ::ApplicationRecord
   belongs_to :template_invocation
 
   def as_raw_continuous_output

--- a/db/migrate/20220713095705_create_template_invocation_events.rb
+++ b/db/migrate/20220713095705_create_template_invocation_events.rb
@@ -1,5 +1,6 @@
 class CreateTemplateInvocationEvents < ActiveRecord::Migration[6.1]
   def change
+    # rubocop:disable Rails/CreateTableWithTimestamps
     create_table :template_invocation_events do |t|
       t.references :template_invocation, :null => false
       t.timestamp :timestamp, :null => false
@@ -7,5 +8,6 @@ class CreateTemplateInvocationEvents < ActiveRecord::Migration[6.1]
       t.string :event, :null => false
       t.string :meta
     end
+    # rubocop:enable Rails/CreateTableWithTimestamps
   end
 end

--- a/db/migrate/20220713095705_create_template_invocation_events.rb
+++ b/db/migrate/20220713095705_create_template_invocation_events.rb
@@ -7,6 +7,10 @@ class CreateTemplateInvocationEvents < ActiveRecord::Migration[6.1]
       t.string :event_type, :null => false
       t.string :event, :null => false
       t.string :meta
+
+      t.index [:template_invocation_id, :timestamp, :event_type],
+        unique: true,
+        name: 'unique_template_invocation_events_index'
     end
     # rubocop:enable Rails/CreateTableWithTimestamps
   end

--- a/db/migrate/20220713095705_create_template_invocation_events.rb
+++ b/db/migrate/20220713095705_create_template_invocation_events.rb
@@ -1,0 +1,11 @@
+class CreateTemplateInvocationEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :template_invocation_events do |t|
+      t.references :template_invocation, :null => false
+      t.timestamp :timestamp, :null => false
+      t.string :event_type, :null => false
+      t.string :event, :null => false
+      t.string :meta
+    end
+  end
+end

--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface'
   s.add_dependency 'dynflow', '>= 1.0.2', '< 2.0.0'
-  s.add_dependency 'foreman-tasks', '>= 5.1.0'
+  s.add_dependency 'foreman-tasks', '>= 7.1.0'
 
   s.add_development_dependency 'factory_bot_rails', '~> 4.8.0'
   s.add_development_dependency 'rdoc'


### PR DESCRIPTION
Before this change all job outputs were stored deep in actions' outputs.
When we wanted to retrieve them, we had load an instance of the action
and then let it assemble all the outputs into a form that the rest of
the application could consume.

This is a first step away from it. Outputs now live in a separate table,
which gets populated as things happen.

TODO:
- [x] check all possible non-happy paths
- [x] make live output populate the events table and then read the data from there

In the future this should allow us to:
- have a more precise progress reporting (in spirit of https://github.com/theforeman/foreman_remote_execution/pull/712) by inserting "control" events into the log
- retrieve only new outputs from the smart proxy instead of retrieving all of them every single time
- load the outputs in chunks when showing them in the ui

Requires:
- https://github.com/theforeman/foreman-tasks/pull/689