### PR TITLE
Fixes #36785 - Show permission error page for job wizard

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -1,13 +1,14 @@
 class UiJobWizardController < ApplicationController
   include FiltersHelper
   def categories
+    can_create_job = authorized_for(controller: :job_invocations, action: :create)
     job_categories = resource_scope(permission: action_permission)
                      .search_for("job_category ~ \"#{params[:search]}\"")
                      .where(:snippet => false)
                      .select(:job_category).distinct
                      .reorder(:job_category)
                      .pluck(:job_category)
-    render :json => {:job_categories => job_categories, :with_katello => with_katello, default_category: default_category, default_template: default_template&.id}
+    render :json => {:can_create_job => can_create_job, :job_categories => job_categories, :with_katello => with_katello, default_category: default_category, default_template: default_template&.id}
   end
 
   def template

--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -30,6 +30,9 @@ export const selectJobTemplatesSearch = state =>
 export const selectJobCategoriesResponse = state =>
   selectAPIResponse(state, JOB_CATEGORIES) || {};
 
+export const selectCanCreateJob = state =>
+  selectJobCategoriesResponse(state).can_create_job || false;
+
 export const selectJobCategories = state =>
   selectJobCategoriesResponse(state).job_categories || [];
 

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,8 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import { Title, Flex, FlexItem, Button } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
+import PermissionDenied from 'foremanReact/components/PermissionDenied/PermissionDenied';
+import { STATUS } from 'foremanReact/constants';
+import {
+  selectCanCreateJob,
+  selectJobCategoriesStatus,
+} from './JobWizardSelectors';
 import { JobWizard } from './JobWizard';
 
 const JobWizardPage = ({ location: { search } }) => {
@@ -13,6 +20,14 @@ const JobWizardPage = ({ location: { search } }) => {
       { caption: title },
     ],
   };
+
+  const canCreateJob = useSelector(selectCanCreateJob);
+  const status = useSelector(selectJobCategoriesStatus);
+
+  if (!canCreateJob && status === STATUS.RESOLVED) {
+    return <PermissionDenied missingPermissions={['create_job_invocations']} />;
+  }
+
   return (
     <PageLayout
       header={title}


### PR DESCRIPTION
An error page is shown if a user without necessary permissions (create_job_invocations) goes to /job_invocations/new.

![image](https://github.com/theforeman/foreman_remote_execution/assets/78563507/05bc14f7-a666-455d-80b5-4836534599b4)

I couldn't decide on what's the best way of implementing it, so feel free to tell me if it would be better to create a new API or make the request (which is in /JobWizard/steps/CategoryAndTemplate/index.js) directly in the /JobWizard/index.js file.

The change of error alerts, if a user doesn't have other permissions needed for submitting the job wizard, will be in another PR.