### PR TITLE
Fixes #35644 - Allow host details features open job form

### DIFF
--- a/webpack/react_app/components/FeaturesDropdown/actions.js
+++ b/webpack/react_app/components/FeaturesDropdown/actions.js
@@ -7,7 +7,28 @@ export const runFeature = (hostId, feature, label) => dispatch => {
     `/job_invocations?feature=${feature}&host_ids%5B%5D=${hostId}`
   );
 
-  const successToast = () => sprintf(__('%s job has been invoked'), label);
+  const successToast = ({ request }) => {
+    if (request.responseURL.includes('job_invocations?')) {
+      return __('Opening job invocation form');
+    }
+    return sprintf(__('%s job has been invoked'), label);
+  };
   const errorToast = ({ message }) => message;
-  dispatch(post({ key: feature.toUpperCase(), url, successToast, errorToast }));
+  dispatch(
+    post({
+      key: feature.toUpperCase(),
+      url,
+      successToast,
+      errorToast,
+      handleSuccess: ({ request }) => {
+        if (request.responseURL.includes('job_invocations?')) {
+          // checking if user should be redicted to finish setting up the job
+          window.location.href = request.responseURL.replace(
+            'job_invocations?',
+            'job_invocations/new?'
+          );
+        }
+      },
+    })
+  );
 };


### PR DESCRIPTION
in the new host details page, in the "schedule a job" drop down.
currently the `runFeature` function assumes that by calling post `/job_invocations?feature=${feature}&host_ids%5B%5D=${hostId}` the job would be executed, but sometimes the call will be redirected to the job form
the options for the `responseURL` are
* `.../job_invocations/78`
* `.../job_invocations?feature=leapp_upgrade&host_ids%5B%5D=139`

Left the success toast as there is no way for the ui knowing if it will be redirected or not before receiving a response