### PR TITLE
Fixes #36374 - Wizard should accept search='' in url

### DIFF
--- a/webpack/JobWizard/autofill.js
+++ b/webpack/JobWizard/autofill.js
@@ -48,8 +48,11 @@ export const useAutoFill = ({
           })
         );
       }
-      if (search && !hostIds?.length) {
-        setHostsSearchQuery(search);
+      if ((search || search === '') && !hostIds?.length) {
+        // replace an empty string search with a dummy search query to match all hosts
+        // but only if search query was entered (based on presence of :search parameter)
+        const hostSearch = search === '' ? "name != ''" : search;
+        setHostsSearchQuery(hostSearch);
       }
       if (templateID) {
         setJobTemplateID(+templateID);


### PR DESCRIPTION
Fixes the bug:
User selects all hosts (not only all in page) in hosts page, and clicks on schedule a job
expected: search to be `name != ''` like in the old form