### PR TITLE
Fixes #35147 - Hosts jobs card to show host job status

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   match 'old/job_invocations/:id/rerun', to: 'job_invocations#rerun', via: [:get, :post], as: 'form_rerun_job_invocation'
   resources :job_invocations, :only => [:create, :show, :index] do
     collection do
+      get 'preview_job_invocations_per_host'
       post 'refresh'
       get 'chart'
       get 'preview_hosts'

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -183,7 +183,7 @@ module ForemanRemoteExecution
           permission :lock_job_templates, { :job_templates => [:lock, :unlock] }, :resource_type => 'JobTemplate'
           permission :create_job_invocations, { :job_invocations => [:new, :create, :legacy_create, :refresh, :rerun, :preview_hosts],
                                                 'api/v2/job_invocations' => [:create, :rerun] }, :resource_type => 'JobInvocation'
-          permission :view_job_invocations, { :job_invocations => [:index, :chart, :show, :auto_complete_search], :template_invocations => [:show],
+          permission :view_job_invocations, { :job_invocations => [:index, :chart, :show, :auto_complete_search, :preview_job_invocations_per_host], :template_invocations => [:show],
                                               'api/v2/job_invocations' => [:index, :show, :output, :raw_output, :outputs] }, :resource_type => 'JobInvocation'
           permission :view_template_invocations, { :template_invocations => [:show],
                                                    'api/v2/template_invocations' => [:template_invocations], :ui_job_wizard => [:job_invocation] }, :resource_type => 'TemplateInvocation'

--- a/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
+++ b/webpack/react_app/components/RecentJobsCard/RecentJobsCard.js
@@ -25,7 +25,7 @@ const RecentJobsCard = ({ hostDetails: { name, id } }) => {
       header={__('Recent jobs')}
       dropdownItems={[
         <DropdownItem
-          href={foremanUrl(`${JOB_BASE_URL}${name}`)}
+          href={foremanUrl(`${JOB_BASE_URL}${id}`)}
           key="link-to-all"
           ouiaId="link-to-all-dropdown-item"
         >
@@ -33,7 +33,7 @@ const RecentJobsCard = ({ hostDetails: { name, id } }) => {
         </DropdownItem>,
         <DropdownItem
           href={foremanUrl(
-            `${JOB_BASE_URL}${name}+and+status+%3D+failed+or+status%3D+succeeded`
+            `${JOB_BASE_URL}${id}+and+status+%3D+failed+or+status%3D+succeeded`
           )}
           key="link-to-finished"
           ouiaId="link-to-finished-dropdown-item"
@@ -41,14 +41,14 @@ const RecentJobsCard = ({ hostDetails: { name, id } }) => {
           {__('View finished jobs')}
         </DropdownItem>,
         <DropdownItem
-          href={foremanUrl(`${JOB_BASE_URL}${name}+and+status+%3D+running`)}
+          href={foremanUrl(`${JOB_BASE_URL}${id}+and+status+%3D+running`)}
           key="link-to-running"
           ouiaId="link-to-running-dropdown-item"
         >
           {__('View running jobs')}
         </DropdownItem>,
         <DropdownItem
-          href={foremanUrl(`${JOB_BASE_URL}${name}+and+status+%3D+queued`)}
+          href={foremanUrl(`${JOB_BASE_URL}${id}+and+status+%3D+queued`)}
           key="link-to-scheduled"
           ouiaId="link-to-scheduled-dropdown-item"
         >

--- a/webpack/react_app/components/RecentJobsCard/RecentJobsTable.js
+++ b/webpack/react_app/components/RecentJobsCard/RecentJobsTable.js
@@ -17,10 +17,10 @@ const RecentJobsTable = ({ status, hostId }) => {
   const jobsUrl =
     hostId &&
     foremanUrl(
-      `${JOB_API_URL}${hostId}+and+status%3D${status}&per_page=${JOBS_IN_CARD}`
+      `${JOB_API_URL}${hostId}&status=${status}&limit=${JOBS_IN_CARD}`
     );
   const {
-    response: { results: jobs },
+    response: { job_invocations: jobs },
     status: responseStatus,
   } = useAPI('get', jobsUrl, RECENT_JOBS_KEY);
 

--- a/webpack/react_app/components/RecentJobsCard/constants.js
+++ b/webpack/react_app/components/RecentJobsCard/constants.js
@@ -6,8 +6,8 @@ export const SCHEDULED_TAB = 2;
 export const JOB_SUCCESS_STATUS = 0;
 export const JOB_ERROR_STATUS = 1;
 
-export const JOB_BASE_URL = '/job_invocations?search=host+%3D+';
+export const JOB_BASE_URL = '/job_invocations?search=targeted_host_id+%3D+';
 export const JOB_API_URL =
-  '/api/job_invocations?order=start_at+DESC&search=targeted_host_id%3D';
+  '/job_invocations/preview_job_invocations_per_host?host_id=';
 export const JOBS_IN_CARD = 3;
 export const RECENT_JOBS_KEY = { key: 'RECENT_JOBS_KEY' };


### PR DESCRIPTION
* also changed the links in the dropdown to filter the hosts with `target_host_id` and not `host` for more correct results