### PR TITLE
Fixes #35806 - Introduce sequence_id to new outputs

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -169,7 +169,7 @@ module Actions
           # This is enough, the error will get shown using add_exception at the end of the method
         end
 
-        task.template_invocation.template_invocation_events.find_each do |output|
+        task.template_invocation.template_invocation_events.order(:sequence_id).find_each do |output|
           if output.event_type == 'exit'
             continuous_output.add_output(_('Exit status: %s') % output.event, 'stdout', output.timestamp)
           else

--- a/db/migrate/20221129170145_redefine_template_invocation_events_index.rb
+++ b/db/migrate/20221129170145_redefine_template_invocation_events_index.rb
@@ -1,0 +1,36 @@
+class RedefineTemplateInvocationEventsIndex < ActiveRecord::Migration[6.0]
+  def up
+    change_table :template_invocation_events do |t|
+      t.remove_index name: :unique_template_invocation_events_index
+      t.integer :sequence_id
+    end
+
+    execute <<~SQL
+      WITH extended_t AS
+      (
+          SELECT id, row_number() over (PARTITION BY template_invocation_id ORDER BY timestamp ASC) AS rn
+          FROM template_invocation_events
+      )
+      UPDATE template_invocation_events SET sequence_id = extended_t.rn
+      FROM extended_t
+      WHERE template_invocation_events.id = extended_t.id;
+    SQL
+
+    change_table :template_invocation_events do |t|
+      t.index [:template_invocation_id, :sequence_id],
+        unique: true,
+        name: 'unique_template_invocation_events_index'
+      t.change :sequence_id, :integer, null: false
+    end
+  end
+
+  def down
+    change_table :template_invocation_events do |t|
+      t.remove_index name: :unique_template_invocation_events_index
+      t.remove :sequence_id
+      t.index [:template_invocation_id, :timestamp, :event_type],
+        unique: true,
+        name: 'unique_template_invocation_events_index'
+    end
+  end
+end


### PR DESCRIPTION
The new storage for job outputs assumed that for each combination of template_invocation_id, event_type, timestamp, there would be up to 1 entry. Considering timestamps are stored with microsecond precision, and sp-rex-ssh collects outputs once per second, this felt somewhat reasonable. However, during transfer the timestamps get serialized (and then deserialized), reducing the precision to seconds in the process. REX then complained about duplicate records when trying to upsert the incoming outputs into the db.

This change introduces sequence_ids to template_invocation_events table. These ids represent the ordering of an output event within the line of events for a given template invocation and as such, every combination of (template_invocation_id, sequence_id) must be unique.

Eventually output providers (pull provider, sp-rex-ssh) should generate the sequence ids themselves, but right now we can generate them on the fly as Foreman is getting full output every time.