### PR TITLE
Fixes #36785 - Show permission error page for job wizard

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -1,4 +1,4 @@
-class UiJobWizardController < ApplicationController
+class UiJobWizardController < Api::V2::BaseController
   include FiltersHelper
   def categories
     job_categories = resource_scope(permission: action_permission)

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -47,7 +47,7 @@ module ForemanRemoteExecution
 
     initializer 'foreman_remote_execution.register_plugin', before: :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_remote_execution do
-        requires_foreman '>= 3.9'
+        requires_foreman '>= 3.10'
         register_global_js_file 'global'
         register_gettext
 

--- a/webpack/JobWizard/JobWizardConstants.js
+++ b/webpack/JobWizard/JobWizardConstants.js
@@ -5,6 +5,10 @@ export const JOB_TEMPLATES = 'JOB_TEMPLATES';
 export const JOB_CATEGORIES = 'JOB_CATEGORIES';
 export const JOB_TEMPLATE = 'JOB_TEMPLATE';
 export const JOB_INVOCATION = 'JOB_INVOCATION';
+export const CURRENT_PERMISSIONS = 'CURRENT_PERMISSIONS';
+export const currentPermissionsUrl = foremanUrl(
+  '/api/v2/permissions/current_permissions'
+);
 export const templatesUrl = foremanUrl('/api/v2/job_templates');
 
 export const repeatTypes = {

--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -1,4 +1,5 @@
 import URI from 'urijs';
+import { get } from 'lodash';
 import {
   selectAPIResponse,
   selectAPIStatus,
@@ -42,6 +43,18 @@ export const selectJobCategoriesStatus = state =>
 export const selectCategoryError = state =>
   selectAPIErrorMessage(state, JOB_CATEGORIES);
 
+export const selectJobCategoriesMissingPermissions = state => {
+  const jobCategoriesResponse = selectJobCategoriesResponse(state);
+  return (
+    get(jobCategoriesResponse, [
+      'response',
+      'data',
+      'error',
+      'missing_permissions',
+    ]) || []
+  );
+};
+
 export const selectAllTemplatesError = state =>
   selectAPIErrorMessage(state, JOB_TEMPLATES);
 
@@ -60,11 +73,21 @@ export const selectAdvancedTemplateInputs = state =>
 export const selectTemplateInputs = state =>
   selectAPIResponse(state, JOB_TEMPLATE).template_inputs || [];
 
+export const selectHostsResponse = state => selectAPIResponse(state, HOSTS_API);
+
 export const selectHostCount = state =>
-  selectAPIResponse(state, HOSTS_API).subtotal || 0;
+  selectHostsResponse(state).subtotal || 0;
 
 export const selectHosts = state =>
-  (selectAPIResponse(state, HOSTS_API).results || []).map(host => host.name);
+  (selectHostsResponse(state).results || []).map(host => host.name);
+
+export const selectHostsMissingPermissions = state => {
+  const hostsResponse = selectHostsResponse(state);
+  return (
+    get(hostsResponse, ['response', 'data', 'error', 'missing_permissions']) ||
+    []
+  );
+};
 
 export const selectIsLoadingHosts = state =>
   !selectAPIStatus(state, HOSTS_API) ||

--- a/webpack/JobWizard/PermissionDenied.js
+++ b/webpack/JobWizard/PermissionDenied.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { Icon } from 'patternfly-react';
+import {
+  Title,
+  Button,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+
+const PermissionDenied = ({ missingPermissions, setProceedAnyway }) => {
+  const description = (
+    <span>
+      {__('You are not authorized to perform this action.')}
+      <br />
+      {__(
+        'Please request the required permissions listed below from a Foreman administrator:'
+      )}
+      <br />
+      <ul className="list-unstyled">
+        {missingPermissions.map(permission => (
+          <li key={permission}>
+            <strong>{permission}</strong>
+          </li>
+        ))}
+      </ul>
+    </span>
+  );
+  const handleProceedAnyway = () => {
+    setProceedAnyway(true);
+  };
+
+  return (
+    <EmptyState variant={EmptyStateVariant.xl}>
+      <span className="empty-state-icon">
+        <Icon name="lock" type="fa" size="2x" />
+      </span>
+      <Title ouiaId="empty-state-header" headingLevel="h5" size="4xl">
+        {__('Permission Denied')}
+      </Title>
+      <EmptyStateBody>{description}</EmptyStateBody>
+      <Button
+        ouiaId="job-invocation-proceed-anyway-button"
+        variant="primary"
+        onClick={handleProceedAnyway}
+      >
+        {__('Proceed Anyway')}
+      </Button>
+    </EmptyState>
+  );
+};
+
+PermissionDenied.propTypes = {
+  missingPermissions: PropTypes.array,
+  setProceedAnyway: PropTypes.func.isRequired,
+};
+
+PermissionDenied.defaultProps = {
+  missingPermissions: ['unknown'],
+};
+
+export default PermissionDenied;

--- a/webpack/JobWizard/index.js
+++ b/webpack/JobWizard/index.js
@@ -1,9 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { STATUS } from 'foremanReact/constants';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import PermissionDenied from './PermissionDenied';
 import { JobWizard } from './JobWizard';
+import {
+  CURRENT_PERMISSIONS,
+  currentPermissionsUrl,
+} from './JobWizardConstants';
 
 const JobWizardPage = ({ location: { search } }) => {
   const title = __('Run job');
@@ -13,6 +21,37 @@ const JobWizardPage = ({ location: { search } }) => {
       { caption: title },
     ],
   };
+  const [proceedAnyway, setProceedAnyway] = useState(false);
+
+  const { response, status } = useAPI(
+    'get',
+    currentPermissionsUrl,
+    CURRENT_PERMISSIONS
+  );
+  const desiredPermissions = [
+    'view_hosts',
+    'view_smart_proxies',
+    'view_job_templates',
+    'create_job_invocations',
+    'create_template_invocations',
+  ];
+  const missingPermissions =
+    status === STATUS.RESOLVED
+      ? desiredPermissions.filter(
+          permission =>
+            !response.results.map(result => result.name).includes(permission)
+        )
+      : [];
+
+  if (!isEmpty(missingPermissions) && !proceedAnyway) {
+    return (
+      <PermissionDenied
+        missingPermissions={missingPermissions}
+        setProceedAnyway={setProceedAnyway}
+      />
+    );
+  }
+
   return (
     <PageLayout
       header={title}

--- a/webpack/JobWizard/steps/HostsAndInputs/index.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/index.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
+import { isEmpty, debounce } from 'lodash';
 import {
+  Alert,
   Button,
   Form,
   FormGroup,
@@ -10,13 +12,13 @@ import {
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { FilterIcon } from '@patternfly/react-icons';
-import { debounce } from 'lodash';
 import { get } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
   selectTemplateInputs,
   selectWithKatello,
   selectHostCount,
+  selectHostsMissingPermissions,
   selectIsLoadingHosts,
 } from '../../JobWizardSelectors';
 import { SelectField } from '../form/SelectField';
@@ -98,6 +100,7 @@ const HostsAndInputs = ({
   ]);
   const withKatello = useSelector(selectWithKatello);
   const hostCount = useSelector(selectHostCount);
+  const missingPermissions = useSelector(selectHostsMissingPermissions);
   const dispatch = useDispatch();
 
   const selectedHosts = selected.hosts;
@@ -126,6 +129,7 @@ const HostsAndInputs = ({
   const [errorText, setErrorText] = useState(
     __('Please select at least one host')
   );
+
   return (
     <div className="target-hosts-and-inputs">
       <WizardTitle title={WIZARD_TITLES.hostsAndInputs} />
@@ -237,6 +241,17 @@ const HostsAndInputs = ({
           value={templateValues}
           setValue={setTemplateValues}
         />
+        {!isEmpty(missingPermissions) && (
+          <Alert variant="warning" title={__('Access denied')}>
+            <span>
+              {__(
+                `Missing the required permissions: ${missingPermissions.join(
+                  ', '
+                )}`
+              )}
+            </span>
+          </Alert>
+        )}
       </Form>
     </div>
   );


### PR DESCRIPTION
Depends on https://github.com/theforeman/foreman/pull/9902

It is showing missing permissions needed on the `/job_invocations/new` page. The "Proceed Anyway" button lets you look at the wizard even though it won't be working properly.
![image](https://github.com/theforeman/foreman_remote_execution/assets/78563507/fd51c177-20bc-4ac7-b756-53812877e3f4)

On the "Category and template" step it shows a warning alert if view_job_templates permission is missing:
![image](https://github.com/theforeman/foreman_remote_execution/assets/78563507/57bd74c6-b8fc-4773-beb7-38ea279d040a)

On the "Target hosts and inputs" step it shows a warning alert if view_hosts permission is missing:
![image](https://github.com/theforeman/foreman_remote_execution/assets/78563507/9fe32e83-13b4-4a9a-807e-e364bf3a2653)