### PR TITLE
Fixes #36707 - Adjust to v2 sub plans

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -63,7 +63,6 @@ module Actions
                                :execution_timeout_interval => job_invocation.execution_timeout_interval,
                                :secrets => secrets(host, job_invocation, provider),
                                :use_batch_triggering => true,
-                               :use_concurrency_control => options[:use_concurrency_control],
                                :first_execution => first_execution,
                                :alternative_names => provider.alternative_names(host) }
         action_options = provider.proxy_command_options(template_invocation, host)

--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'deface'
   s.add_dependency 'dynflow', '>= 1.0.2', '< 2.0.0'
-  s.add_dependency 'foreman-tasks', '>= 7.1.0'
+  s.add_dependency 'foreman-tasks', '>= 8.2.0'
 
   s.add_development_dependency 'factory_bot_rails', '~> 4.8.0'
   s.add_development_dependency 'rdoc'

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -122,17 +122,14 @@ module ForemanRemoteExecution
 
     describe 'concurrency control' do
       let(:level) { 5 }
-      let(:span) { 60 }
 
       it 'can be disabled' do
-        job_invocation.expects(:concurrency_level)
-        _(planned.input.key?(:concurrency_control)).must_equal false
+        _(planned.concurrency_limit).must_equal nil
       end
 
       it 'can limit concurrency level' do
-        job_invocation.expects(:concurrency_level).returns(level).twice
-        planned.input[:concurrency_control][:level].wont_be_empty
-        planned.input[:concurrency_control].key?(:time).must_equal false
+        job_invocation.expects(:concurrency_level).twice.returns(level)
+        _(planned.concurrency_limit).must_equal level
       end
     end
 


### PR DESCRIPTION
This should resolve the issues with limit-based concurrency control. It now behaves slightly differently - per-host tasks don't get created at all until there is capacity for them.

Requires:
- https://github.com/Dynflow/dynflow/pull/428
- https://github.com/theforeman/foreman-tasks/pull/722

TODO:
- [x] bump dependency on foreman-tasks
- [x] drop time based concurrency options https://github.com/theforeman/foreman_remote_execution/pull/834