### PR TITLE
Fixes #36565 - Use correct permissions for job category lookup

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -1,7 +1,7 @@
 class UiJobWizardController < ApplicationController
   include FiltersHelper
   def categories
-    job_categories = resource_scope
+    job_categories = resource_scope(permission: action_permission)
                      .search_for("job_category ~ \"#{params[:search]}\"")
                      .where(:snippet => false)
                      .select(:job_category).distinct


### PR DESCRIPTION
This previously defaulted to a combination of action_permission and controller name.