### PR TITLE
Fixes #36627 - Discard irrelevant inputs on template change

### DIFF
--- a/webpack/JobWizard/JobWizard.js
+++ b/webpack/JobWizard/JobWizard.js
@@ -169,8 +169,23 @@ export const JobWizard = ({ rerunData }) => {
                   job_template: { name, description_format },
                 },
               }) => {
+                const allowedInputs = template_inputs
+                  .map(({ name: _name }) => _name)
+                  .concat(
+                    advanced_template_inputs.map(({ name: _name }) => _name)
+                  );
+                const prune = inputs =>
+                  allowedInputs.reduce(
+                    (acc, key) =>
+                      inputs.hasOwnProperty(key)
+                        ? { [key]: inputs[key], ...acc }
+                        : acc,
+                    {}
+                  );
+                setTemplateValues(prune);
                 setAdvancedValues(currentAdvancedValues => ({
                   ...currentAdvancedValues,
+                  templateValues: prune(currentAdvancedValues.templateValues),
                   description:
                     generateDefaultDescription({
                       description_format,


### PR DESCRIPTION
Previously we kept the pre-filled values from the previous template and then sent them to the backend together with the inputs for the new template. This prevented the job from being started as the backend didn't know what to do with the extra inputs.