### PR TITLE
Fixes #35471 - Slot & Fill renders only one component

### DIFF
--- a/webpack/react_app/extend/Fills.js
+++ b/webpack/react_app/extend/Fills.js
@@ -23,12 +23,13 @@ const fills = [
   {
     slot: 'registrationAdvanced',
     name: 'interface',
-    component: props => (
-      <>
-        <RexInterface {...props} />
-        <RexPull {...props} />
-      </>
-    ),
+    component: props => <RexInterface {...props} />,
+    weight: 500,
+  },
+  {
+    slot: 'registrationAdvanced',
+    name: 'pull',
+    component: props => <RexPull {...props} />,
     weight: 500,
   },
   {
@@ -40,11 +41,11 @@ const fills = [
 ];
 
 const registerFills = () => {
-  fills.forEach(({ slot, id, component: Component, weight, metadata }) =>
+  fills.forEach(({ slot, name, component: Component, weight, metadata }) =>
     addGlobalFill(
       slot,
-      id,
-      <Component key={`rex-fill-${id}`} />,
+      `rex-${name}`,
+      <Component key={`rex-${name}`} />,
       weight,
       metadata
     )


### PR DESCRIPTION
undoing - https://github.com/theforeman/foreman_remote_execution/pull/754
the `name` key was not used and `id` was used instead, `id` was always undefined.