### PR TITLE
Fixes #35910 - Submit in legacy job form redirects wrong

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -40,6 +40,16 @@ class JobInvocationsController < ApplicationController
     render :action => 'new'
   end
 
+  def legacy_create
+    @composer = prepare_composer
+    if @composer.trigger
+      redirect_to job_invocation_path(@composer.job_invocation)
+    else
+      @composer.job_invocation.description_format = nil if params.fetch(:job_invocation, {}).key?(:description_override)
+      render :action => 'new'
+    end
+  end
+
   def create
     @composer = prepare_composer
     if @composer.trigger

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
   match 'job_invocations/new', to: 'react#index', :via => [:get], as: 'new_job_invocation'
   match 'job_invocations/new', to: 'job_invocations#create', via: [:post], as: 'create_job_invocation'
+  match 'job_invocations/', to: 'job_invocations#legacy_create', via: [:post], as: 'legacy_create_job_invocation'
   match 'job_invocations/:id/rerun', to: 'react#index', :via => [:get], as: 'rerun_job_invocation'
   match 'old/job_invocations/new', to: 'job_invocations#new', via: [:get], as: 'form_new_job_invocation'
   match 'old/job_invocations/:id/rerun', to: 'job_invocations#rerun', via: [:get, :post], as: 'form_rerun_job_invocation'

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -181,7 +181,7 @@ module ForemanRemoteExecution
           permission :destroy_job_templates, { :job_templates => [:destroy],
                                                :'api/v2/job_templates' => [:destroy] }, :resource_type => 'JobTemplate'
           permission :lock_job_templates, { :job_templates => [:lock, :unlock] }, :resource_type => 'JobTemplate'
-          permission :create_job_invocations, { :job_invocations => [:new, :create, :refresh, :rerun, :preview_hosts],
+          permission :create_job_invocations, { :job_invocations => [:new, :create, :legacy_create, :refresh, :rerun, :preview_hosts],
                                                 'api/v2/job_invocations' => [:create, :rerun] }, :resource_type => 'JobInvocation'
           permission :view_job_invocations, { :job_invocations => [:index, :chart, :show, :auto_complete_search], :template_invocations => [:show],
                                               'api/v2/job_invocations' => [:index, :show, :output, :raw_output, :outputs] }, :resource_type => 'JobInvocation'


### PR DESCRIPTION
Draft until search is fixed in forms, as until then users cant really submit jobs from the legacy form