### PR TITLE
Fixes #35308 - Make script provider name match proxy feature

### DIFF
--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -4,7 +4,7 @@ class RemoteExecutionProvider
 
   class << self
     def provider_for(type)
-      providers[type.to_s] || providers[:script]
+      providers[type.to_s] || providers[:Script]
     end
 
     def registered_name

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -334,7 +334,7 @@ module ForemanRemoteExecution
       ForemanTasks::Task.include ForemanRemoteExecution::ForemanTasksTaskExtensions
       ForemanTasks::Cleaner.include ForemanRemoteExecution::ForemanTasksCleanerExtensions
       RemoteExecutionProvider.register(:SSH, ::SSHExecutionProvider)
-      RemoteExecutionProvider.register(:script, ::ScriptExecutionProvider)
+      RemoteExecutionProvider.register(:Script, ::ScriptExecutionProvider)
 
       ForemanRemoteExecution.register_rex_feature
 

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -6,11 +6,11 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
     it { _(providers).must_be_kind_of HashWithIndifferentAccess }
     it 'makes providers accessible using symbol' do
       _(providers[:SSH]).must_equal SSHExecutionProvider
-      _(providers[:script]).must_equal ScriptExecutionProvider
+      _(providers[:Script]).must_equal ScriptExecutionProvider
     end
     it 'makes providers accessible using string' do
       _(providers['SSH']).must_equal SSHExecutionProvider
-      _(providers['script']).must_equal ScriptExecutionProvider
+      _(providers['Script']).must_equal ScriptExecutionProvider
     end
   end
 
@@ -32,6 +32,10 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
 
     it 'accepts strings' do
       RemoteExecutionProvider.provider_for('SSH').must_equal SSHExecutionProvider
+    end
+
+    it 'returns a default one if unknown value is provided' do
+      RemoteExecutionProvider.provider_for('WinRM').must_equal ScriptExecutionProvider
     end
   end
 


### PR DESCRIPTION
When assigning REX proxies to a subnet, proxy features are matched
exactly against registered REX provider names. Since there is a one
letter mismatch, proxies having only Script feature would not show as
available in the list.