### PR TITLE
Feat: OutputTemplates

### DIFF
--- a/app/assets/javascripts/foreman_remote_execution/output_templates.js
+++ b/app/assets/javascripts/foreman_remote_execution/output_templates.js
@@ -1,0 +1,10 @@
+function show_import_output_template_modal() {
+  var modal_window = $('#importOutputTemplateModal');
+  modal_window.modal({'show': true});
+  modal_window.find('a[rel="popover-modal"]').popover();
+}
+
+function close_import_output_template_modal() {
+  var modal_window = $('#importOutputTemplateModal');
+  modal_window.modal('hide');
+}

--- a/app/assets/stylesheets/foreman_remote_execution/template_invocation.scss
+++ b/app/assets/stylesheets/foreman_remote_execution/template_invocation.scss
@@ -32,7 +32,7 @@ div.terminal {
     min-height: 50px;
   }
 
-  div.line.stderr, div.line.error, div.line.debug {
+  div.line.stderr, div.line.error, div.line.debug, div.line.output_templates, div.line.output_templates_err {
     color: red;
   }
 

--- a/app/controllers/api/v2/output_templates_controller.rb
+++ b/app/controllers/api/v2/output_templates_controller.rb
@@ -1,0 +1,61 @@
+module Api
+  module V2
+    class OutputTemplatesController < ::Api::V2::BaseController
+      include ::Api::Version2
+      include ::Foreman::Renderer
+      include ::Foreman::Controller::ProvisioningTemplates
+      include ::Foreman::Controller::Parameters::OutputTemplate
+
+      api :GET, '/output_templates/', N_('List output templates')
+      # location and Organization
+      param_group :taxonomy_scope, ::Api::V2::BaseController
+      # search and pagination allows to display and filter the index page of templates
+      param_group :search_and_pagination, ::Api::V2::BaseController
+      def index
+        # do not show saved runtime templates
+        @output_templates = resource_scope_for_index.filter { |template| !template.snippet }
+      end
+
+      def_param_group :output_template do
+        param :output_template, Hash, :required => true, :action_aware => true do
+          param :name, String, :required => true, :desc => N_('Template name')
+          param :description, String
+          param :template, String, :required => true
+          param :output, String
+          param :snippet, :bool, :allow_nil => true
+          param :locked, :bool, :desc => N_('Whether or not the template is locked for editing')
+          param :effective_user_attributes, Hash, :desc => N_('Effective user options') do
+            param :value, String, :desc => N_('What user should be used to run the script (using sudo-like mechanisms)'), :allowed_nil => true
+            param :overridable, :bool, :desc => N_('Whether it should be allowed to override the effective user from the invocation form.')
+            param :current_user, :bool, :desc => N_('Whether the current user login should be used as the effective user')
+          end
+          param_group :taxonomies, ::Api::V2::BaseController
+        end
+      end
+
+      api :POST, '/output_templates/', N_('Create an output template')
+      param_group :output_template, :as => :create
+      def create
+        @output_template = OutputTemplate.new(output_template_params)
+        process_response @output_template.save
+      end
+
+      api :DELETE, '/output_templates/:id', N_('Delete an output template')
+      param :id, :identifier, :required => true
+      def destroy
+        process_response @output_template.destroy
+      end
+
+      api :POST, '/output_templates/import', N_('Import an output template from ERB')
+      param :template, String, :required => true, :desc => N_('Template ERB')
+      param :overwrite, :bool, :required => false, :desc => N_('Overwrite template if it already exists')
+      def import
+        options = params[:overwrite] ? { :update => true } : { :build_new => true }
+
+        @output_template = OutputTemplate.import_raw(params[:template], options)
+        @output_template ||= OutputTemplate.new
+        process_response @output_template.save
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/foreman/controller/parameters/job_template.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/job_template.rb
@@ -15,7 +15,7 @@ module Foreman::Controller::Parameters::JobTemplate
 
     def job_template_params_filter
       Foreman::ParameterFilter.new(::TemplateInput).tap do |filter|
-        filter.permit :job_category, :provider_type, :description_format, :execution_timeout_interval,
+        filter.permit :job_category, :provider_type, :description_format, :execution_timeout_interval, :output_template_ids => [],
           :effective_user_attributes => [job_template_effective_user_filter],
           :template_inputs_attributes => [template_input_params_filter],
           :foreign_input_sets_attributes => [foreign_input_set_params_filter]

--- a/app/controllers/concerns/foreman/controller/parameters/output_template.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/output_template.rb
@@ -1,0 +1,29 @@
+module Foreman::Controller::Parameters::OutputTemplate
+  extend ActiveSupport::Concern
+  include Foreman::Controller::Parameters::Taxonomix
+  include ::Foreman::Controller::Parameters::Template
+  include Foreman::Controller::Parameters::TemplateInput
+
+  class_methods do
+    def output_template_effective_user_filter
+      Foreman::ParameterFilter.new(::OutputTemplateEffectiveUser).tap do |filter|
+        filter.permit_by_context(:value, :current_user, :overridable,
+          :nested => true)
+      end
+    end
+
+    def output_template_params_filter
+      Foreman::ParameterFilter.new(::TemplateInput).tap do |filter|
+        filter.permit :description_format,
+          :effective_user_attributes => [output_template_effective_user_filter],
+          :template_inputs_attributes => [template_input_params_filter]
+        add_template_params_filter(filter)
+        add_taxonomix_params_filter(filter)
+      end
+    end
+  end
+
+  def output_template_params
+    self.class.output_template_params_filter.filter_params(params, parameter_filter_context, :output_template)
+  end
+end

--- a/app/controllers/output_templates_controller.rb
+++ b/app/controllers/output_templates_controller.rb
@@ -1,0 +1,18 @@
+class OutputTemplatesController < ::TemplatesController
+  include ::Foreman::Controller::Parameters::OutputTemplate
+
+  def import
+    contents = params.fetch(:imported_template, {}).fetch(:template, nil).try(:read)
+
+    @template = OutputTemplate.import_raw(contents, :update => ActiveRecord::Type::Boolean.new.deserialize(params[:imported_template][:overwrite]))
+    if @template&.save
+      flash[:success] = _('Output template imported successfully.')
+      redirect_to output_templates_path(:search => "name = \"#{@template.name}\"")
+    else
+      @template ||= OutputTemplate.import_raw(contents, :build_new => true)
+      @template.valid?
+      flash[:warning] = _('Unable to save template. Correct highlighted errors')
+      render :action => 'new'
+    end
+  end
+end

--- a/app/controllers/template_invocations_controller.rb
+++ b/app/controllers/template_invocations_controller.rb
@@ -15,6 +15,8 @@ class TemplateInvocationsController < ApplicationController
     @since = params[:since].to_f if params[:since].present?
     @line_sets = @template_invocation_task.main_action.live_output
     @line_sets = @line_sets.drop_while { |o| o['timestamp'].to_f <= @since } if @since
+    @template_output_sets = @line_sets.select { |o| o['output_type'] == 'template_output' || o['output_type'] == 'template_output_err' }
+    @line_sets.select! { |o| o['output_type'] != 'template_output' && o['output_type'] != 'template_output_err' }
     @line_counter = params[:line_counter].to_i
   end
 end

--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -20,6 +20,7 @@ class UiJobWizardController < ApplicationController
       :template_inputs => template_inputs,
       :provider_name => job_template.provider.provider_input_namespace,
       :advanced_template_inputs => advanced_template_inputs+provider_inputs,
+      :default_output_templates => job_template.output_templates,
     }
   end
 

--- a/app/lib/actions/remote_execution/output_processing_action.rb
+++ b/app/lib/actions/remote_execution/output_processing_action.rb
@@ -1,0 +1,45 @@
+module Actions
+  module RemoteExecution
+    class OutputProcessing < Dynflow::Action
+
+      def process_proxy_template(output, template, invocation)
+        base = Host.authorized(:view_hosts, Host)
+        # provide host information for the output template rendering
+        host = base.find(invocation.host_id)
+        renderer = InputTemplateRenderer.new(template, host, invocation, nil, false, [], output)
+        processed_output = renderer.render
+        unless processed_output
+          return renderer.error_message.html_safe, false
+        end
+        return processed_output, true
+      end
+
+      def run
+        processed_outputs = []
+        template_invocation = TemplateInvocation.find(input[:template_invocation_id])
+        events = template_invocation.template_invocation_events
+        sq_id = events.max_by { |e| e.sequence_id }.sequence_id + 1
+        output_templates = template_invocation.job_invocation.output_templates
+        output_templates.each_with_index.map do |output_templ, templ_id|
+          for i in 0..events.length - 1 do
+            if events[i][:event].instance_of?(String) && events[i][:event_type] == 'stdout'
+              output, success = process_proxy_template(events[i][:event], output_templ, template_invocation)
+              processed_outputs << {
+                sequence_id: sq_id,
+                template_invocation_id: template_invocation.id,
+                event: output,
+                timestamp: events[i][:timestamp] || Time.zone.now,
+                event_type: success ? 'template_output' : 'template_output_err',
+              }
+              # template invocation id and a sequence combination has to be unique
+              sq_id += 1
+            end
+          end
+        end
+        processed_outputs.each_slice(1000) do |batch|
+          TemplateInvocationEvent.upsert_all(batch, unique_by: [:template_invocation_id, :sequence_id]) # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -185,9 +185,11 @@ module Actions
         property :task, object_of: 'Task', desc: 'Returns the task to which this action belongs'
         property :job_invocation_id, Integer, desc: "Returns the id of the job invocation"
         property :job_invocation, object_of: 'JobInvocation', desc: "Returns the job invocation"
+        property :output, String, desc: "Returns the output of the template invocation"
       end
       class Jail < ::Actions::ObservableAction::Jail
-        allow :job_invocation_id, :job_invocation
+        # enables variables in the template
+        allow :job_invocation_id, :job_invocation, :output
       end
     end
   end

--- a/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/taxonomy_extensions.rb
@@ -4,6 +4,7 @@ module ForemanRemoteExecution
 
     included do
       has_many :job_templates, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'JobTemplate'
+      has_many :output_templates, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'OutputTemplate'
 
       # TODO: on foreman_version_bump
       # workaround for #11805 - use before_create for setting

--- a/app/models/input_template_renderer.rb
+++ b/app/models/input_template_renderer.rb
@@ -7,12 +7,12 @@ class InputTemplateRenderer
 
   delegate :logger, to: Rails
 
-  attr_accessor :template, :host, :invocation, :template_input_values, :error_message, :templates_stack, :current_user
+  attr_accessor :template, :host, :invocation, :template_input_values, :error_message, :templates_stack, :current_user, :output
 
   # takes template object that should be rendered
   # host and template invocation arguments are optional
   # so we can render values based on parameters, facts or user inputs
-  def initialize(template, host = nil, invocation = nil, input_values = nil, preview = false, templates_stack = [])
+  def initialize(template, host = nil, invocation = nil, input_values = nil, preview = false, templates_stack = [], output = "")
     raise Foreman::Exception, N_('Recursive rendering of templates detected') if templates_stack.include?(template)
 
     @host = host
@@ -21,6 +21,8 @@ class InputTemplateRenderer
     @template_input_values = input_values
     @preview = preview
     @templates_stack = templates_stack + [template]
+    # gives templates the access to the output variable
+    @output = output
   end
 
   def render
@@ -44,6 +46,7 @@ class InputTemplateRenderer
         templates_stack: templates_stack,
         input_template_instance: self,
         current_user: User.current.try(:login),
+        output: output,
       }
     )
     Foreman::Renderer.render(source, @scope)

--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -90,6 +90,10 @@ class JobInvocation < ApplicationRecord
 
   encrypts :password, :key_passphrase, :effective_user_password
 
+  # join table for linking output templates
+  has_many :job_invocation_templates, dependent: :destroy
+  has_many :output_templates, through: :job_invocation_templates
+
   class Jail < Safemode::Jail
     allow :sub_task_for_host, :template_invocations_hosts
   end

--- a/app/models/job_invocation_template.rb
+++ b/app/models/job_invocation_template.rb
@@ -1,0 +1,4 @@
+class JobInvocationTemplate < ApplicationRecord
+  belongs_to :job_invocation
+  belongs_to :output_template
+end

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -23,6 +23,9 @@ class JobTemplate < ::Template
   # rubocop:enable Rails/HasManyOrHasOneDependent
   has_many :remote_execution_features, :dependent => :nullify
 
+  has_many :job_template_output_templates, dependent: :destroy
+  has_many :output_templates, through: :job_template_output_templates
+
   # these can't be shared in parent class, scoped search can't handle STI properly
   # tested with scoped_search 3.2.0
   include Taxonomix

--- a/app/models/job_template_output_template.rb
+++ b/app/models/job_template_output_template.rb
@@ -1,0 +1,4 @@
+class JobTemplateOutputTemplate < ApplicationRecord
+  belongs_to :job_template
+  belongs_to :output_template
+end

--- a/app/models/output_template.rb
+++ b/app/models/output_template.rb
@@ -1,0 +1,57 @@
+class OutputTemplate < ::Template
+  audited
+  include Taxonomix
+  include Authorizable
+
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+  scoped_search :on => :name, :complete_value => true, :default_order => true
+  scoped_search :on => :locked, :complete_value => {:true => true, :false => false}
+  scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}
+
+  has_many :audits, :as => :auditable, :class_name => Audited.audit_class.name, :dependent => :nullify
+  validates :name, :uniqueness => true
+  validates :template, :presence => true
+
+  has_many :job_invocation_templates, dependent: :destroy
+  has_many :job_invocations, through: :job_invocation_templates
+
+  has_many :job_template_output_templates, dependent: :destroy
+  has_many :job_templates, through: :job_template_output_templates
+
+  class << self
+    # we have to override the base_class because polymorphic associations does not detect it correctly, more details at
+    # http://apidock.com/rails/ActiveRecord/Associations/ClassMethods/has_many#1010-Polymorphic-has-many-within-inherited-class-gotcha
+    def base_class
+      self
+    end
+
+    # allows importing templates in the controller
+    def import_raw(contents, options = {})
+      metadata = Template.parse_metadata(contents)
+      import_parsed(metadata['name'], contents, metadata, options)
+    end
+
+    def import_raw!(contents, options = {})
+      template = import_raw(contents, options)
+      template&.save!
+      template
+    end
+
+    def import_parsed(name, text, _metadata, options = {})
+      transaction do
+        # Do not search for duplicates in case we want to always create new template
+        existing = self.find_by(:name => name) if !options.delete(:build_new)
+        # Do not save duplicates
+        return unless options.delete(:update) && existing
+
+        template = existing || self.new(:name => name)
+        template.import_without_save(text, options)
+        template
+      end
+    end
+  end
+
+  def default_input_values(ignore_keys)
+    return {}
+  end
+end

--- a/app/models/output_template_effective_user.rb
+++ b/app/models/output_template_effective_user.rb
@@ -1,0 +1,19 @@
+class OutputTemplateEffectiveUser < ApplicationRecord
+  belongs_to :output_template
+  before_validation :set_defaults
+
+  def set_defaults
+    self.overridable = true if self.overridable.nil?
+    self.current_user = false if self.current_user.nil?
+  end
+
+  def compute_value
+    if current_user?
+      User.current.login
+    elsif value.present?
+      value
+    else
+      Setting[:remote_execution_effective_user]
+    end
+  end
+end

--- a/app/views/api/v2/output_templates/base.json.rabl
+++ b/app/views/api/v2/output_templates/base.json.rabl
@@ -1,0 +1,3 @@
+object @output_template
+
+attributes :id, :name, :provider_type, :snippet, :description_format, :created_at, :updated_at

--- a/app/views/api/v2/output_templates/index.json.rabl
+++ b/app/views/api/v2/output_templates/index.json.rabl
@@ -1,0 +1,3 @@
+collection @output_templates
+
+extends 'api/v2/output_templates/base'

--- a/app/views/job_templates/_custom_tab_headers.html.erb
+++ b/app/views/job_templates/_custom_tab_headers.html.erb
@@ -1,2 +1,3 @@
 <li><a href="#template_job" data-toggle="tab"><%= _("Job") %></a></li>
 <li><a href="#template_type" data-toggle="tab"><%= _("Type") %></a></li>
+<li><a href="#output_templates" data-toggle="tab"><%= _('Output Templates') %></a></li>

--- a/app/views/job_templates/_custom_tabs.html.erb
+++ b/app/views/job_templates/_custom_tabs.html.erb
@@ -39,3 +39,7 @@
 <div class="tab-pane" id="template_type">
   <%= checkbox_f f, :snippet, :onchange => "snippet_changed(this)", :label=>_('Snippet'), :disabled => @template.locked? %>
 </div>
+
+<div class="tab-pane" id="output_templates">
+  <%= multiple_selects f, :output_template_ids, OutputTemplate, @template.output_templates.try(:map, &:id), :label => _("Default Output Templates") %>
+</div>

--- a/app/views/output_templates/_import_output_template_modal.html.erb
+++ b/app/views/output_templates/_import_output_template_modal.html.erb
@@ -1,0 +1,20 @@
+<% stylesheet 'foreman_remote_execution/foreman_remote_execution' %>
+
+<!-- modal window -->
+<div class="modal fade" id="importOutputTemplateModal" role="dialog" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" onclick="close_import_output_template_modal(); return false;"><span aria-hidden="true">&times;</span><span class="sr-only"><%= _('Close') %></span></button>
+        <h4 class="modal-title">Import Output Template</h4>
+      </div>
+      <div class="modal-body">
+        <%= form_for :imported_template, :url => import_output_templates_path do |f| %>
+          <%= file_field_f f, :template, :size => "col-md-10", :help_block  => _("Select an ERB file to upload in order to import an output template. The template must contain metadata in the first ERB comment.") %>
+          <%= checkbox_f(f, :overwrite, :label => _('Overwrite'), :help_block => _("Whether to overwrite the template if it already exists")) %>
+          <%= submit_or_cancel f, false, :cancel_path => 'javascript:close_import_output_template_modal();' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/output_templates/edit.html.erb
+++ b/app/views/output_templates/edit.html.erb
@@ -1,0 +1,18 @@
+<%= javascript 'foreman_remote_execution/template_input' %>
+
+<%= breadcrumbs(
+    items: [
+      {
+        caption: _('Output Templates'),
+        url: url_for(output_templates_path)
+      },
+      {
+        caption: _('Edit %s' % @template.to_label)
+      }
+    ]
+  )
+%>
+
+<% title _("Edit Output Template") %>
+
+<%= render :partial => 'form' %>

--- a/app/views/output_templates/index.html.erb
+++ b/app/views/output_templates/index.html.erb
@@ -1,0 +1,38 @@
+<%= javascript 'foreman_remote_execution/output_templates' %>
+<%= javascript 'foreman_remote_execution/template_input' %>
+
+<% title _("Output Templates") %>
+<% title_actions(link_to_function(_('Import'), 'show_import_output_template_modal();', :class => 'btn btn-default'),
+                 new_link(_("Create Output Template"))) %>
+
+<table class="<%= table_css_classes('table-fixed') %>">
+  <thead>
+    <tr>
+      <th class="col-md-6"><%= sort :name, :as => s_("OutputTemplate|Name") %></th>
+      <th class="col-md-1"><%= sort :snippet, :as => s_("OutputTemplate|Snippet") %></th>
+      <th class="col-md-1"><%= sort :locked, :as => s_("OutputTemplate|Locked"), :default => "DESC" %></th>
+      <th class="col-md-1"><%= _('Actions') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% for output_template in @templates %>
+      <% if !output_template.snippet %>
+        <%# do not show runtime templates %>
+        <tr>
+          <td class="display-two-pane ellipsis"><%= link_to_if_authorized output_template,
+                                                                hash_for_edit_output_template_path(:id => output_template).merge(:auth_object => output_template, :authorizer => authorizer) %></td>
+          <td align='center'><%= checked_icon output_template.snippet %></td>
+          <td align='center'>
+            <%= locked_icon output_template.locked?, _("This template is locked for editing.") %>
+          </td>
+          <td>
+            <%= action_buttons(*permitted_actions(output_template)) %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+<%= will_paginate_with_info @templates %>
+
+<%= render :partial => 'import_output_template_modal' %>

--- a/app/views/output_templates/new.html.erb
+++ b/app/views/output_templates/new.html.erb
@@ -1,0 +1,5 @@
+<%= javascript 'foreman_remote_execution/template_input' %>
+
+<% title _("New Output Template") %>
+
+<%= render :partial => 'form' %>

--- a/app/views/template_invocations/show.html.erb
+++ b/app/views/template_invocations/show.html.erb
@@ -16,42 +16,69 @@ end
 <% stylesheet 'foreman_remote_execution/foreman_remote_execution' %>
 <% javascript 'foreman_remote_execution/template_invocation' %>
 
-<div id="title_action">
-  <div class="btn-toolbar pull-right">
-    <%= button_group(link_to(_('Back to Job'), job_invocation_path(@template_invocation.job_invocation), :class => 'btn btn-default'),
-                    (link_to(_('Rerun'), rerun_job_invocation_path(@template_invocation.job_invocation, :host_ids => [ @host.id ]), :class => 'btn btn-default') if authorized_for(:permission => :create_job_invocations))) %>
-    <%= button_group(link_to_function(_('Toggle command'), '$("div.preview").toggle()', :class => 'btn btn-default'),
-                     link_to_function(_('Toggle STDERR'), '$("div.line.stderr").toggle()', :class => 'btn btn-default'),
-                     link_to_function(_('Toggle STDOUT'), '$("div.line.stdout").toggle()', :class => 'btn btn-default'),
-                     link_to_function(_('Toggle DEBUG'), '$("div.line.debug").toggle()', :class => 'btn btn-default')) if @host %>
-    <%= button_group(template_invocation_task_buttons(@template_invocation_task, @template_invocation.job_invocation)) %>
-  </div>
-</div>
-<% if @host %>
-  <% proxy_id = @template_invocation_task.input[:proxy_id] %>
-  <h3>
-    <%= _('Target: ') %><%= link_to(@host.name, current_host_details_path(@host)) %>
-    <% if proxy_id && proxy = SmartProxy.find_by(id: proxy_id) %>
-      <%= _('using Smart Proxy') %> <%= link_to(proxy.name, smart_proxy_path(proxy)) %>
+<div id="template-invocations-show" class="row">
+  <%# add tab to template invocation show page %>
+  <ul id="template-invocations-show-tabs" class="nav nav-tabs">
+    <li class="active"><a href="#results" data-toggle="tab"><%= _('Results') %></a></li>
+    <% unless @template_output_sets.empty? %>
+      <li><a href="#processed" data-toggle="tab"><%= _('Processed') %></a></li>
     <% end %>
-  </h3>
-
-  <div class="preview hidden">
-    <%= preview_box(@template_invocation, @host) %>
-  </div>
-
-  <div class="terminal" data-refresh-url="<%= template_invocation_path(@template_invocation) %>">
-    <% if @error %>
-      <div class="line error"><%= @error %></div>
-    <% else %>
-      <%= link_to_function(_('Scroll to bottom'), '$("html, body").animate({ scrollTop: $(document).height() }, "slow");', :class => 'pull-right scroll-link-bottom') %>
-
-      <div class="printable">
-        <%= render :partial => 'output_line_set', :collection => normalize_line_sets(@line_sets) %>
+  </ul>
+  <div id="host-show-tabs-content" class="tab-content">
+    <div class="tab-pane active" id="results">
+      <div id="title_action">
+        <div class="btn-toolbar pull-right">
+          <%= button_group(link_to(_('Back to Job'), job_invocation_path(@template_invocation.job_invocation), :class => 'btn btn-default'),
+                          (link_to(_('Rerun'), rerun_job_invocation_path(@template_invocation.job_invocation, :host_ids => [ @host.id ]), :class => 'btn btn-default') if authorized_for(:permission => :create_job_invocations))) %>
+          <%= button_group(link_to_function(_('Toggle command'), '$("div.preview").toggle()', :class => 'btn btn-default'),
+                          link_to_function(_('Toggle STDERR'), '$("div.line.stderr").toggle()', :class => 'btn btn-default'),
+                          link_to_function(_('Toggle STDOUT'), '$("div.line.stdout").toggle()', :class => 'btn btn-default'),
+                          link_to_function(_('Toggle DEBUG'), '$("div.line.debug").toggle()', :class => 'btn btn-default')) if @host %>
+          <%= button_group(template_invocation_task_buttons(@template_invocation_task, @template_invocation.job_invocation)) %>
+        </div>
       </div>
+      <% if @host %>
+        <% proxy_id = @template_invocation_task.input[:proxy_id] %>
+        <h3>
+          <%= _('Target: ') %><%= link_to(@host.name, current_host_details_path(@host)) %>
+          <% if proxy_id && proxy = SmartProxy.find_by(id: proxy_id) %>
+            <%= _('using Smart Proxy') %> <%= link_to(proxy.name, smart_proxy_path(proxy)) %>
+          <% end %>
+        </h3>
 
-      <%= link_to_function(_('Scroll to top'), '$("html, body").animate({ scrollTop: 0 }, "slow");', :class => 'pull-right scroll-link-top') %>
-    <% end %>
+        <div class="preview hidden">
+          <%= preview_box(@template_invocation, @host) %>
+        </div>
+        <div class="terminal" data-refresh-url="<%= template_invocation_path(@template_invocation) %>">
+          <% if @error %>
+            <div class="line error"><%= @error %></div>
+          <% else %>
+            <%= link_to_function(_('Scroll to bottom'), '$("html, body").animate({ scrollTop: $(document).height() }, "slow");', :class => 'pull-right scroll-link-bottom') %>
+
+            <div class="printable">
+              <%= render :partial => 'output_line_set', :collection => normalize_line_sets(@line_sets) %>
+            </div>
+
+            <%= link_to_function(_('Scroll to top'), '$("html, body").animate({ scrollTop: 0 }, "slow");', :class => 'pull-right scroll-link-top') %>
+          <% end %>
+        </div>
+      </div>
+      <div class="tab-pane" id="processed">
+        <% for processed_output in @template_output_sets %>
+          <div class="terminal" data-refresh-url="<%= template_invocation_path(@template_invocation) %>">
+            <% if processed_output['output_type'] == "template_output_err" %>
+              <div class="line error">
+            <% else %>
+              <div class="printable">
+            <% end %>
+                <%# separate each processed output and prepend line numbers %>
+                <% @line_counter = 0 %>
+                <%= render :partial => 'output_line_set', :collection => normalize_line_sets([processed_output]) %>
+              </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,21 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :output_templates, :except => [:show] do
+    member do
+      get 'clone_template'
+      get 'lock'
+      get 'export'
+      get 'unlock'
+      post 'preview'
+    end
+    collection do
+      post 'preview'
+      post 'import'
+      get 'auto_complete_search'
+    end
+  end
+
   match 'job_invocations/new', to: 'react#index', :via => [:get], as: 'new_job_invocation'
   match 'job_invocations/new', to: 'job_invocations#create', via: [:post], as: 'create_job_invocation'
   match 'job_invocations/', to: 'job_invocations#legacy_create', via: [:post], as: 'legacy_create_job_invocation'
@@ -80,12 +95,24 @@ Rails.application.routes.draw do
         end
       end
 
+      resources :output_templates, :except => [:new, :edit] do
+        resources :locations, :only => [:index, :show]
+        resources :organizations, :only => [:index, :show]
+        get :export, :on => :member
+        post :clone, :on => :member
+        collection do
+          post 'import'
+        end
+      end
+
       resources :organizations, :only => [:index] do
         resources :job_templates, :only => [:index, :show]
+        resources :output_templates, :only => [:index, :show]
       end
 
       resources :locations, :only => [:index] do
         resources :job_templates, :only => [:index, :show]
+        resources :output_templates, :only => [:index, :show]
       end
 
       resources :templates, :only => :none do

--- a/db/migrate/20230303084916_change_index.rb
+++ b/db/migrate/20230303084916_change_index.rb
@@ -1,0 +1,15 @@
+class ChangeIndex < ActiveRecord::Migration[6.1]
+  def up
+    remove_index :template_invocation_events, name: 'unique_template_invocation_events_index'
+    add_index :template_invocation_events, [:template_invocation_id, :sequence_id], name: 'unique_template_invocation_events_index', unique: true
+  end
+
+  def down
+    change_table :template_invocation_events do |t|
+      t.remove_index name: :unique_template_invocation_events_index
+      t.index [:template_invocation_id, :timestamp, :event_type, :sequence_id],
+        unique: true,
+        name: 'unique_template_invocation_events_index'
+    end
+  end
+end

--- a/db/migrate/20230316090507_create_job_invocation_template.rb
+++ b/db/migrate/20230316090507_create_job_invocation_template.rb
@@ -1,0 +1,10 @@
+class CreateJobInvocationTemplate < ActiveRecord::Migration[6.1]
+  def change
+    create_table :job_invocation_templates do |t|
+      t.references :job_invocation, null: false, foreign_key: true
+      t.references :output_template, null: false, foreign_key: {to_table: :templates}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230428112606_create_job_template_output_template.rb
+++ b/db/migrate/20230428112606_create_job_template_output_template.rb
@@ -1,0 +1,8 @@
+class CreateJobTemplateOutputTemplate < ActiveRecord::Migration[6.1]
+  def change
+    create_table :job_template_output_templates do |t|
+      t.references :job_template, null: false, foreign_key: {to_table: :templates}
+      t.references :output_template, null: false, foreign_key: {to_table: :templates}
+    end
+  end
+end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -195,6 +195,7 @@ module ForemanRemoteExecution
           permission :filter_autocompletion_for_template_invocation, { :template_invocations => [ :auto_complete_search, :index ] },
             :resource_type => 'TemplateInvocation'
           permission :cockpit_hosts, { 'cockpit' => [:redirect, :host_ssh_params] }, :resource_type => 'Host'
+          permission :view_output_templates, { :output_templates => [:index, :show, :auto_complete_search, :preview, :export]}, :resource_type => 'OutputTemplate'
         end
 
         USER_PERMISSIONS = [
@@ -232,6 +233,11 @@ module ForemanRemoteExecution
           caption: N_('Job templates'),
           parent: :hosts_menu,
           after: :provisioning_templates
+        menu :top_menu, :output_templates,
+          url_hash: { controller: :output_templates, action: :index },
+          caption: N_('Output templates'),
+          parent: :hosts_menu,
+          after: :job_templates
         menu :admin_menu, :remote_execution_features,
           url_hash: { controller: :remote_execution_features, action: :index },
           caption: N_('Remote Execution Features'),

--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -15,6 +15,7 @@ import CategoryAndTemplate from './steps/CategoryAndTemplate/';
 import { AdvancedFields } from './steps/AdvancedFields/AdvancedFields';
 import {
   JOB_TEMPLATE,
+  OUTPUT_TEMPLATE,
   WIZARD_TITLES,
   SCHEDULE_TYPES,
   initialScheduleState,
@@ -46,6 +47,9 @@ export const JobWizard = ({ rerunData }) => {
     rerunData?.template_invocations?.[0]?.template_id ||
       jobCategoriesResponse?.default_template
   );
+  const [selectedOutputTemplates, setOutputTemplates] = useState([]);
+  const [runtimeTemplate, setRuntimeTemplate] = useState('');
+
   const [category, setCategory] = useState(
     rerunData?.job_category || jobCategoriesResponse?.default_category || ''
   );
@@ -215,14 +219,17 @@ export const JobWizard = ({ rerunData }) => {
     setSelectedTargets,
     setHostsSearchQuery,
     setJobTemplateID,
+    setOutputTemplates,
     setTemplateValues,
     setAdvancedValues,
   });
   const templateError = !!useSelector(selectTemplateError);
   const templateResponse = useSelector(selectJobTemplate);
   const isSubmitting = useSelector(selectIsSubmitting);
-  const isTemplatesLoading = useSelector(state =>
-    selectIsLoading(state, JOB_TEMPLATE)
+  const isTemplatesLoading = useSelector(
+    state =>
+      selectIsLoading(state, JOB_TEMPLATE) &&
+      selectIsLoading(state, OUTPUT_TEMPLATE)
   );
   const isTemplate =
     !isTemplatesLoading &&
@@ -241,6 +248,10 @@ export const JobWizard = ({ rerunData }) => {
         <CategoryAndTemplate
           jobTemplate={jobTemplateID}
           setJobTemplate={setJobTemplateID}
+          outputTemplates={selectedOutputTemplates}
+          setOutputTemplates={setOutputTemplates}
+          runtimeTemplate={runtimeTemplate}
+          setRuntimeTemplate={setRuntimeTemplate}
           category={category}
           setCategory={setCategory}
           isCategoryPreselected={
@@ -395,6 +406,8 @@ export const JobWizard = ({ rerunData }) => {
         <ReviewDetails
           jobCategory={category}
           jobTemplateID={jobTemplateID}
+          selectedOutputTemplates={selectedOutputTemplates}
+          runtimeTemplate={runtimeTemplate}
           advancedValues={advancedValues}
           scheduleValue={scheduleValue}
           templateValues={templateValues}
@@ -424,6 +437,8 @@ export const JobWizard = ({ rerunData }) => {
   const onSave = () => {
     submit({
       jobTemplateID,
+      selectedOutputTemplates,
+      runtimeTemplate,
       templateValues,
       advancedValues,
       scheduleValue,
@@ -486,6 +501,7 @@ JobWizard.propTypes = {
         input_values: PropTypes.array,
       })
     ),
+    output_templates: PropTypes.array,
     inputs: PropTypes.object,
     description_format: PropTypes.string,
   }),

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -2,10 +2,13 @@ import { translate as __ } from 'foremanReact/common/I18n';
 import { foremanUrl } from 'foremanReact/common/helpers';
 
 export const JOB_TEMPLATES = 'JOB_TEMPLATES';
+export const OUTPUT_TEMPLATES = 'OUTPUT_TEMPLATES';
 export const JOB_CATEGORIES = 'JOB_CATEGORIES';
 export const JOB_TEMPLATE = 'JOB_TEMPLATE';
+export const OUTPUT_TEMPLATE = 'OUTPUT_TEMPLATE';
 export const JOB_INVOCATION = 'JOB_INVOCATION';
 export const templatesUrl = foremanUrl('/api/v2/job_templates');
+export const outputTemplatesUrl = foremanUrl('/api/v2/output_templates');
 
 export const repeatTypes = {
   noRepeat: __('Does not repeat'),

--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -9,8 +9,10 @@ import { selectRouterLocation } from 'foremanReact/routes/RouterSelector';
 
 import {
   JOB_TEMPLATES,
+  OUTPUT_TEMPLATES,
   JOB_CATEGORIES,
   JOB_TEMPLATE,
+  OUTPUT_TEMPLATE,
   HOSTS_API,
   JOB_INVOCATION,
 } from './JobWizardConstants';
@@ -26,6 +28,19 @@ export const selectJobTemplates = state =>
 
 export const selectJobTemplatesSearch = state =>
   selectAPIResponse(state, JOB_TEMPLATES)?.search;
+
+export const filterOutputTemplates = templates =>
+  templates?.filter(template => !template.snippet) || [];
+
+export const selectOutputTemplates = state =>
+  filterOutputTemplates(selectAPIResponse(state, OUTPUT_TEMPLATES)?.results) ||
+  filterOutputTemplates(selectAPIResponse(state, OUTPUT_TEMPLATES));
+
+export const selectOutputTemplatesStatus = state =>
+  selectAPIStatus(state, OUTPUT_TEMPLATES);
+
+export const selectOutputTemplatesSearch = state =>
+  selectAPIResponse(state, OUTPUT_TEMPLATES)?.search;
 
 export const selectJobCategoriesResponse = state =>
   selectAPIResponse(state, JOB_CATEGORIES) || {};
@@ -48,6 +63,9 @@ export const selectAllTemplatesError = state =>
 export const selectTemplateError = state =>
   selectAPIErrorMessage(state, JOB_TEMPLATE);
 
+export const selectOutputTemplateError = state =>
+  selectAPIErrorMessage(state, OUTPUT_TEMPLATE);
+
 export const selectJobTemplate = state =>
   selectAPIResponse(state, JOB_TEMPLATE);
 
@@ -56,6 +74,9 @@ export const selectEffectiveUser = state =>
 
 export const selectAdvancedTemplateInputs = state =>
   selectAPIResponse(state, JOB_TEMPLATE).advanced_template_inputs || [];
+
+export const selectDefaultOutputTemplates = state =>
+  selectAPIResponse(state, JOB_TEMPLATE).default_output_templates || [];
 
 export const selectTemplateInputs = state =>
   selectAPIResponse(state, JOB_TEMPLATE).template_inputs || [];

--- a/webpack/JobWizard/steps/CategoryAndTemplate/OutputTemplateTextField.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/OutputTemplateTextField.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { FormGroup, TextArea } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+export const OutputTemplateTextField = ({
+  runtimeTemplate,
+  setRuntimeTemplate,
+}) => (
+  <FormGroup label="Runtime template" isRequired={false}>
+    <TextArea
+      required={false}
+      value={runtimeTemplate}
+      onChange={setRuntimeTemplate}
+    />
+  </FormGroup>
+);
+
+OutputTemplateTextField.propTypes = {
+  runtimeTemplate: PropTypes.string.isRequired,
+  setRuntimeTemplate: PropTypes.func.isRequired,
+};

--- a/webpack/JobWizard/steps/CategoryAndTemplate/SelectedTemplates.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/SelectedTemplates.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Chip, ChipGroup, Button } from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const SelectedTemplate = ({ selected, setSelected, categoryName }) => {
+  const deleteItem = itemToRemove => {
+    setSelected(oldSelected =>
+      oldSelected.filter(item => item.id !== itemToRemove)
+    );
+  };
+  return (
+    <ChipGroup className="templates-chip-group" categoryName={categoryName}>
+      {selected.map(({ name, id }, index) => (
+        <Chip
+          key={index}
+          id={`${categoryName}-${id}`}
+          onClick={() => deleteItem(id)}
+          closeBtnAriaLabel={`Close ${name}`}
+        >
+          {name}
+        </Chip>
+      ))}
+    </ChipGroup>
+  );
+};
+
+export const SelectedTemplates = ({
+  selectedOutputTemplates,
+  setOutputTemplates,
+  runtimeTemplate,
+  setRuntimeTemplate,
+}) => {
+  const clearAll = () => {
+    setOutputTemplates(() => []);
+    setRuntimeTemplate(() => '');
+  };
+  return (
+    <div className="selected-chips">
+      <SelectedTemplate
+        selected={selectedOutputTemplates}
+        categoryName="Predefined templates"
+        setSelected={setOutputTemplates}
+      />
+      <Button variant="link" className="clear-chips" onClick={clearAll}>
+        {__('Clear templates')}
+      </Button>
+    </div>
+  );
+};
+
+SelectedTemplates.propTypes = {
+  selectedOutputTemplates: PropTypes.array.isRequired,
+  setOutputTemplates: PropTypes.func.isRequired,
+  runtimeTemplate: PropTypes.string.isRequired,
+  setRuntimeTemplate: PropTypes.func.isRequired,
+};
+
+SelectedTemplate.propTypes = {
+  categoryName: PropTypes.string.isRequired,
+  selected: PropTypes.array.isRequired,
+  setSelected: PropTypes.func.isRequired,
+};

--- a/webpack/JobWizard/steps/CategoryAndTemplate/searchOutputTemplates.js
+++ b/webpack/JobWizard/steps/CategoryAndTemplate/searchOutputTemplates.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import URI from 'urijs';
+import { SelectVariant } from '@patternfly/react-core';
+import { get } from 'foremanReact/redux/API';
+import { selectResponse, selectIsLoading } from '../../JobWizardSelectors';
+import { SearchSelect } from '../form/SearchSelect';
+
+export const searchOutputTemplates = (apiKey, url) => {
+  const dispatch = useDispatch();
+  const uri = new URI(url);
+  const onSearch = search =>
+    dispatch(
+      get({
+        key: apiKey,
+        url: uri.addSearch({
+          per_page: 'all',
+        }),
+      })
+    );
+
+  const response = useSelector(state => selectResponse(state, apiKey));
+  const isLoading = useSelector(state => selectIsLoading(state, apiKey));
+  return [onSearch, response, isLoading];
+};
+
+export const OutputSelect = props => (
+  <SearchSelect
+    {...props}
+    variant={SelectVariant.typeaheadMulti}
+    useNameSearch={searchOutputTemplates}
+  />
+);

--- a/webpack/JobWizard/steps/ReviewDetails/index.js
+++ b/webpack/JobWizard/steps/ReviewDetails/index.js
@@ -33,6 +33,8 @@ import { HostPreviewModal } from '../HostsAndInputs/HostPreviewModal';
 const ReviewDetails = ({
   jobCategory,
   jobTemplateID,
+  selectedOutputTemplates,
+  runtimeTemplate,
   advancedValues,
   scheduleValue,
   templateValues,
@@ -96,6 +98,24 @@ const ReviewDetails = ({
       </div>
     );
   };
+  const stringOutputTemplates = () => {
+    const runtimeTemplateCount = runtimeTemplate === '' ? 0 : 1;
+    const outputTemplatesTotal =
+      selectedOutputTemplates.length + runtimeTemplateCount;
+    if (outputTemplatesTotal === 0) {
+      return __('No Output Templates');
+    }
+    if (
+      (outputTemplatesTotal === 1 || outputTemplatesTotal === 2) &&
+      outputTemplatesTotal === selectedOutputTemplates.length
+    ) {
+      return selectedOutputTemplates.map(t => t.name).join(', ');
+    }
+    if (runtimeTemplateCount === 1 && outputTemplatesTotal === 1) {
+      return runtimeTemplate;
+    }
+    return outputTemplatesTotal + __(' templates selected');
+  };
   const [isAdvancedShown, setIsAdvancedShown] = useState(false);
   const detailsFirstHalf = [
     {
@@ -113,6 +133,14 @@ const ReviewDetails = ({
         </StepButton>
       ),
       value: jobTemplate,
+    },
+    {
+      label: (
+        <StepButton stepName={WIZARD_TITLES.categoryAndTemplate}>
+          {__('Output template')}
+        </StepButton>
+      ),
+      value: stringOutputTemplates(),
     },
     {
       label: (
@@ -323,6 +351,8 @@ const ReviewDetails = ({
 ReviewDetails.propTypes = {
   jobCategory: PropTypes.string.isRequired,
   jobTemplateID: PropTypes.number,
+  selectedOutputTemplates: PropTypes.array.isRequired,
+  runtimeTemplate: PropTypes.string.isRequired,
   advancedValues: PropTypes.object.isRequired,
   scheduleValue: PropTypes.object.isRequired,
   templateValues: PropTypes.object.isRequired,

--- a/webpack/JobWizard/submit.js
+++ b/webpack/JobWizard/submit.js
@@ -4,6 +4,8 @@ import { buildHostQuery } from './steps/HostsAndInputs/buildHostQuery';
 
 export const submit = ({
   jobTemplateID,
+  selectedOutputTemplates,
+  runtimeTemplate,
   templateValues,
   advancedValues,
   scheduleValue,
@@ -118,6 +120,8 @@ export const submit = ({
       execution_timeout_interval: timeoutToKill,
       feature,
       time_to_pickup: timeToPickup,
+      output_templates: selectedOutputTemplates,
+      runtime_templates: [runtimeTemplate],
     },
   };
   if (Object.keys(providerValues).length) {


### PR DESCRIPTION
This patch adds the possibility to process the output of the jobs.
There are two ways to do that: 
1) Define a reusable Output Template = an ERB template that with the help of variable @output can process the job output.
2) Define a Runtime Template = as indicated in the name, users can define the template on the runtime by filling in a text field in the wizard.

On top of that, it is possible to set default Output Templates for a Job Template, meaning it would be selected directly when selecting a new Output Template.

Let me add 'How to use' screenshots.
![image](https://github.com/theforeman/foreman_remote_execution/assets/87140865/5a96f276-7a64-4b2e-ac7f-04c167fb035c)
![image](https://github.com/theforeman/foreman_remote_execution/assets/87140865/5b7a800a-dc3d-4115-ba0c-41784d96fccc)
Now, when executing the job, there are new fields in the wizard:
![image](https://github.com/theforeman/foreman_remote_execution/assets/87140865/dd7cef7b-6c92-4cd8-b261-31c7ab49348c)
![image](https://github.com/theforeman/foreman_remote_execution/assets/87140865/0f080b75-73ca-4a99-a228-b90ccd5faa9e)
^ There is a slight change now - users can define only one Runtime template. Therefore users do not have to submit:)
When you want to see the output of the job, navigate to the "Processed tab":
![image](https://github.com/theforeman/foreman_remote_execution/assets/87140865/eaa6ebcf-8c77-466a-9672-c52882e45f82)



This patch will show Runtime templates in the "default Output Templates" multi-select field. A [solution](https://github.com/avitova/foreman/commit/67f9aa7f6ff1cd4446fe23e125825467eff2a1bd) for not showing these would be a part of a patch to the Foreman repo.