### PR TITLE
Fixes #36231 - Do not raise when checking exit status

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -180,7 +180,7 @@ module Actions
       end
 
       def exit_status
-        input[:with_event_logging] ? task.template_invocation.template_invocation_events.find_by(event_type: 'exit').event : delegated_output[:exit_status]
+        input[:with_event_logging] ? task.template_invocation.template_invocation_events.find_by(event_type: 'exit')&.event : delegated_output[:exit_status]
       end
 
       def host_id


### PR DESCRIPTION
With the template invocation events based implementation, checking exit status raised an exception if the task was still running (and the event was missing).