### PR TITLE
Fixes #36881 - Display full hostgroup name in Job Wizard

### DIFF
--- a/webpack/JobWizard/steps/HostsAndInputs/hostgroups.gql
+++ b/webpack/JobWizard/steps/HostsAndInputs/hostgroups.gql
@@ -3,7 +3,7 @@ query($search: String!) {
     totalCount
     nodes {
       id
-      name
+      name: title
     }
   }
 }


### PR DESCRIPTION
`name` is the short name, while `title` is the full name, including the host group parent