### PR TITLE
Fixes #35307 - Do not rely on tasks always being there

### DIFF
--- a/app/models/host_status/execution_status.rb
+++ b/app/models/host_status/execution_status.rb
@@ -50,7 +50,8 @@ class HostStatus::ExecutionStatus < HostStatus::Status
   end
 
   def status_link
-    job_invocation = last_stopped_task.parent_task.job_invocations.first
+    job_invocation = last_stopped_task&.parent_task&.job_invocations&.first
+    return unless job_invocation
     return nil unless User.current.can?(:view_job_invocations, job_invocation)
 
     Rails.application.routes.url_helpers.job_invocation_path(job_invocation)


### PR DESCRIPTION
when calculating details of execution status.