### PR TITLE
Fixes #36605 - Job category is not set in job template edit

### DIFF
--- a/app/views/job_templates/_custom_tabs.html.erb
+++ b/app/views/job_templates/_custom_tabs.html.erb
@@ -1,7 +1,7 @@
 <div class="tab-pane" id="template_job">
 
   <%= autocomplete_f(f, :job_category,
-        :search_query => '',
+        :search_query => @template.job_category,
         :placeholder => _("Job category") + ' ...',
         :disabled => @template.locked?) %>
   <%= text_f f, :description_format,


### PR DESCRIPTION
Users cant edit and save Job templates without re-setting the job category. Job category should be filled in on edit