### PR TITLE
Fixes #36967 - convert2rhel analyze removes OS from the host

### DIFF
--- a/app/views/templates/script/convert2rhel_analyze.erb
+++ b/app/views/templates/script/convert2rhel_analyze.erb
@@ -31,6 +31,9 @@ export CONVERT2RHEL_DISABLE_TELEMETRY=1
 
 /usr/bin/convert2rhel analyze -y
 
+# Workaround for https://issues.redhat.com/browse/RHELC-1280
+subscription-manager facts --update
+
 if grep -q ERROR /var/log/convert2rhel/convert2rhel-pre-conversion.json; then
     echo "Error: Some error(s) have been found."
     echo "Exiting ..."


### PR DESCRIPTION
Workaround for the issue with 'convert2rhel analyze', where after the job run, OS is unassigned from the host.

See https://issues.redhat.com/browse/RHELC-1280