### PR TITLE
Fixes #35725 - job wizard resource inputs not working

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -62,7 +62,7 @@ class UiJobWizardController < ApplicationController
     job = JobInvocation.authorized.find(params[:id])
     composer = JobInvocationComposer.from_job_invocation(job, params).params
     job_template_inputs = JobTemplate.authorized.find(composer[:template_invocations][0][:template_id]).template_inputs_with_foreign
-    inputs = Hash[job_template_inputs.map { |input| ["inputs[#{input[:name]}]", {:advanced => input[:advanced], :value => (composer[:template_invocations][0][:input_values].find { |value| value[:template_input_id] == input[:id] })[:value]}] }]
+    inputs = Hash[job_template_inputs.map { |input| ["inputs[#{input[:name]}]", {:advanced => input[:advanced], :value => (composer[:template_invocations][0][:input_values].find { |value| value[:template_input_id] == input[:id] }).try(:[], :value)}] }]
     job_organization = Taxonomy.find_by(id: job.task.input[:current_organization_id])
     job_location = Taxonomy.find_by(id: job.task.input[:current_location_id])
     render :json => {

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -64,7 +64,7 @@ export const dataName = {
 };
 export const HOSTS_TO_PREVIEW_AMOUNT = 20;
 
-export const DEBOUNCE_HOST_COUNT = 1500;
+export const DEBOUNCE_API = 1500;
 export const HOST_IDS = 'HOST_IDS';
 export const REX_FEATURE = 'REX_FEATURE';
 

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/__snapshots__/AdvancedFields.test.js.snap
@@ -49,7 +49,7 @@ Array [
         "port": null,
         "preventInvalidHostname": false,
         "protocol": null,
-        "query": "resource=ForemanTasks%3A%3ATask&name=",
+        "query": "resource=ForemanTasks%3A%3ATask",
         "urn": null,
         "username": null,
       },

--- a/webpack/JobWizard/steps/HostsAndInputs/index.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/index.js
@@ -35,7 +35,7 @@ import {
   hostQuerySearchID,
   HOSTS_API,
   HOSTS_TO_PREVIEW_AMOUNT,
-  DEBOUNCE_HOST_COUNT,
+  DEBOUNCE_API,
 } from '../../JobWizardConstants';
 import { WizardTitle } from '../form/WizardTitle';
 import { SelectAPI } from './SelectAPI';
@@ -66,7 +66,7 @@ const HostsAndInputs = ({
           },
         })
       );
-    }, DEBOUNCE_HOST_COUNT)();
+    }, DEBOUNCE_API)();
   }, [
     dispatch,
     selected,

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -8,7 +8,7 @@ import { TRIGGERS } from 'foremanReact/components/AutoComplete/AutoCompleteConst
 import { getResults } from 'foremanReact/components/AutoComplete/AutoCompleteActions';
 import { helpLabel } from './FormHelpers';
 import { SelectField } from './SelectField';
-import { ResourceSelectAPI } from './ResourceSelect';
+import { ResourceSelect } from './ResourceSelect';
 import { DateTimePicker } from '../form/DateTimePicker';
 import { noop } from '../../../helpers';
 
@@ -93,11 +93,11 @@ export const formatter = (input, values, setValue) => {
         isRequired={required}
         key={id}
       >
-        <ResourceSelectAPI
+        <ResourceSelect
           name={name}
           apiKey={resourceType.replace('::', '')}
           url={`/ui_job_wizard/resources?resource=${resourceType}`}
-          selected={value || {}}
+          selected={value || ''}
           setSelected={newValue => setValue({ ...values, [name]: newValue })}
         />
       </FormGroup>

--- a/webpack/JobWizard/steps/form/ResourceSelect.js
+++ b/webpack/JobWizard/steps/form/ResourceSelect.js
@@ -1,29 +1,116 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import Immutable from 'seamless-immutable';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { useSelector, useDispatch } from 'react-redux';
 import URI from 'urijs';
 import { get } from 'foremanReact/redux/API';
 import { selectResponse, selectIsLoading } from '../../JobWizardSelectors';
-import { SearchSelect } from '../form/SearchSelect';
+import { DEBOUNCE_API } from '../../JobWizardConstants';
 
-export const useNameSearchAPI = (apiKey, url) => {
+export const ResourceSelect = ({
+  name,
+  selected,
+  setSelected,
+  placeholderText,
+  apiKey,
+  url,
+}) => {
+  const maxResults = 100;
   const dispatch = useDispatch();
   const uri = new URI(url);
   const onSearch = search => {
     dispatch(
       get({
         key: apiKey,
-        url: uri.addSearch({
-          name: search,
-        }),
+        url: uri.addSearch(search),
       })
     );
   };
 
   const response = useSelector(state => selectResponse(state, apiKey));
   const isLoading = useSelector(state => selectIsLoading(state, apiKey));
-  return [onSearch, response, isLoading];
+  const [isOpen, setIsOpen] = useState(false);
+  const [typingTimeout, setTypingTimeout] = useState(null);
+  useEffect(() => {
+    onSearch(selected ? { id: selected } : {});
+    if (typingTimeout) {
+      return () => clearTimeout(typingTimeout);
+    }
+    return undefined;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  let selectOptions = [];
+  if (response.subtotal > maxResults) {
+    selectOptions = [
+      <SelectOption
+        isDisabled
+        key={0}
+        description={__('Please refine your search.')}
+      >
+        {sprintf(
+          __('You have %s results to display. Showing first %s results'),
+          response.subtotal,
+          maxResults
+        )}
+      </SelectOption>,
+    ];
+  }
+  selectOptions = [
+    ...selectOptions,
+    ...Immutable.asMutable(response?.results || [])?.map((result, index) => (
+      <SelectOption key={index + 1} value={result.id}>
+        {result.name}
+      </SelectOption>
+    )),
+  ];
+
+  const onSelect = (event, selection) => {
+    setSelected(selection);
+    setIsOpen(false);
+  };
+  const autoSearch = searchTerm => {
+    if (typingTimeout) clearTimeout(typingTimeout);
+    setTypingTimeout(
+      setTimeout(() => onSearch({ name: searchTerm }), DEBOUNCE_API)
+    );
+  };
+  return (
+    <Select
+      toggleAriaLabel={`${name} toggle`}
+      chipGroupComponent={<></>}
+      variant={SelectVariant.typeahead}
+      selections={selected}
+      loadingVariant={isLoading ? 'spinner' : null}
+      onSelect={onSelect}
+      onToggle={setIsOpen}
+      isOpen={isOpen}
+      className="without_select2"
+      maxHeight="45vh"
+      onTypeaheadInputChanged={value => {
+        autoSearch(value || '');
+      }}
+      placeholderText={placeholderText}
+      typeAheadAriaLabel={`${name} typeahead input`}
+    >
+      {selectOptions}
+    </Select>
+  );
 };
 
-export const ResourceSelectAPI = props => (
-  <SearchSelect {...props} useNameSearch={useNameSearchAPI} />
-);
+ResourceSelect.propTypes = {
+  name: PropTypes.string,
+  selected: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  setSelected: PropTypes.func.isRequired,
+  placeholderText: PropTypes.string,
+  apiKey: PropTypes.string.isRequired,
+  url: PropTypes.string,
+};
+
+ResourceSelect.defaultProps = {
+  name: 'typeahead select',
+  selected: {},
+  placeholderText: '',
+  url: '',
+};

--- a/webpack/JobWizard/steps/form/SearchSelect.js
+++ b/webpack/JobWizard/steps/form/SearchSelect.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import Immutable from 'seamless-immutable';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
+import { DEBOUNCE_API } from '../../JobWizardConstants';
 
 export const maxResults = 100;
 
@@ -19,7 +20,6 @@ export const SearchSelect = ({
   const [onSearch, response, isLoading] = useNameSearch(apiKey, url);
   const [isOpen, setIsOpen] = useState(false);
   const [typingTimeout, setTypingTimeout] = useState(null);
-  const autoSearchDelay = 500;
   useEffect(() => {
     onSearch(selected.name || '');
     if (typingTimeout) {
@@ -71,7 +71,7 @@ export const SearchSelect = ({
   };
   const autoSearch = searchTerm => {
     if (typingTimeout) clearTimeout(typingTimeout);
-    setTypingTimeout(setTimeout(() => onSearch(searchTerm), autoSearchDelay));
+    setTypingTimeout(setTimeout(() => onSearch(searchTerm), DEBOUNCE_API));
   };
   return (
     <Select


### PR DESCRIPTION
Fixed:
* Review step crashing when there is input in a resource input
* rerun not filling resource inputs
* submit sending wrong data for resource inputs

The `ResourceSelect` "new" component is an edited version of `SearchSelect` which was used for it in the previous pr.