### PR TITLE
Fixes #36780 - Hide multiple titles on run job page

### DIFF
--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -47,7 +47,7 @@ module ForemanRemoteExecution
 
     initializer 'foreman_remote_execution.register_plugin', before: :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_remote_execution do
-        requires_foreman '>= 3.8'
+        requires_foreman '>= 3.9'
         register_global_js_file 'global'
         register_gettext
 

--- a/webpack/JobWizard/JobWizardPageRerun.js
+++ b/webpack/JobWizard/JobWizardPageRerun.js
@@ -1,15 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import URI from 'urijs';
-import {
-  Alert,
-  Title,
-  Divider,
-  Skeleton,
-  Flex,
-  FlexItem,
-  Button,
-} from '@patternfly/react-core';
+import { Alert, Divider, Skeleton, Button } from '@patternfly/react-core';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
@@ -54,25 +46,18 @@ const JobWizardPageRerun = ({
       header={title}
       breadcrumbOptions={breadcrumbOptions}
       searchable={false}
+      toolbarButtons={
+        <Button
+          variant="link"
+          component="a"
+          href={`/old/job_invocations/${id}/rerun${search}`}
+        >
+          {__('Use old form')}
+        </Button>
+      }
     >
       <React.Fragment>
         <React.Fragment>
-          <Flex>
-            <FlexItem>
-              <Title headingLevel="h2" size="2xl">
-                {title}
-              </Title>
-            </FlexItem>
-            <FlexItem align={{ default: 'alignRight' }}>
-              <Button
-                variant="link"
-                component="a"
-                href={`/old/job_invocations/${id}/rerun${search}`}
-              >
-                {__('Use old form')}
-              </Button>
-            </FlexItem>
-          </Flex>
           <Divider component="div" />
         </React.Fragment>
         {!status || status === STATUS.PENDING ? (

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Title, Flex, FlexItem, Button } from '@patternfly/react-core';
+import { Button } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { JobWizard } from './JobWizard';
@@ -18,23 +18,14 @@ const JobWizardPage = ({ location: { search } }) => {
       header={title}
       breadcrumbOptions={breadcrumbOptions}
       searchable={false}
-      beforeToolbarComponent={
-        <Flex>
-          <FlexItem>
-            <Title headingLevel="h2" size="2xl">
-              {title}
-            </Title>
-          </FlexItem>
-          <FlexItem align={{ default: 'alignRight' }}>
-            <Button
-              variant="link"
-              component="a"
-              href={`/old/job_invocations/new${search}`}
-            >
-              {__('Use legacy form')}
-            </Button>
-          </FlexItem>
-        </Flex>
+      toolbarButtons={
+        <Button
+          variant="link"
+          component="a"
+          href={`/old/job_invocations/new${search}`}
+        >
+          {__('Use legacy form')}
+        </Button>
       }
       pageSectionType="wizard"
     >


### PR DESCRIPTION
Run job wizard had multiple titles because of the usage of `beforeToolbarComponent` in the PageLayout. It is dependent on https://github.com/theforeman/foreman/pull/9830.

![image](https://github.com/theforeman/foreman_remote_execution/assets/78563507/4f9d18f3-ab5a-4afa-9b57-d0c0b1aa3205)
