### PR TITLE
Fixes #35721 - reset to default button to job wizard fields

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -35,6 +35,7 @@ import ReviewDetails from './steps/ReviewDetails/';
 import { useValidation } from './validation';
 import { useAutoFill } from './autofill';
 import { submit } from './submit';
+import { generateDefaultDescription } from './JobWizardHelpers';
 import './JobWizard.scss';
 
 export const JobWizard = ({ rerunData }) => {
@@ -66,20 +67,6 @@ export const JobWizard = ({ rerunData }) => {
       : routerSearch
   );
   const dispatch = useDispatch();
-  const generateDefaultDescription = ({
-    description_format,
-    advancedInputs,
-    inputs,
-    name,
-  }) => {
-    if (description_format) return description_format;
-    const allInputs = [...advancedInputs, ...inputs];
-    if (!allInputs.length) return name;
-    const inputsString = allInputs
-      .map(({ name: inputname }) => `${inputname}="%{${inputname}}"`)
-      .join(' ');
-    return `${name} with inputs ${inputsString}`;
-  };
 
   const setDefaults = useCallback(
     ({

--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -145,6 +145,9 @@
   .pf-c-radio__body {
     font-size: var(--pf-c-radio__label--FontSize);
   }
+  .reset-default{
+    padding-bottom: 0;
+  }
 }
 
 .job-wizard-alert.pf-c-alert.pf-m-warning {

--- a/webpack/JobWizard/JobWizardHelpers.js
+++ b/webpack/JobWizard/JobWizardHelpers.js
@@ -1,0 +1,15 @@
+/* eslint-disable camelcase */
+export const generateDefaultDescription = ({
+  description_format,
+  advancedInputs,
+  inputs,
+  name,
+}) => {
+  if (description_format) return description_format;
+  const allInputs = [...advancedInputs, ...inputs];
+  if (!allInputs.length) return name;
+  const inputsString = allInputs
+    .map(({ name: inputname }) => `${inputname}="%{${inputname}}"`)
+    .join(' ');
+  return `${name} with inputs ${inputsString}`;
+};

--- a/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/AdvancedFields.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
@@ -5,7 +6,9 @@ import { Form } from '@patternfly/react-core';
 import {
   selectEffectiveUser,
   selectAdvancedTemplateInputs,
+  selectJobTemplate,
 } from '../../JobWizardSelectors';
+import { generateDefaultDescription } from '../../JobWizardHelpers';
 import {
   EffectiveUserField,
   TimeoutToKillField,
@@ -29,6 +32,7 @@ export const AdvancedFields = ({
 }) => {
   const effectiveUser = useSelector(selectEffectiveUser);
   const advancedTemplateInputs = useSelector(selectAdvancedTemplateInputs);
+  const jobTemplate = useSelector(selectJobTemplate);
   return (
     <>
       <WizardTitle
@@ -40,9 +44,11 @@ export const AdvancedFields = ({
           inputs={advancedTemplateInputs}
           value={advancedValues.templateValues}
           setValue={newValue => setAdvancedValues({ templateValues: newValue })}
+          defaultValue={jobTemplate}
         />
         <SSHUserField
           value={advancedValues.sshUser}
+          defaultValue={jobTemplate.ssh_user}
           setValue={newValue =>
             setAdvancedValues({
               sshUser: newValue,
@@ -52,6 +58,7 @@ export const AdvancedFields = ({
         {effectiveUser?.overridable && (
           <EffectiveUserField
             value={advancedValues.effectiveUserValue}
+            defaultValue={jobTemplate.effective_user?.value}
             setValue={newValue =>
               setAdvancedValues({
                 effectiveUserValue: newValue,
@@ -63,9 +70,16 @@ export const AdvancedFields = ({
           inputValues={{ ...templateValues, ...advancedValues.templateValues }}
           value={advancedValues.description}
           setValue={newValue => setAdvancedValues({ description: newValue })}
+          defaultValue={generateDefaultDescription({
+            description_format: jobTemplate.job_template.description_format,
+            advancedInputs: jobTemplate.advanced_template_inputs,
+            inputs: jobTemplate.template_inputs,
+            name: jobTemplate.job_template.name,
+          })}
         />
         <TimeoutToKillField
           value={advancedValues.timeoutToKill}
+          defaultValue={jobTemplate.job_template.execution_timeout_interval}
           setValue={newValue =>
             setAdvancedValues({
               timeoutToKill: newValue,
@@ -98,6 +112,7 @@ export const AdvancedFields = ({
         />
         <ConcurrencyLevelField
           value={advancedValues.concurrencyLevel}
+          defaultValue={jobTemplate.concurrency_control?.level}
           setValue={newValue =>
             setAdvancedValues({
               concurrencyLevel: newValue,
@@ -106,6 +121,7 @@ export const AdvancedFields = ({
         />
         <TimeSpanLevelField
           value={advancedValues.timeSpan}
+          defaultValue={jobTemplate.concurrency_control?.time_span}
           setValue={newValue =>
             setAdvancedValues({
               timeSpan: newValue,

--- a/webpack/JobWizard/steps/AdvancedFields/DescriptionField.js
+++ b/webpack/JobWizard/steps/AdvancedFields/DescriptionField.js
@@ -7,8 +7,14 @@ import {
   selectTemplateInputs,
   selectAdvancedTemplateInputs,
 } from '../../JobWizardSelectors';
+import { ResetDefault } from '../form/FormHelpers';
 
-export const DescriptionField = ({ inputValues, value, setValue }) => {
+export const DescriptionField = ({
+  inputValues,
+  value,
+  setValue,
+  defaultValue,
+}) => {
   const inputs = [
     ...useSelector(selectTemplateInputs),
     ...useSelector(selectAdvancedTemplateInputs),
@@ -45,6 +51,9 @@ export const DescriptionField = ({ inputValues, value, setValue }) => {
   return (
     <FormGroup
       label={__('Description')}
+      labelInfo={
+        <ResetDefault setValue={setValue} defaultValue={defaultValue} />
+      }
       fieldId="description"
       helperText={
         <Button variant="link" isInline onClick={togglePreview}>
@@ -84,7 +93,9 @@ DescriptionField.propTypes = {
   inputValues: PropTypes.object.isRequired,
   value: PropTypes.string,
   setValue: PropTypes.func.isRequired,
+  defaultValue: PropTypes.string,
 };
 DescriptionField.defaultProps = {
   value: '',
+  defaultValue: '',
 };

--- a/webpack/JobWizard/steps/AdvancedFields/Fields.js
+++ b/webpack/JobWizard/steps/AdvancedFields/Fields.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, TextInput, Radio } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { helpLabel } from '../form/FormHelpers';
+import { helpLabel, ResetDefault } from '../form/FormHelpers';
 import { formatter } from '../form/Formatter';
 import { NumberInput } from '../form/NumberInput';
 
-export const EffectiveUserField = ({ value, setValue }) => (
+export const EffectiveUserField = ({ value, setValue, defaultValue }) => (
   <FormGroup
     label={__('Effective user')}
     labelIcon={helpLabel(
@@ -16,6 +16,7 @@ export const EffectiveUserField = ({ value, setValue }) => (
       'effective-user'
     )}
     fieldId="effective-user"
+    labelInfo={<ResetDefault setValue={setValue} defaultValue={defaultValue} />}
   >
     <TextInput
       aria-label="effective user"
@@ -28,7 +29,7 @@ export const EffectiveUserField = ({ value, setValue }) => (
   </FormGroup>
 );
 
-export const TimeoutToKillField = ({ value, setValue }) => (
+export const TimeoutToKillField = ({ value, setValue, defaultValue }) => (
   <NumberInput
     formProps={{
       label: __('Timeout to kill'),
@@ -39,6 +40,9 @@ export const TimeoutToKillField = ({ value, setValue }) => (
         'timeout-to-kill'
       ),
       fieldId: 'timeout-to-kill',
+      labelInfo: (
+        <ResetDefault setValue={setValue} defaultValue={defaultValue} />
+      ),
     }}
     inputProps={{
       value,
@@ -119,7 +123,7 @@ export const EffectiveUserPasswordField = ({ value, setValue }) => (
   </FormGroup>
 );
 
-export const ConcurrencyLevelField = ({ value, setValue }) => (
+export const ConcurrencyLevelField = ({ value, setValue, defaultValue }) => (
   <NumberInput
     formProps={{
       label: __('Concurrency level'),
@@ -130,6 +134,9 @@ export const ConcurrencyLevelField = ({ value, setValue }) => (
         'concurrency-level'
       ),
       fieldId: 'concurrency-level',
+      labelInfo: (
+        <ResetDefault setValue={setValue} defaultValue={defaultValue} />
+      ),
     }}
     inputProps={{
       min: 1,
@@ -142,7 +149,7 @@ export const ConcurrencyLevelField = ({ value, setValue }) => (
   />
 );
 
-export const TimeSpanLevelField = ({ value, setValue }) => (
+export const TimeSpanLevelField = ({ value, setValue, defaultValue }) => (
   <NumberInput
     formProps={{
       label: __('Time span'),
@@ -153,6 +160,9 @@ export const TimeSpanLevelField = ({ value, setValue }) => (
         'time-span'
       ),
       fieldId: 'time-span',
+      labelInfo: (
+        <ResetDefault setValue={setValue} defaultValue={defaultValue} />
+      ),
     }}
     inputProps={{
       min: 1,
@@ -204,11 +214,12 @@ export const TemplateInputsFields = ({ inputs, value, setValue }) => (
   <>{inputs?.map(input => formatter(input, value, setValue))}</>
 );
 
-export const SSHUserField = ({ value, setValue }) => (
+export const SSHUserField = ({ value, setValue, defaultValue }) => (
   <FormGroup
     label={__('SSH user')}
     labelIcon={helpLabel(__('A user to be used for SSH.'), 'ssh-user')}
     fieldId="ssh-user"
+    labelInfo={<ResetDefault setValue={setValue} defaultValue={defaultValue} />}
   >
     <TextInput
       aria-label="ssh user"
@@ -224,9 +235,11 @@ export const SSHUserField = ({ value, setValue }) => (
 EffectiveUserField.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   setValue: PropTypes.func.isRequired,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 EffectiveUserField.defaultProps = {
   value: '',
+  defaultValue: null,
 };
 
 TimeoutToKillField.propTypes = EffectiveUserField.propTypes;

--- a/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/__tests__/TemplateInputs.test.js
@@ -50,4 +50,36 @@ describe('TemplateInputs', () => {
     });
     expect(textField.value).toBe(textValue);
   });
+  it('should set back default data', async () => {
+    render(
+      <MockedProvider mocks={gqlMock} addTypename={false}>
+        <Provider store={store}>
+          <JobWizard />
+        </Provider>
+      </MockedProvider>
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByText(WIZARD_TITLES.hostsAndInputs));
+    });
+    const textValue = 'I am a plain text';
+    const textField = screen.getByLabelText('plain hidden', {
+      selector: 'textarea',
+    });
+
+    await act(async () => {
+      await fireEvent.change(textField, {
+        target: { value: textValue },
+      });
+    });
+    expect(
+      screen.getByLabelText('plain hidden', {
+        selector: 'textarea',
+      }).value
+    ).toBe(textValue);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Reset to default'));
+    });
+    expect(textField.value).toBe('Default val');
+  });
 });

--- a/webpack/JobWizard/steps/form/FormHelpers.js
+++ b/webpack/JobWizard/steps/form/FormHelpers.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Popover } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import { Popover, Button } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 
@@ -22,3 +23,22 @@ export const helpLabel = (text, id) => {
 export const isPositiveNumber = text => parseInt(text, 10) > 0;
 
 export const isValidDate = d => d instanceof Date && !Number.isNaN(d);
+
+export const ResetDefault = ({ setValue, defaultValue }) =>
+  defaultValue && (
+    <Button
+      className="reset-default"
+      component="a"
+      variant="link"
+      isSmall
+      onClick={() => setValue(defaultValue)}
+    >
+      {__('Reset to default')}
+    </Button>
+  );
+
+ResetDefault.propTypes = {
+  setValue: PropTypes.func.isRequired,
+  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+ResetDefault.defaultProps = { defaultValue: null };

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -6,7 +6,7 @@ import SearchBar from 'foremanReact/components/SearchBar';
 import { getControllerSearchProps } from 'foremanReact/constants';
 import { TRIGGERS } from 'foremanReact/components/AutoComplete/AutoCompleteConstants';
 import { getResults } from 'foremanReact/components/AutoComplete/AutoCompleteActions';
-import { helpLabel } from './FormHelpers';
+import { helpLabel, ResetDefault } from './FormHelpers';
 import { SelectField } from './SelectField';
 import { ResourceSelect } from './ResourceSelect';
 import { DateTimePicker } from '../form/DateTimePicker';
@@ -48,12 +48,15 @@ const TemplateSearchField = ({
     <FormGroup
       label={name}
       labelIcon={helpLabel(labelText, name)}
+      labelInfo={
+        <ResetDefault defaultValue={defaultValue} setValue={setSearch} />
+      }
       fieldId={id}
       isRequired={required}
       className="foreman-search-field"
     >
       <SearchBar
-        initialQuery={defaultValue}
+        initialQuery={values[name]}
         data={{
           ...props,
           autocomplete: {
@@ -80,10 +83,19 @@ export const formatter = (input, values, setValue) => {
     hidden_value: hidden,
     resource_type: resourceType,
     value_type: valueType,
+    default: defaultValue,
   } = input;
   const labelText = input.description;
   const value = values[name];
   const id = name.replace(/ /g, '-');
+
+  const labelInfo = (
+    <ResetDefault
+      defaultValue={defaultValue}
+      setValue={newValue => setValue({ ...values, [name]: newValue })}
+    />
+  );
+
   if (valueType === 'resource') {
     return (
       <FormGroup
@@ -92,6 +104,7 @@ export const formatter = (input, values, setValue) => {
         labelIcon={helpLabel(labelText, name)}
         isRequired={required}
         key={id}
+        labelInfo={labelInfo}
       >
         <ResourceSelect
           name={name}
@@ -107,6 +120,7 @@ export const formatter = (input, values, setValue) => {
     const options = input.options.split(/\r?\n/).map(option => option.trim());
     return (
       <SelectField
+        labelInfo={labelInfo}
         key={id}
         isRequired={required}
         label={name}
@@ -121,6 +135,7 @@ export const formatter = (input, values, setValue) => {
   if (isTextType) {
     return (
       <FormGroup
+        labelInfo={labelInfo}
         key={name}
         label={name}
         labelIcon={helpLabel(labelText, name)}
@@ -142,6 +157,7 @@ export const formatter = (input, values, setValue) => {
   if (inputType === 'date') {
     return (
       <FormGroup
+        labelInfo={labelInfo}
         key={name}
         label={name}
         labelIcon={helpLabel(labelText, name)}
@@ -165,7 +181,7 @@ export const formatter = (input, values, setValue) => {
       <TemplateSearchField
         key={id}
         name={name}
-        defaultValue={value}
+        defaultValue={defaultValue}
         controller={controller}
         url={`/${controller}/auto_complete_search`}
         labelText={labelText}

--- a/webpack/JobWizard/steps/form/SelectField.js
+++ b/webpack/JobWizard/steps/form/SelectField.js
@@ -3,6 +3,7 @@ import { FormGroup, Select, SelectOption } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
 export const SelectField = ({
+  labelInfo,
   label,
   fieldId,
   options,
@@ -29,6 +30,7 @@ export const SelectField = ({
   ];
   return (
     <FormGroup
+      labelInfo={labelInfo}
       label={label}
       fieldId={fieldId}
       labelIcon={labelIcon}
@@ -54,6 +56,7 @@ export const SelectField = ({
 };
 SelectField.propTypes = {
   label: PropTypes.string,
+  labelInfo: PropTypes.node,
   fieldId: PropTypes.string.isRequired,
   options: PropTypes.array,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
@@ -64,6 +67,7 @@ SelectField.propTypes = {
 
 SelectField.defaultProps = {
   label: null,
+  labelInfo: null,
   options: [],
   labelIcon: null,
   value: null,


### PR DESCRIPTION
Adds a button next to every field that can have a default value to reset the field to that value.
Will show button only for fields that have a default value
example screenshot:
![Screenshot from 2022-11-04 20-03-34](https://user-images.githubusercontent.com/30431079/200055130-88dbb648-53e4-4504-8959-d494dc96ec81.png)
