### PR TITLE
Refs #35308 - Propagate the new registered name to more places

### DIFF
--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -213,7 +213,7 @@ class JobInvocation < ApplicationRecord
     providers = available_providers(host)
     providers.each do |provider|
       pattern_template_invocations.each do |template_invocation|
-        if template_invocation.template.provider_type.downcase == provider.downcase
+        if template_invocation.template.provider_type == provider
           return template_invocation
         end
       end

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -213,7 +213,7 @@ class JobInvocation < ApplicationRecord
     providers = available_providers(host)
     providers.each do |provider|
       pattern_template_invocations.each do |template_invocation|
-        if template_invocation.template.provider_type == provider
+        if template_invocation.template.provider_type.downcase == provider.downcase
           return template_invocation
         end
       end

--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -4,7 +4,7 @@ class RemoteExecutionProvider
 
   class << self
     def provider_for(type)
-      providers[type.to_s] || providers[:Script]
+      providers[type.to_s] || providers[:script]
     end
 
     def registered_name
@@ -26,6 +26,10 @@ class RemoteExecutionProvider
 
     def provider_names
       providers.keys.map(&:to_s)
+    end
+
+    def provider_proxy_features
+      providers.values.map(&:proxy_feature).flatten.uniq.compact
     end
 
     def proxy_command_options(template_invocation, host)

--- a/app/views/overrides/subnets/_rex_tab_pane.html.erb
+++ b/app/views/overrides/subnets/_rex_tab_pane.html.erb
@@ -1,5 +1,5 @@
 <div class="tab-pane" id="rex_proxies">
   <%= fields_for :subnet do |f| %>
-    <%= multiple_selects f, :remote_execution_proxies, SmartProxy.authorized.with_features(*RemoteExecutionProvider.provider_names).distinct, @subnet.remote_execution_proxy_ids, {:label => _("Proxies"), :help_inline => _("Select as many remote execution proxies as applicable for this subnet.  When multiple proxies with the same provider are added, actions will be load balanced among them.")} %>
+    <%= multiple_selects f, :remote_execution_proxies, SmartProxy.authorized.with_features(*RemoteExecutionProvider.provider_proxy_features).distinct, @subnet.remote_execution_proxy_ids, {:label => _("Proxies"), :help_inline => _("Select as many remote execution proxies as applicable for this subnet.  When multiple proxies with the same provider are added, actions will be load balanced among them.")} %>
   <% end %>
 </div>

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -334,7 +334,7 @@ module ForemanRemoteExecution
       ForemanTasks::Task.include ForemanRemoteExecution::ForemanTasksTaskExtensions
       ForemanTasks::Cleaner.include ForemanRemoteExecution::ForemanTasksCleanerExtensions
       RemoteExecutionProvider.register(:SSH, ::SSHExecutionProvider)
-      RemoteExecutionProvider.register(:Script, ::ScriptExecutionProvider)
+      RemoteExecutionProvider.register(:script, ::ScriptExecutionProvider)
 
       ForemanRemoteExecution.register_rex_feature
 

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -6,11 +6,11 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
     it { _(providers).must_be_kind_of HashWithIndifferentAccess }
     it 'makes providers accessible using symbol' do
       _(providers[:SSH]).must_equal SSHExecutionProvider
-      _(providers[:Script]).must_equal ScriptExecutionProvider
+      _(providers[:script]).must_equal ScriptExecutionProvider
     end
     it 'makes providers accessible using string' do
       _(providers['SSH']).must_equal SSHExecutionProvider
-      _(providers['Script']).must_equal ScriptExecutionProvider
+      _(providers['script']).must_equal ScriptExecutionProvider
     end
   end
 
@@ -53,6 +53,28 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
 
       it { _(provider_names).must_include 'SSH' }
       it { _(provider_names).must_include 'Custom' }
+    end
+  end
+
+  describe '.provider_proxy_features' do
+    it 'returns correct values' do
+      RemoteExecutionProvider.stubs(:providers).returns(
+        :SSH => SSHExecutionProvider,
+        :script => ScriptExecutionProvider
+      )
+
+      features = RemoteExecutionProvider.provider_proxy_features
+      _(features).must_include 'SSH'
+      _(features).must_include 'Script'
+      RemoteExecutionProvider.unstub(:providers)
+    end
+
+    it 'can deal with non-arrays' do
+      provider = OpenStruct.new(proxy_feature: 'Testing')
+      RemoteExecutionProvider.stubs(:providers).returns(:testing => provider)
+      features = RemoteExecutionProvider.provider_proxy_features
+      _(features).must_include 'Testing'
+      RemoteExecutionProvider.unstub(:providers)
     end
   end
 


### PR DESCRIPTION
Without this, running a job would fail with
`NoMethodError: undefined method 'host_id=' for ["SSH", "Script"]:Array`