### PR TITLE
Fixes #36851 - Rename migration file so it doesn't break migrations

### DIFF
--- a/db/migrate/20210517132916_add_host_proxy_invocations.rb
+++ b/db/migrate/20210517132916_add_host_proxy_invocations.rb
@@ -1,12 +1,12 @@
 class AddHostProxyInvocations < ActiveRecord::Migration[6.0]
   def change
     # rubocop:disable Rails/CreateTableWithTimestamps
-    create_table :host_proxy_invocations do |t|
+    create_table :host_proxy_invocations, if_not_exists: true do |t|
       t.references :host, :null => false
       t.references :smart_proxy, :null => false
     end
     # rubocop:enable Rails/CreateTableWithTimestamps
 
-    add_index :host_proxy_invocations, [:host_id, :smart_proxy_id], unique: true
+    add_index :host_proxy_invocations, [:host_id, :smart_proxy_id], unique: true, if_not_exists: true
   end
 end


### PR DESCRIPTION
The migration file `2021051713291621250977 AddHostProxyInvocations` always gets treated as the latest migration when you try to do `rails db:rollback`. This is not ideal.

I think it's because the file is oddly named; it has 8 more characters in the timestamp than every other migration file. This causes Rails to think it's a newer timestamp, because I guess the number is the biggest or something?

![image](https://github.com/theforeman/foreman_remote_execution/assets/22042343/78f2a7bc-1411-4a83-9617-d521ef15ed01)

Anyway, I tested it and it seems like renaming it to be in line with the other files works fine.
