### PR TITLE
Fixes #35584 - Make job wizard the default way to create jobs

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -45,8 +45,7 @@ class JobInvocationsController < ApplicationController
     if @composer.trigger
       redirect_to job_invocation_path(@composer.job_invocation)
     else
-      @composer.job_invocation.description_format = nil if params.fetch(:job_invocation, {}).key?(:description_override)
-      render :action => 'new'
+      redirect_to new_job_invocation_path({:inputs => params[:inputs], :feature => params[:feature], :host_ids => params[:host_ids]})
     end
   end
 

--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -62,7 +62,7 @@ class UiJobWizardController < ApplicationController
     job = JobInvocation.authorized.find(params[:id])
     composer = JobInvocationComposer.from_job_invocation(job, params).params
     job_template_inputs = JobTemplate.authorized.find(composer[:template_invocations][0][:template_id]).template_inputs_with_foreign
-    inputs = Hash[job_template_inputs.map { |input| ["inputs[#{input[:name]}]", (composer[:template_invocations][0][:input_values].find { |value| value[:template_input_id] == input[:id] })[:value]] }]
+    inputs = Hash[job_template_inputs.map { |input| ["inputs[#{input[:name]}]", {:advanced => input[:advanced], :value => (composer[:template_invocations][0][:input_values].find { |value| value[:template_input_id] == input[:id] })[:value]}] }]
     job_organization = Taxonomy.find_by(id: job.task.input[:current_organization_id])
     job_location = Taxonomy.find_by(id: job.task.input[:current_location_id])
     render :json => {

--- a/app/helpers/job_invocations_helper.rb
+++ b/app/helpers/job_invocations_helper.rb
@@ -13,13 +13,6 @@ module JobInvocationsHelper
     end
   end
 
-  def job_invocations_buttons
-    [
-      documentation_button_rex('3.2ExecutingaJob'),
-      display_link_if_authorized(_('Run Job'), hash_for_new_job_invocation_path),
-    ]
-  end
-
   def template_name_and_provider_link(template)
     template_name = content_tag(:strong, template.name)
     provider = template.provider.humanized_name

--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -56,7 +56,7 @@ module RemoteExecutionHelper
   def job_invocations_buttons
     [
       documentation_button_rex('3.2ExecutingaJob'),
-      new_link(_('Run Job')),
+      display_link_if_authorized(_('Run Job'), hash_for_new_job_invocation_path, {:class => "btn btn-primary"}),
     ]
   end
 

--- a/app/views/job_invocations/new.html.erb
+++ b/app/views/job_invocations/new.html.erb
@@ -1,4 +1,9 @@
 <% javascript 'foreman_remote_execution/template_invocation' %>
 <% stylesheet 'foreman_remote_execution/foreman_remote_execution' %>
 <% title _('Job invocation') %>
+<% if(request.path_parameters[:action] == "rerun") %>
+  <%= display_link_if_authorized(_('Use new job wizard'), hash_for_rerun_job_invocation_path({:id => request.path_parameters[:id]}).merge(request.query_parameters)) %>
+<% else %>
+  <%= display_link_if_authorized(_('Use new job wizard'), hash_for_new_job_invocation_path().merge(request.query_parameters)) %>
+<%end%>
 <%= render :partial => 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Rails.application.routes.draw do
     end
   end
 
-  match 'job_invocations/new', to: 'job_invocations#new', via: [:get, :post], as: 'new_job_invocation'
+  match 'job_invocations/new', to: 'react#index', :via => [:get], as: 'new_job_invocation'
+  match 'job_invocations/new', to: 'job_invocations#create', via: [:post], as: 'create_job_invocation'
+  match 'job_invocations/:id/rerun', to: 'react#index', :via => [:get], as: 'rerun_job_invocation'
+  match 'old/job_invocations/new', to: 'job_invocations#new', via: [:get], as: 'form_new_job_invocation'
+  match 'old/job_invocations/:id/rerun', to: 'job_invocations#rerun', via: [:get, :post], as: 'form_rerun_job_invocation'
   resources :job_invocations, :only => [:create, :show, :index] do
     collection do
       post 'refresh'
@@ -25,7 +29,6 @@ Rails.application.routes.draw do
       get 'auto_complete_search'
     end
     member do
-      get 'rerun'
       post 'cancel'
     end
   end
@@ -47,9 +50,6 @@ Rails.application.routes.draw do
   get 'ui_job_wizard/template/:id', to: 'ui_job_wizard#template'
   get 'ui_job_wizard/resources', to: 'ui_job_wizard#resources'
   get 'ui_job_wizard/job_invocation', to: 'ui_job_wizard#job_invocation'
-
-  match '/experimental/job_wizard/new', to: 'react#index', :via => [:get]
-  match '/experimental/job_wizard/:id/rerun', to: 'react#index', :via => [:get]
 
   namespace :api, :defaults => {:format => 'json'} do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -243,13 +243,6 @@ module ForemanRemoteExecution
           parent: :monitor_menu,
           after: :audits
 
-        menu :labs_menu, :job_wizard,
-          url_hash: { controller: 'job_wizard', action: :index },
-          caption: N_('Job wizard'),
-          parent: :lab_features_menu,
-          url: '/experimental/job_wizard/new',
-          after: :host_wizard
-
         register_custom_status HostStatus::ExecutionStatus
         # add dashboard widget
         # widget 'foreman_remote_execution_widget', name: N_('Foreman plugin template widget'), sizex: 4, sizey: 1

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -64,7 +64,7 @@ export const dataName = {
 };
 export const HOSTS_TO_PREVIEW_AMOUNT = 20;
 
-export const DEBOUNCE_HOST_COUNT = 700;
+export const DEBOUNCE_HOST_COUNT = 1500;
 export const HOST_IDS = 'HOST_IDS';
 export const REX_FEATURE = 'REX_FEATURE';
 

--- a/webpack/JobWizard/JobWizardPageRerun.js
+++ b/webpack/JobWizard/JobWizardPageRerun.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import URI from 'urijs';
-import { Alert, Title, Divider, Skeleton } from '@patternfly/react-core';
+import {
+  Alert,
+  Title,
+  Divider,
+  Skeleton,
+  Flex,
+  FlexItem,
+  Button,
+} from '@patternfly/react-core';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
@@ -31,7 +39,7 @@ const JobWizardPageRerun = ({
   const title = __('Run job');
   const breadcrumbOptions = {
     breadcrumbItems: [
-      { caption: __('Jobs'), url: `/jobs` },
+      { caption: __('Jobs'), url: `/job_invocations` },
       { caption: title },
     ],
   };
@@ -48,9 +56,25 @@ const JobWizardPageRerun = ({
       searchable={false}
     >
       <React.Fragment>
-        <Title headingLevel="h2" size="2xl">
-          {title}
-        </Title>
+        <React.Fragment>
+          <Flex>
+            <FlexItem>
+              <Title headingLevel="h2" size="2xl">
+                {title}
+              </Title>
+            </FlexItem>
+            <FlexItem align={{ default: 'alignRight' }}>
+              <Button
+                variant="link"
+                component="a"
+                href={`/old/job_invocations/${id}/rerun${search}`}
+              >
+                {__('Use old form')}
+              </Button>
+            </FlexItem>
+          </Flex>
+          <Divider component="div" />
+        </React.Fragment>
         {!status || status === STATUS.PENDING ? (
           <div style={{ height: '400px' }}>
             <Skeleton

--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -24,11 +24,17 @@ export const filterJobTemplates = templates =>
 export const selectJobTemplates = state =>
   filterJobTemplates(selectAPIResponse(state, JOB_TEMPLATES)?.results);
 
+export const selectJobTemplatesSearch = state =>
+  selectAPIResponse(state, JOB_TEMPLATES)?.search;
+
+export const selectJobCategoriesResponse = state =>
+  selectAPIResponse(state, JOB_CATEGORIES) || {};
+
 export const selectJobCategories = state =>
-  selectAPIResponse(state, JOB_CATEGORIES).job_categories || [];
+  selectJobCategoriesResponse(state).job_categories || [];
 
 export const selectWithKatello = state =>
-  selectAPIResponse(state, JOB_CATEGORIES).with_katello || false;
+  selectJobCategoriesResponse(state).with_katello || false;
 
 export const selectJobCategoriesStatus = state =>
   selectAPIStatus(state, JOB_CATEGORIES);

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,14 +1,15 @@
 import React from 'react';
-import { Title, Divider } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import { Title, Divider, Flex, FlexItem, Button } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { JobWizard } from './JobWizard';
 
-const JobWizardPage = () => {
+const JobWizardPage = ({ location: { search } }) => {
   const title = __('Run job');
   const breadcrumbOptions = {
     breadcrumbItems: [
-      { caption: __('Jobs'), url: `/jobs` },
+      { caption: __('Jobs'), url: `/job_invocations` },
       { caption: title },
     ],
   };
@@ -19,9 +20,22 @@ const JobWizardPage = () => {
       searchable={false}
     >
       <React.Fragment>
-        <Title headingLevel="h2" size="2xl">
-          {title}
-        </Title>
+        <Flex>
+          <FlexItem>
+            <Title headingLevel="h2" size="2xl">
+              {title}
+            </Title>
+          </FlexItem>
+          <FlexItem align={{ default: 'alignRight' }}>
+            <Button
+              variant="link"
+              component="a"
+              href={`/old/job_invocations/new${search}`}
+            >
+              {__('Use legacy form')}
+            </Button>
+          </FlexItem>
+        </Flex>
         <Divider component="div" />
         <JobWizard />
       </React.Fragment>
@@ -29,4 +43,9 @@ const JobWizardPage = () => {
   );
 };
 
+JobWizardPage.propTypes = {
+  location: PropTypes.shape({
+    search: PropTypes.string,
+  }).isRequired,
+};
 export default JobWizardPage;

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -315,7 +315,7 @@ describe('AdvancedFields', () => {
             data: {
               ...jobTemplateResponse,
               job_template: {
-                ...jobTemplateResponse.jobTemplate,
+                ...jobTemplateResponse.job_template,
                 description_format: 'Run %{command}',
               },
 

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.js
@@ -42,8 +42,10 @@ export const CategoryAndTemplate = ({
   )?.name;
 
   const onSelectCategory = newCategory => {
-    setCategory(newCategory);
-    setJobTemplate(null);
+    if (selectedCategory !== newCategory) {
+      setCategory(newCategory);
+      setJobTemplate(null);
+    }
   };
   const { categoryError, allTemplatesError, templateError } = errors;
   const isError = !!(categoryError || allTemplatesError || templateError);

--- a/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.test.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/CategoryAndTemplate.test.js
@@ -43,14 +43,18 @@ describe('Category And Template', () => {
 
     // Template
     fireEvent.click(
-      screen.getByDisplayValue('template1', { selector: 'button' })
+      screen.getByDisplayValue('Puppet Agent Disable - Script Default', {
+        selector: 'button',
+      })
     );
     await act(async () => {
       await fireEvent.click(screen.getByText('template2'));
     });
     fireEvent.click(screen.getAllByText(WIZARD_TITLES.categoryAndTemplate)[0]); // to remove focus
     expect(
-      screen.queryAllByDisplayValue('template1', { selector: 'button' })
+      screen.queryAllByDisplayValue('Puppet Agent Disable - Script Default', {
+        selector: 'button',
+      })
     ).toHaveLength(0);
     expect(
       screen.queryAllByDisplayValue('template2', { selector: 'button' })

--- a/webpack/JobWizard/steps/CategoryAndTemplate/index.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/index.js
@@ -11,6 +11,7 @@ import {
   selectCategoryError,
   selectAllTemplatesError,
   selectTemplateError,
+  selectJobTemplatesSearch,
 } from '../../JobWizardSelectors';
 import { CategoryAndTemplate } from './CategoryAndTemplate';
 
@@ -46,7 +47,8 @@ const ConnectedCategoryAndTemplate = ({
           }) => {
             if (!isCategoryPreselected) {
               setCategory(defaultCategory || jobCategories[0] || '');
-              if (defaultTemplate) setJobTemplate(defaultTemplate);
+              if (defaultTemplate)
+                setJobTemplate(current => current || defaultTemplate);
             }
           },
         })
@@ -56,27 +58,33 @@ const ConnectedCategoryAndTemplate = ({
   }, [jobCategoriesStatus]);
 
   const jobCategories = useSelector(selectJobCategories);
+  const jobTemplatesSearch = useSelector(selectJobTemplatesSearch);
   useEffect(() => {
     if (category) {
-      const templatesUrlObject = new URI(templatesUrl);
-      dispatch(
-        get({
-          key: JOB_TEMPLATES,
-          url: templatesUrlObject.addSearch({
-            search: `job_category="${category}"`,
-            per_page: 'all',
-          }),
-          handleSuccess: response => {
-            if (!jobTemplate)
-              setJobTemplate(
-                current =>
-                  current ||
-                  Number(filterJobTemplates(response?.data?.results)[0]?.id) ||
-                  null
-              );
-          },
-        })
-      );
+      const newJobTemplatesSearch = `job_category="${category}"`;
+      if (jobTemplatesSearch !== newJobTemplatesSearch) {
+        const templatesUrlObject = new URI(templatesUrl);
+        dispatch(
+          get({
+            key: JOB_TEMPLATES,
+            url: templatesUrlObject.addSearch({
+              search: newJobTemplatesSearch,
+              per_page: 'all',
+            }),
+            handleSuccess: response => {
+              if (!jobTemplate)
+                setJobTemplate(
+                  current =>
+                    current ||
+                    Number(
+                      filterJobTemplates(response?.data?.results)[0]?.id
+                    ) ||
+                    null
+                );
+            },
+          })
+        );
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [category, dispatch]);

--- a/webpack/JobWizard/submit.js
+++ b/webpack/JobWizard/submit.js
@@ -70,7 +70,7 @@ export const submit = ({
         : 'dynamic_query',
       randomized_ordering: isRandomizedOrdering,
       inputs: { ...templateValues, ...advancedTemplateValues },
-      ssh_user: sshUser,
+      ssh_user: sshUser || null,
       ssh: {
         effective_user: effectiveUserValue,
         effective_user_password: effectiveUserPassword,

--- a/webpack/Routes/routes.js
+++ b/webpack/Routes/routes.js
@@ -4,12 +4,12 @@ import JobWizardPageRerun from '../JobWizard/JobWizardPageRerun';
 
 const ForemanREXRoutes = [
   {
-    path: '/experimental/job_wizard/new',
+    path: '/job_invocations/new',
     exact: true,
-    render: () => <JobWizardPage />,
+    render: props => <JobWizardPage {...props} />,
   },
   {
-    path: '/experimental/job_wizard/:id/rerun',
+    path: '/job_invocations/:id/rerun',
     exact: true,
     render: props => <JobWizardPageRerun {...props} />,
   },


### PR DESCRIPTION
* move job wizard from `/experimental/job_wizard/new` to `job_invocations/new`
* move job form from `job_invocations/new` to `old/job_invocations/new`
* remove job wizard from the lab menu tab
* fix bug where hosts list in the url can be a single host (and not an array)
* fix bug where users get to the wizard from the host details page, and then go back (to host details) and again to the job wizard caused some data to be not displayed correctly in the wizard because the `component state` was deleted but the `redux store` stayed the same
* remove unused `job_invocations_buttons` 
* fixed wizards breadcrumbs to go to the correct all jobs url
* if users want to use the old form/new wizard there is a link to the other type in the form/wizard