### PR TITLE
Fixes #36600 - Regex should only match the first ERB comment, not all

### DIFF
--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -192,7 +192,7 @@ class JobTemplate < ::Template
     self.default = options[:default] unless options[:default].nil?
 
     # job templates have too long metadata, we remove them on parsing until it's stored in separate attribute
-    self.template = self.template.gsub(/<%\#.+?.-?%>\n?/m, '').strip
+    self.template = self.template.sub(/<%\#.+?.-?%>\n?/m, '').strip
   end
 
   def default_input_values(ignore_keys)

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -94,6 +94,8 @@ class JobTemplateTest < ActiveSupport::TestCase
       %>
 
       service <%= input("service_name") %> restart
+
+      <%# test comment %>
       END_TEMPLATE
 
       JobTemplate.import_raw!(template, :default => true)
@@ -122,7 +124,7 @@ class JobTemplateTest < ActiveSupport::TestCase
     end
 
     it 'has a template' do
-      _(template.template.squish).must_equal 'service <%= input("service_name") %> restart'
+      _(template.template.squish).must_equal 'service <%= input("service_name") %> restart <%# test comment %>'
     end
 
     it 'imports inputs' do


### PR DESCRIPTION
The `JobTemplate#import_custom_data` method removes metadata from a job template's contents. But the regex actually causes any ERB comment to be removed, not just the metadata at the top of the file:

![image](https://github.com/theforeman/foreman_remote_execution/assets/22042343/65c7a784-4df6-4275-aaa3-d08ac88f2712)

This commit updates the regex so that only the first ERB comment is matched:

![image](https://github.com/theforeman/foreman_remote_execution/assets/22042343/0f8fbfa7-1c4c-4113-9060-fe6f81f06f28)


