### PR TITLE
Fixes #35972 - Link to new form from empty state

### DIFF
--- a/app/views/job_invocations/welcome.html.erb
+++ b/app/views/job_invocations/welcome.html.erb
@@ -9,6 +9,6 @@
     <p><%= link_to _('Learn more about this in the documentation.'),
            documentation_url('1.ForemanRemoteExecution1.3Manual', :root_url => 'https://www.theforeman.org/plugins/foreman_remote_execution/1.3/index.html#'), :rel => 'external' %></p>
     <div class="blank-slate-pf-main-action">
-        <%= new_link(_("Run Job"), {}, { :class => "btn-lg" }) %>
+        <%= display_link_if_authorized(_("Run Job"), { :action => :create }, { :class => "btn btn-primary btn-lg" }) %>
     </div>
 </div>


### PR DESCRIPTION
Rails routing gets a bit confused by a lot of things routing to react#index. It was generating a link for job_invocations#new, but that is an endpoint serving the old form.