### PR TITLE
Fixes #36564 - Add eslint rule to alert missing ouia-ids

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,8 @@
 {
-  "plugins": ["@theforeman/foreman"],
+  "plugins": [
+    "@theforeman/foreman",
+    "@theforeman/rules"
+  ],
   "extends": [
     "plugin:@theforeman/foreman/core",
     "plugin:@theforeman/foreman/plugins"

--- a/.github/workflows/js_ci.yml
+++ b/.github/workflows/js_ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Run plugin linter
         run: |
           npm run lint
+      - name: Run custom plugin linter
+        run: |
+          npm run lint:custom
       - name: Run plugin tests
         run: |
           npm run test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "lint": "tfm-lint --plugin -d /webpack",
+    "lint:custom": "eslint ./webpack",
     "test": "tfm-test --plugin",
     "test:watch": "tfm-test --plugin --watchAll",
     "test:current": "tfm-test --plugin --watch",
@@ -23,6 +24,7 @@
     "@babel/core": "^7.7.0",
     "@theforeman/builder": "^12.0.1",
     "@theforeman/eslint-plugin-foreman": "^12.0.1",
+    "@theforeman/eslint-plugin-rules": "^12.0.2",
     "@theforeman/test": "^12.0.1",
     "@theforeman/vendor-dev": "^12.0.1",
     "babel-eslint": "^10.0.0",


### PR DESCRIPTION
We keep forgetting adding ouia-ids to react component, this is a rule to alert us in the pr that we forgot. 