### PR TITLE
Fixes #36108 - do not load non-existant charts.js

### DIFF
--- a/app/views/job_invocations/show.html.erb
+++ b/app/views/job_invocations/show.html.erb
@@ -1,6 +1,6 @@
 <% title @job_invocation.description %>
 <% stylesheet 'foreman_remote_execution/foreman_remote_execution' %>
-<% javascript 'charts', 'foreman_remote_execution/template_invocation' %>
+<% javascript 'foreman_remote_execution/template_invocation' %>
 <% javascript *webpack_asset_paths('foreman_remote_execution', :extension => 'js') %>
 <% content_for(:stylesheets) do %>
   <%= webpacked_plugins_css_for :foreman_remote_execution %>


### PR DESCRIPTION
We used charts.js from Foreman, but that was dropped in Foreman 3.0 (https://github.com/theforeman/foreman/commit/69379b51a33344de93836950565ecbfae0c4df23) and results in 404 errors when trying to load the job invocation page.