### PR TITLE
Fixes #36096 - Add provider inputs to job wizard

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -13,11 +13,13 @@ class UiJobWizardController < ApplicationController
   def template
     job_template = JobTemplate.authorized.find(params[:id])
     advanced_template_inputs, template_inputs = map_template_inputs(job_template.template_inputs_with_foreign).partition { |x| x["advanced"] }
+    provider_inputs = job_template.provider.provider_inputs.map { |input| input.instance_values.merge({:provider_input => true, default: input.value }) }
     render :json => {
       :job_template => job_template,
       :effective_user => job_template.effective_user,
       :template_inputs => template_inputs,
-      :advanced_template_inputs => advanced_template_inputs,
+      :provider_name => job_template.provider.provider_input_namespace,
+      :advanced_template_inputs => advanced_template_inputs+provider_inputs,
     }
   end
 
@@ -66,6 +68,9 @@ class UiJobWizardController < ApplicationController
     job_organization = Taxonomy.find_by(id: job.task.input[:current_organization_id])
     job_location = Taxonomy.find_by(id: job.task.input[:current_location_id])
     render :json => {
+      :provider_input_values => composer[:template_invocations][0][:provider_input_values],
+      :provider_input_values1 => job[:provider_input_values],
+      :job2 => composer[:template_invocations][0],
       :job => composer,
       :job_organization => job_organization,
       :job_location => job_location,

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -379,6 +379,8 @@ export const JobWizard = ({ rerunData }) => {
           location,
           organization,
           feature: routerSearch?.feature,
+          provider: templateResponse.provider_name,
+          advancedInputs: templateResponse.advanced_template_inputs,
         });
       }}
     />

--- a/webpack/JobWizard/submit.js
+++ b/webpack/JobWizard/submit.js
@@ -12,6 +12,8 @@ export const submit = ({
   location,
   organization,
   feature,
+  provider,
+  advancedInputs,
   dispatch,
 }) => {
   const {
@@ -37,6 +39,13 @@ export const submit = ({
     keyPassphrase,
     timeToPickup,
   } = advancedValues;
+  const providerInputs = advancedInputs.filter(v => v.provider_input);
+  const providerValues = {};
+  providerInputs.forEach(({ name }) => {
+    providerValues[name] = advancedTemplateValues[name];
+    delete advancedTemplateValues[name];
+  });
+
   const getCronLine = () => {
     const [hour, minute] = repeatData.at
       ? repeatData.at.split(':')
@@ -112,6 +121,9 @@ export const submit = ({
       time_to_pickup: timeToPickup,
     },
   };
+  if (Object.keys(providerValues).length) {
+    api.job_invocation[provider] = providerValues;
+  }
 
   dispatch(
     post({


### PR DESCRIPTION
Adding them in the api response as part of the advanced inputs so that the ui will treat them as template inputs, and split them on submit from the advanced inputs.
Tested that they were actually added with ` TemplateInvocation.last.provider_input_values.first.value`