### PR TITLE
Fixes #36166 - Revamp job hooks

### DIFF
--- a/app/lib/actions/remote_execution/event_helpers.rb
+++ b/app/lib/actions/remote_execution/event_helpers.rb
@@ -20,8 +20,6 @@ module Actions
       end
 
       def self.included(base)
-        # Added by default by ObservableAction
-        base.execution_plan_hooks.do_not_use :emit_event, :on => :success
         base.extend ClassEventHelpers
       end
 

--- a/app/lib/actions/remote_execution/event_helpers.rb
+++ b/app/lib/actions/remote_execution/event_helpers.rb
@@ -1,0 +1,44 @@
+module Actions
+  module RemoteExecution
+    module EventHelpers
+      module ClassEventHelpers
+        def event_states
+          []
+        end
+
+        def event_names
+          event_states.map do |state|
+            event_name_base + '_' + event_name_suffix(state).to_s
+          end
+        end
+
+        def feature_job_event_names(label)
+          event_states.map do |state|
+            ::Foreman::Observable.event_name_for("#{event_name_base}_#{label}_#{event_name_suffix(state)}")
+          end
+        end
+      end
+
+      def self.included(base)
+        # Added by default by ObservableAction
+        base.execution_plan_hooks.do_not_use :emit_event, :on => :success
+        base.extend ClassEventHelpers
+      end
+
+      def emit_event(execution_plan, hook)
+        return unless root_action?
+
+        payload = event_payload(execution_plan)
+        base = self.class.event_name_base
+        suffix = self.class.event_name_suffix(hook)
+        if input["job_features"]&.any?
+          input['job_features'].each do |feature|
+            name = "#{base}_#{feature}_#{suffix}"
+            trigger_hook name, payload: payload
+          end
+        end
+        trigger_hook("#{base}_#{suffix}", payload: payload)
+      end
+    end
+  end
+end

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -7,8 +7,6 @@ module Actions
       include ::Actions::RemoteExecution::TemplateInvocationProgressLogging
       include ::Actions::RemoteExecution::EventHelpers
 
-      execution_plan_hooks.use :emit_event, :on => [:success, :failure]
-
       middleware.do_not_use Dynflow::Middleware::Common::Transaction
       middleware.use Actions::Middleware::HideSecrets
 
@@ -82,10 +80,6 @@ module Actions
 
       def self.event_states
         [:success, :failure]
-      end
-
-      def emit_event(plan)
-        super(plan, execution_plan.result == :success ? :success : :failure)
       end
 
       def secrets(host, job_invocation, provider)

--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -12,8 +12,6 @@ module Actions
       execution_plan_hooks.use :notify_on_success, :on => :success
       execution_plan_hooks.use :notify_on_failure, :on => :failure
       execution_plan_hooks.use :emit_running_event, :on => :running
-      execution_plan_hooks.use :emit_failure_event, :on => :failure
-      execution_plan_hooks.use :emit_success_event, :on => :success
 
       class CheckOnProxyActions; end
 
@@ -164,14 +162,6 @@ module Actions
 
       def self.event_states
         [:success, :failure, :running]
-      end
-
-      def emit_failure_event(plan)
-        emit_event(plan, :failure)
-      end
-
-      def emit_success_event(plan)
-        emit_event(plan, :success)
       end
 
       def emit_running_event(plan)

--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -3,6 +3,7 @@ module Actions
     class RunHostsJob < Actions::ActionWithSubPlans
       include Actions::RecurringAction
       include Actions::ObservableAction
+      include Actions::RemoteExecution::EventHelpers
 
       middleware.use Actions::Middleware::BindJobInvocation
       middleware.use Actions::Middleware::RecurringLogic
@@ -10,7 +11,9 @@ module Actions
 
       execution_plan_hooks.use :notify_on_success, :on => :success
       execution_plan_hooks.use :notify_on_failure, :on => :failure
-      execution_plan_hooks.use :emit_event_running, :on => :running
+      execution_plan_hooks.use :emit_running_event, :on => :running
+      execution_plan_hooks.use :emit_failure_event, :on => :failure
+      execution_plan_hooks.use :emit_success_event, :on => :success
 
       class CheckOnProxyActions; end
 
@@ -28,7 +31,8 @@ module Actions
       def plan(job_invocation)
         job_invocation.task_group.save! if job_invocation.task_group.try(:new_record?)
         task.add_missing_task_groups(job_invocation.task_group) if job_invocation.task_group
-        action_subject(job_invocation)
+        features = job_invocation.pattern_templates.flat_map { |t| t.remote_execution_features.pluck(:label) }.uniq
+        action_subject(job_invocation, job_features: features)
         job_invocation.targeting.resolve_hosts! if job_invocation.targeting.dynamic? || !job_invocation.targeting.resolved?
         set_up_concurrency_control job_invocation
         input.update(:job_category => job_invocation.job_category)
@@ -158,11 +162,19 @@ module Actions
         input[:proxy_batch_size]
       end
 
-      def self.event_names
-        super + [event_name_base + '_' + event_name_suffix('running')]
+      def self.event_states
+        [:success, :failure, :running]
       end
 
-      def emit_event_running(plan)
+      def emit_failure_event(plan)
+        emit_event(plan, :failure)
+      end
+
+      def emit_success_event(plan)
+        emit_event(plan, :success)
+      end
+
+      def emit_running_event(plan)
         emit_event(plan, :running)
       end
 

--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface'
   s.add_dependency 'dynflow', '>= 1.0.2', '< 2.0.0'
-  s.add_dependency 'foreman-tasks', '>= 8.2.0'
+  s.add_dependency 'foreman-tasks', '>= 8.3.0'
 
   s.add_development_dependency 'factory_bot_rails', '~> 4.8.0'
   s.add_development_dependency 'rdoc'

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -280,8 +280,10 @@ module ForemanRemoteExecution
           ::Dynflow::Action.descendants.select do |klass|
             klass <= ::Actions::ObservableAction
           end.map(&:namespaced_event_names) +
-          RemoteExecutionFeature.all.pluck(:label).map do |label|
-            ::Actions::RemoteExecution::RunHostJob.feature_job_event_name(label)
+          RemoteExecutionFeature.all.pluck(:label).flat_map do |label|
+            [::Actions::RemoteExecution::RunHostJob, ::Actions::RemoteExecution::RunHostsJob].map do |klass|
+              klass.feature_job_event_names(label)
+            end
           end
         )
       end

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -39,7 +39,7 @@ module ForemanRemoteExecution
     end
     let(:action) do
       create_action(Actions::RemoteExecution::RunHostsJob).tap do |action|
-        action.expects(:action_subject).with(job_invocation)
+        action.expects(:action_subject).with(job_invocation, job_features: [])
         ForemanTasks::Task::DynflowTask.stubs(:where).returns(mock.tap { |m| m.stubs(:first! => task) })
       end
     end


### PR DESCRIPTION
Per host in job now have per feature events when the action succeeds or fails.

Per job now have general running/stopped/failed as well as per feature running/stopped/failed events. Note, both the generic and per-feature are emitted.