### PR TITLE
Fixes #36944 - reduce the amount of SQL queries during grabbing host status

### DIFF
--- a/app/models/host_status/execution_status.rb
+++ b/app/models/host_status/execution_status.rb
@@ -13,7 +13,7 @@ class HostStatus::ExecutionStatus < HostStatus::Status
   STATUS_NAMES = { OK => 'succeeded', ERROR => 'failed', QUEUED => 'queued', RUNNING => 'running', CANCELLED => 'cancelled' }.freeze
 
   def relevant?(*args)
-    execution_tasks.present?
+    host.get_status(HostStatus::ExecutionStatus).present?
   end
 
   def to_status(options = {})
@@ -39,7 +39,7 @@ class HostStatus::ExecutionStatus < HostStatus::Status
   def to_label(options = {})
     case to_status(options)
       when OK
-        execution_tasks.present? ? N_('Last execution succeeded') : N_('No execution finished yet')
+        N_('Last execution succeeded')
       when CANCELLED
         N_('Last execution cancelled')
       when ERROR


### PR DESCRIPTION
Go to /hosts on the UI with about 72 hosts.

```
OLD:
# Completed 200 OK in 9661ms (Views: 8498.6ms | ActiveRecord: 672.9ms | Allocations: 4942784) 
2260 (SQL Queries)
# Completed 200 OK in 7188ms (Views: 6221.3ms | ActiveRecord: 451.8ms | Allocations: 4948319)
2279

NEW:
# Completed 200 OK in 8094ms (Views: 6972.9ms | ActiveRecord: 548.3ms | Allocations: 4790678)
2002
# Completed 200 OK in 7164ms (Views: 6050.3ms | ActiveRecord: 621.6ms | Allocations: 4754622)
1992
```

SQL query:
```
SELECT "foreman_tasks_tasks".* FROM "foreman_tasks_tasks" INNER JOIN "foreman_tasks_links" ON "foreman_tasks_links"."task_id" = "foreman_tasks_tasks"."id" WHERE "foreman_tasks_tasks"."type" = $1 AND "foreman_tasks_tasks"."label" = $2 AND "foreman_tasks_links"."resource_id" = $3 AND "foreman_tasks_links"."resource_type" = $4  [["type", "ForemanTasks::Task::DynflowTask"], ["label", "Actions::RemoteExecution::RunHostJob"], ["resource_id", 46], ["resource_type", "Host::Managed"]]
```
This SQL Query was removed.  Old: 358 queries. New: 0

Reduced allocations: ~ 152106




