### PR TITLE
Fixes #36241 - job wizard - datepicker z index fix

### DIFF
--- a/webpack/JobWizard/JobWizard.scss
+++ b/webpack/JobWizard/JobWizard.scss
@@ -6,20 +6,15 @@
 
   .pf-c-wizard__nav.pf-m-expanded {
     z-index: calc(
-      var(--pf-c-wizard__footer--ZIndex) + 2
-    ); // So the small screen navigation can be shown above the select box
+      var(--pf-c-wizard__toggle--ZIndex) + 2
+    ); // So the small screen navigation can be shown above the select box and wizard body
   }
 
   .pf-c-wizard__main {
     overflow: visible;
     z-index: calc(
-      var(--pf-c-wizard__footer--ZIndex) + 1
-    ); // So the select box can be shown above the wizard footer
-  }
-  .pf-c-wizard__nav {
-    z-index: calc(
-      var(--pf-c-wizard__footer--ZIndex) + 2
-    ); // So the navigation box can be shown above the wizard body
+      var(--pf-c-wizard__toggle--ZIndex) + 1
+    ); // So the select box can be shown above the wizard footer and navigation toggle
   }
   .pf-c-wizard__main-body {
     max-width: 500px;


### PR DESCRIPTION
Fixing this:
![Screenshot from 2023-03-28 12-57-23](https://user-images.githubusercontent.com/30431079/228216910-d661d06a-0c4f-4011-bbd1-64d222ae6ddb.png)
Removed css was not needed as it was trying to solve the issue where users will expend the navigation (on small screen) and could not use the navigation, when the navigation is expanded it has `pf-m-expanded`