### PR TITLE
Refs #35584 - fix url for host details feature open job form

### DIFF
--- a/webpack/react_app/components/FeaturesDropdown/actions.js
+++ b/webpack/react_app/components/FeaturesDropdown/actions.js
@@ -6,9 +6,10 @@ export const runFeature = (hostId, feature, label) => dispatch => {
   const url = foremanUrl(
     `/job_invocations?feature=${feature}&host_ids%5B%5D=${hostId}`
   );
+  const redirectUrl = 'job_invocations/new';
 
   const successToast = ({ request }) => {
-    if (request.responseURL.includes('job_invocations?')) {
+    if (request.responseURL.includes(redirectUrl)) {
       return __('Opening job invocation form');
     }
     return sprintf(__('%s job has been invoked'), label);
@@ -21,12 +22,9 @@ export const runFeature = (hostId, feature, label) => dispatch => {
       successToast,
       errorToast,
       handleSuccess: ({ request }) => {
-        if (request.responseURL.includes('job_invocations?')) {
+        if (request.responseURL.includes(redirectUrl)) {
           // checking if user should be redicted to finish setting up the job
-          window.location.href = request.responseURL.replace(
-            'job_invocations?',
-            'job_invocations/new?'
-          );
+          window.location.href = request.responseURL;
         }
       },
     })


### PR DESCRIPTION
Fix for https://github.com/theforeman/foreman_remote_execution/pull/762 after https://github.com/theforeman/foreman_remote_execution/pull/758 broke it and changed the url from `/job_invocations?feature=` to `/job_invocations/new?feature=`