### PR TITLE
refs #34970 - Host Registration - put interface back

### DIFF
--- a/webpack/react_app/extend/Fills.js
+++ b/webpack/react_app/extend/Fills.js
@@ -23,13 +23,12 @@ const fills = [
   {
     slot: 'registrationAdvanced',
     name: 'interface',
-    component: props => <RexInterface {...props} />,
-    weight: 500,
-  },
-  {
-    slot: 'registrationAdvanced',
-    name: 'pull',
-    component: props => <RexPull {...props} />,
+    component: props => (
+      <>
+        <RexInterface {...props} />
+        <RexPull {...props} />
+      </>
+    ),
     weight: 500,
   },
   {


### PR DESCRIPTION
Changes from PR#725 accidentaly removes interface
field from registration form.

[0] https://github.com/theforeman/foreman_remote_execution/pull/725