### PR TITLE
Fixes #35515 - Fix proxy selection for subclassed providers

### DIFF
--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -9,7 +9,7 @@ class RemoteExecutionProvider
 
     def registered_name
       klass = self
-      providers.key(klass)
+      ::RemoteExecutionProvider.providers.key(klass)
     end
 
     def proxy_feature

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -56,6 +56,28 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
     end
   end
 
+  describe '.proxy_feature' do
+    # rubocop:disable Naming/ConstantName
+    it 'handles provider subclasses properly' do
+      old = ::RemoteExecutionProvider
+
+      class P2 < old
+      end
+      ::RemoteExecutionProvider = P2
+
+      class CustomProvider < ::RemoteExecutionProvider
+      end
+
+      ::RemoteExecutionProvider.register('custom', CustomProvider)
+
+      feature = CustomProvider.proxy_feature
+      _(feature).must_equal 'custom'
+    ensure
+      ::RemoteExecutionProvider = old
+    end
+    # rubocop:enable Naming/ConstantName
+  end
+
   describe '.provider_proxy_features' do
     it 'returns correct values' do
       RemoteExecutionProvider.stubs(:providers).returns(


### PR DESCRIPTION
::RemoteExecutionProvider does a lookup inside class instance variables set on it. When a custom provider subclasses ::RemoteExecutionProvider, this lookup is done inside the subclass, where the variables are not set so this lookup returns nil.

The other piece is `Host::Managed#remote_execution_proxies(provider)` returning all the proxies, if `provider` is `nil`.

The unfortunate outcome of those two above is that when using subclassed providers (such as in Ansible), proxies were not filtered based on available features.

The fix causes the lookup to be performed on the top-level class, instead of in the subclass.