### PR TITLE
Fixes #36127 - Cant pre-fill job wizard advanced inputs

### DIFF
--- a/webpack/JobWizard/autofill.js
+++ b/webpack/JobWizard/autofill.js
@@ -72,6 +72,7 @@ export const useAutoFill = ({
           if (input) {
             if (typeof rest[key] === 'string') {
               setTemplateValues(prev => ({ ...prev, [input]: rest[key] }));
+              setAdvancedValues(prev => ({ ...prev, [input]: rest[key] }));
             } else {
               const { value, advanced } = rest[key];
               if (advanced) {

--- a/webpack/JobWizard/steps/HostsAndInputs/__tests__/HostsAndInputs.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/__tests__/HostsAndInputs.test.js
@@ -158,8 +158,9 @@ describe('Hosts', () => {
 
   it('input fill from url', async () => {
     const inputText = 'test text';
+    const advancedInputText = 'test adv text';
     routerSelectors.selectRouterLocation.mockImplementation(() => ({
-      search: `feature=test_feature&inputs[plain hidden]=${inputText}`,
+      search: `feature=test_feature&inputs[plain hidden]=${inputText}&inputs[adv plain hidden]=${advancedInputText}`,
     }));
     render(
       <MockedProvider mocks={gqlMock} addTypename={false}>
@@ -182,5 +183,13 @@ describe('Hosts', () => {
       selector: 'textarea',
     });
     expect(textField.value).toBe(inputText);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Advanced fields'));
+    });
+    const advancedTextField = screen.getByLabelText('adv plain hidden', {
+      selector: 'textarea',
+    });
+    expect(advancedTextField.value).toBe(advancedInputText);
   });
 });


### PR DESCRIPTION
The inputs get filtered later into advanced/template input, can be checked with `/job_invocations/new?feature=leapp_remediation_plan&inputs%5Bremediation_ids%5D="1%2C2%2C3"&inputs[run_preupgrade]=false` 