### PR TITLE
Consistent version in documentation URLs

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -203,8 +203,7 @@ module RemoteExecutionHelper
   end
 
   def documentation_button_rex(section = '')
-    url = 'http://theforeman.org/plugins/foreman_remote_execution/' +
-      "#{ForemanRemoteExecution::VERSION.split('.').take(2).join('.')}/index.html#"
+    url = "https://theforeman.org/plugins/foreman_remote_execution/#{rex_doc_version}/index.html#"
     documentation_button section, :root_url => url
   end
 
@@ -275,5 +274,9 @@ module RemoteExecutionHelper
         status: template_invocation_status(task, job_invocation.task),
         actions: template_invocation_actions(task, host, job_invocation, template_invocation) }
     end
+  end
+
+  def rex_doc_version
+    ForemanRemoteExecution::VERSION.split('.').take(2).join('.')
   end
 end

--- a/app/views/job_invocations/welcome.html.erb
+++ b/app/views/job_invocations/welcome.html.erb
@@ -7,7 +7,8 @@
         <%= _("Foreman can run arbitrary commands on remote hosts using different providers, such as SSH or Ansible. Communication goes through the Smart Proxy so Foreman does not have to have direct access to the target hosts and can scale to control many hosts.") %></br>
     </p>
     <p><%= link_to _('Learn more about this in the documentation.'),
-           documentation_url('1.ForemanRemoteExecution1.3Manual', :root_url => 'https://www.theforeman.org/plugins/foreman_remote_execution/1.3/index.html#'), :rel => 'external' %></p>
+      external_link_path(type: 'plugin_manual', name: 'foreman_remote_execution', version: rex_doc_version, section: "#1.ForemanRemoteExecution#{rex_doc_version}Manual"),
+      rel: 'external' %></p>
     <div class="blank-slate-pf-main-action">
         <%= display_link_if_authorized(_("Run Job"), { :action => :create }, { :class => "btn btn-primary btn-lg" }) %>
     </div>


### PR DESCRIPTION
This now uses the plugin manual helper to redirect users. It consistently uses the same version as the REX documentation buttons.

Ideally it would also use the plugin_manual type in documentation_url, but that doesn't work in Foreman itself.

I am a bit worried that it now breaks all links, since https://theforeman.org/plugins/foreman_remote_execution/ only has versions 1.7, 1.3, and some 0.x versions. Given we're already up to 9.1 this isn't going to work for anything. Because of that I think it may be safe to assume nobody clicks the documentation buttons.