### PR TITLE
Fixes #36751 - check permissions for schedule job button

### DIFF
--- a/app/controllers/api/v2/remote_execution_features_controller.rb
+++ b/app/controllers/api/v2/remote_execution_features_controller.rb
@@ -29,6 +29,14 @@ module Api
         process_response @remote_execution_feature.update(remote_execution_feature_params)
       end
 
+      api :GET, '/api/hosts/:id/available_remote_execution_features', N_('List available remote execution features for a host')
+      param :id, :identifier, :required => true
+      def available_remote_execution_features
+        host = Host.find(params[:id])
+        @remote_execution_features = resource_scope
+        @permissions = {:can_run_job => (authorized_for(controller: :job_invocations, action: :create) && (!host.infrastructure_host? || User.current.can?(:execute_jobs_on_infrastructure_hosts))) }
+      end
+
       private
 
       def parent_scope

--- a/app/views/api/v2/remote_execution_features/available_remote_execution_features.json.rabl
+++ b/app/views/api/v2/remote_execution_features/available_remote_execution_features.json.rabl
@@ -1,0 +1,6 @@
+node :permissions do
+  @permissions
+end
+child @remote_execution_features do
+  extends 'api/v2/remote_execution_features/main'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
         resources :foreign_input_sets, :only => [:index, :show, :create, :destroy, :update]
       end
 
+      get 'hosts/:id/available_remote_execution_features', to: 'remote_execution_features#available_remote_execution_features'
+
       resources :remote_execution_features, :only => [:show, :index, :update]
     end
   end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -178,7 +178,7 @@ module ForemanRemoteExecution
                                             :'api/v2/template_inputs' => [:create, :update, :destroy],
                                             :'api/v2/foreign_input_sets' => [:create, :update, :destroy]}, :resource_type => 'JobTemplate'
           permission :edit_remote_execution_features, { :remote_execution_features => [:index, :show, :update],
-                                                        :'api/v2/remote_execution_features' => [:index, :show, :update]}, :resource_type => 'RemoteExecutionFeature'
+                                                        :'api/v2/remote_execution_features' => [:index, :show, :update, :available_remote_execution_features]}, :resource_type => 'RemoteExecutionFeature'
           permission :destroy_job_templates, { :job_templates => [:destroy],
                                                :'api/v2/job_templates' => [:destroy] }, :resource_type => 'JobTemplate'
           permission :lock_job_templates, { :job_templates => [:lock, :unlock] }, :resource_type => 'JobTemplate'

--- a/webpack/react_app/components/FeaturesDropdown/constant.js
+++ b/webpack/react_app/components/FeaturesDropdown/constant.js
@@ -1,2 +1,3 @@
-export const REX_FEATURES_API = '/api/remote_execution_features';
+export const REX_FEATURES_API = host =>
+  `/api/v2/hosts/${host}/available_remote_execution_features`;
 export const NEW_JOB_PAGE = '/job_invocations/new?host_ids%5B%5D';

--- a/webpack/react_app/components/FeaturesDropdown/index.js
+++ b/webpack/react_app/components/FeaturesDropdown/index.js
@@ -19,12 +19,18 @@ import { runFeature } from './actions';
 
 const FeaturesDropdown = ({ hostId }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const {
-    response: { results: features },
-    status,
-  } = useAPI('get', foremanUrl(REX_FEATURES_API));
-
+  const { response, status } = useAPI(
+    'get',
+    foremanUrl(REX_FEATURES_API(hostId))
+  );
   const dispatch = useDispatch();
+  // eslint-disable-next-line camelcase
+  const canRunJob = response?.permissions?.can_run_job;
+  if (!canRunJob) {
+    return null;
+  }
+  // eslint-disable-next-line camelcase
+  const features = response?.remote_execution_features;
   const dropdownItems = features
     ?.filter(feature => feature.host_action_button)
     ?.map(({ name, label, id, description }) => (


### PR DESCRIPTION
Took the permissions from the old host page, schedule job button: https://github.com/theforeman/foreman_remote_execution/blob/0b75d16284b5abc8d121d4b3cf665d0122540f84/app/helpers/hosts_extensions_helper.rb#L56 