### PR TITLE
Fixes #36003 - Migration error 'column settings.category does not exist'

### DIFF
--- a/db/migrate/20210816100932_rex_setting_category_to_dsl.rb
+++ b/db/migrate/20210816100932_rex_setting_category_to_dsl.rb
@@ -1,5 +1,5 @@
 class RexSettingCategoryToDsl < ActiveRecord::Migration[6.0]
   def up
-    Setting.where(category: 'Setting::RemoteExecution').update_all(category: 'Setting')
+    Setting.where(category: 'Setting::RemoteExecution').update_all(category: 'Setting') if column_exists?(:settings, :category)
   end
 end


### PR DESCRIPTION
See:

https://github.com/theforeman/foreman/pull/9524
https://github.com/theforeman/foreman/pull/9524#issuecomment-1404661119