### PR TITLE
Fixes #36619 - Reduce issues with cockpit message framing

### DIFF
--- a/extra/cockpit/foreman-cockpit-session
+++ b/extra/cockpit/foreman-cockpit-session
@@ -170,24 +170,41 @@ class Relay
   def initialize(proxy, params)
     @proxy = proxy
     @params = params
+    @inject_authorization = @params['ssh_user'] != 'root' && @params['effective_user_password']
   end
 
   def proxy_loop
     proxy1 = ProxyBuffer.new($stdin, @sock)
     proxy2 = ProxyBuffer.new(@sock, $stdout)
     proxy2.on_data do |data|
-      message = Cockpit.read_control(StringIO.new(data))
-      if message.is_a?(Hash) && message['command'] == 'authorize'
-        response = {
-          'command' => 'authorize',
-          'cookie' => message['cookie'],
-          'response' => @params['effective_user_password'],
-        }
-        proxy1.enqueue(Cockpit.encode_message(response))
-        ''
-      else
-        data
+      if @inject_authorization
+        sio = StringIO.new(data)
+        begin
+          message = Cockpit.read_control(sio)
+        rescue StandardError
+          # We're looking for one specific message, but the expectation that one
+          # invocation of this callback processes one message doesn't really
+          # hold. The message we're looking for is sent quite early in the
+          # communication, if at all, so the chance that it will be aligned with
+          # the beginning of the buffer is quite high. If we somehow fail to
+          # process the contents of the buffer, we should just carry on.
+          #
+          # With the authorization injection check in place, this is more of a
+          # precaution so that unexpectedly big message won't bring the entire
+          # thing down.
+        end
+        if message.is_a?(Hash) && message['command'] == 'authorize'
+          response = {
+            'command' => 'authorize',
+            'cookie' => message['cookie'],
+            'response' => @params['effective_user_password'],
+          }
+          proxy1.enqueue(Cockpit.encode_message(response))
+          @inject_authorization = false
+          data = sio.read # Return whatever was left unread after read_control
+        end
       end
+      data
     end
 
     proxies = [proxy1, proxy2]
@@ -271,7 +288,7 @@ class Relay
                 end
       raise AccessDeniedError, message
     else
-      raise CockpitError, "Error talking to smart proxy: #{response}"
+      raise CockpitError, "Error talking to smart proxy: #{body}"
     end
   end
 end


### PR DESCRIPTION
Previously, we were parsing *all* messages that were being proxies so that we could inject effective user password in case it was needed. If network delays were introduce into the flow, messages could be framed in a way that we would not be able to parse them. Trying to parse an incomplete message could lead to an unhandle exception, which would terminate the session.

This patch keeps track of whether we still need to inject the autohrization message into the communication. From what I've seen, the authorization message is the second message being sent so we can stop inspecting messages quite early and thus significantly reduce the window in which the bug can be triggered.

This also does not look into the messages (apart from the first one) at all, if the remote user is already root or if we don't have a password anyway.