### PR TITLE
Fixes #35788 - add run now, skip to review buttons

### DIFF
--- a/webpack/JobWizard/Footer.js
+++ b/webpack/JobWizard/Footer.js
@@ -1,0 +1,104 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  WizardFooter,
+  WizardContextConsumer,
+  Tooltip,
+  Spinner,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { WIZARD_TITLES } from './JobWizardConstants';
+import { selectIsSubmitting } from './JobWizardSelectors';
+
+export const Footer = ({ canSubmit, onSave }) => {
+  const isSubmitting = useSelector(selectIsSubmitting);
+  return (
+    <WizardFooter>
+      <WizardContextConsumer>
+        {({ activeStep, onNext, onBack, onClose, goToStepByName }) => {
+          const isValid =
+            activeStep && activeStep.enableNext !== undefined
+              ? activeStep.enableNext
+              : true;
+
+          return (
+            <>
+              <Button
+                variant="primary"
+                type="submit"
+                onClick={onNext}
+                isDisabled={!isValid || isSubmitting}
+              >
+                {activeStep.name === WIZARD_TITLES.review
+                  ? __('Submit')
+                  : __('Next')}
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={onBack}
+                isDisabled={
+                  activeStep.name === WIZARD_TITLES.categoryAndTemplate
+                }
+              >
+                {__('Back')}
+              </Button>
+              <Tooltip
+                content={
+                  <div>
+                    {canSubmit
+                      ? __('Start job')
+                      : __('Fill all required fields in all the steps')}
+                  </div>
+                }
+              >
+                <Button
+                  variant="tertiary"
+                  onClick={onSave}
+                  isAriaDisabled={!canSubmit}
+                  isDisabled={isSubmitting}
+                >
+                  {__('Run on selected hosts')}
+                </Button>
+              </Tooltip>
+              <Tooltip
+                content={
+                  <div>
+                    {canSubmit
+                      ? __('Skip to review step')
+                      : __(
+                          'Fill all required fields in all the steps to start the job'
+                        )}
+                  </div>
+                }
+              >
+                <Button
+                  variant="tertiary"
+                  onClick={() => goToStepByName(WIZARD_TITLES.review)}
+                  isAriaDisabled={!canSubmit}
+                  isDisabled={isSubmitting}
+                >
+                  {__('Skip to review')}
+                </Button>
+              </Tooltip>
+              <Button variant="link" onClick={onClose}>
+                {__('Cancel')}
+              </Button>
+              {isSubmitting && (
+                <div>
+                  <Spinner size="lg" />
+                </div>
+              )}
+            </>
+          );
+        }}
+      </WizardContextConsumer>
+    </WizardFooter>
+  );
+};
+
+Footer.propTypes = {
+  canSubmit: PropTypes.bool.isRequired,
+  onSave: PropTypes.func.isRequired,
+};

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -37,6 +37,7 @@ import { useAutoFill } from './autofill';
 import { submit } from './submit';
 import { generateDefaultDescription } from './JobWizardHelpers';
 import { StartsBeforeErrorAlert } from './StartsBeforeErrorAlert';
+import { Footer } from './Footer';
 import './JobWizard.scss';
 
 export const JobWizard = ({ rerunData }) => {
@@ -420,6 +421,22 @@ export const JobWizard = ({ rerunData }) => {
   ];
   const location = useForemanLocation();
   const organization = useForemanOrganization();
+  const onSave = () => {
+    submit({
+      jobTemplateID,
+      templateValues,
+      advancedValues,
+      scheduleValue,
+      dispatch,
+      selectedTargets,
+      hostsSearchQuery,
+      location,
+      organization,
+      feature: routerSearch?.feature,
+      provider: templateResponse.provider_name,
+      advancedInputs: templateResponse.advanced_template_inputs,
+    });
+  };
   return (
     <>
       {isStartsBeforeError && <StartsBeforeErrorAlert />}
@@ -429,22 +446,13 @@ export const JobWizard = ({ rerunData }) => {
         steps={steps}
         height="100%"
         className="job-wizard"
-        onSave={() => {
-          submit({
-            jobTemplateID,
-            templateValues,
-            advancedValues,
-            scheduleValue,
-            dispatch,
-            selectedTargets,
-            hostsSearchQuery,
-            location,
-            organization,
-            feature: routerSearch?.feature,
-            provider: templateResponse.provider_name,
-            advancedInputs: templateResponse.advanced_template_inputs,
-          });
-        }}
+        onSave={onSave}
+        footer={
+          <Footer
+            canSubmit={!!steps[steps.length - 1].enableNext}
+            onSave={onSave}
+          />
+        }
       />
     </>
   );

--- a/webpack/JobWizard/__tests__/validation.test.js
+++ b/webpack/JobWizard/__tests__/validation.test.js
@@ -154,6 +154,10 @@ describe('Job wizard validation', () => {
     });
 
     expect(screen.getByText(WIZARD_TITLES.schedule)).toBeDisabled();
+    expect(screen.getByText('Run on selected hosts')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
     expect(screen.getByText(WIZARD_TITLES.review)).toBeDisabled();
 
     await act(async () => {
@@ -162,6 +166,11 @@ describe('Job wizard validation', () => {
       });
     });
 
+    expect(screen.getByText('Run on selected hosts')).toBeEnabled();
+    expect(screen.getByText('Run on selected hosts')).toHaveAttribute(
+      'aria-disabled',
+      'false'
+    );
     expect(screen.getByText(WIZARD_TITLES.schedule)).toBeEnabled();
     expect(screen.getByText(WIZARD_TITLES.review)).toBeEnabled();
   });


### PR DESCRIPTION
community discussion: https://community.theforeman.org/t/choose-a-design-for-new-remote-execution-job-invocation/32193
The poll results say that users want both buttons, so added a button that runs the job immediately with the entered/pre submitted fields, and a button that moves the user to the review step (if all the required fields are filled).
Added a spinner to make it clear that the "run now" button was clicked and is waiting for the server for a redirect.
Originally we said that the button text will be `run on x hosts` but host selection can be dynamic so the number shown wont always be correct.
![Screenshot from 2023-03-28 11-49-14](https://user-images.githubusercontent.com/30431079/228200696-bed817ed-269c-4d21-a5cd-c40bdc46803f.png)
