### PR TITLE
Fixes #36114 - Prevent accessing dynflow internals until ready

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -238,7 +238,7 @@ module RemoteExecutionHelper
 
   def load_template_from_task(template_invocation, target)
     task = template_invocation.job_invocation.sub_task_for_host(target)
-    return if task.nil?
+    return if [nil, 'scheduled', 'planning'].include?(task&.state)
 
     task.execution_plan.actions[1].try(:input).try(:[], 'script')
   end


### PR DESCRIPTION
To prevent re-rendering of templates before showing them in the UI, we tried to pull them from the associated tasks. However, we only checked task's presence, not its state. This opened door to us trying to access data that is not there yet. The data should be there once the task goes gets planned completely.