### PR TITLE
Fixes #36974 - show run job button to rex users

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -33,8 +33,7 @@ module RemoteExecutionHelper
       links << { title: _('Host detail'),
         action: { href: current_host_details_path(host), 'data-method': 'get', id: "#{host.name}-actions-detail" } }
     end
-
-    if authorized_for(hash_for_rerun_job_invocation_path(id: job_invocation, host_ids: [ host.id ], authorizer: job_hosts_authorizer))
+    if authorized_for(controller: :job_invocations, action: :create) && (!host.infrastructure_host? || User.current.can?(:execute_jobs_on_infrastructure_hosts))
       links << { title: (_('Rerun on %s') % host.name),
         action: { href: rerun_job_invocation_path(job_invocation, host_ids: [ host.id ]),
                   'data-method': 'get', id: "#{host.name}-actions-rerun" } }
@@ -56,7 +55,7 @@ module RemoteExecutionHelper
   def job_invocations_buttons
     [
       documentation_button_rex('3.2ExecutingaJob'),
-      display_link_if_authorized(_('Run Job'), hash_for_new_job_invocation_path, {:class => "btn btn-primary"}),
+      authorized_for(controller: :job_invocations, action: :create) ? link_to(_('Run Job'), hash_for_new_job_invocation_path, {:class => "btn btn-primary"}) : '',
     ]
   end
 
@@ -70,12 +69,12 @@ module RemoteExecutionHelper
         title: _('Create report for this job'),
         disabled: task.pending?)
     end
-    if authorized_for(hash_for_new_job_invocation_path)
+    if authorized_for(controller: :job_invocations, action: :create)
       buttons << link_to(_('Rerun'), rerun_job_invocation_path(:id => job_invocation.id),
         :class => 'btn btn-default',
         :title => _('Rerun the job'))
     end
-    if authorized_for(hash_for_new_job_invocation_path)
+    if authorized_for(controller: :job_invocations, action: :create)
       buttons << link_to(_('Rerun failed'), rerun_job_invocation_path(:id => job_invocation.id, :failed_only => 1),
         :class => 'btn btn-default',
         :disabled => job_invocation.failed_hosts.none?,

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -177,8 +177,11 @@ module ForemanRemoteExecution
                                             :'api/v2/job_templates' => [:update],
                                             :'api/v2/template_inputs' => [:create, :update, :destroy],
                                             :'api/v2/foreign_input_sets' => [:create, :update, :destroy]}, :resource_type => 'JobTemplate'
-          permission :edit_remote_execution_features, { :remote_execution_features => [:index, :show, :update],
-                                                        :'api/v2/remote_execution_features' => [:index, :show, :update, :available_remote_execution_features]}, :resource_type => 'RemoteExecutionFeature'
+          permission :view_remote_execution_features, { :remote_execution_features => [:index, :show],
+                                                        :'api/v2/remote_execution_features' => [:index, :show, :available_remote_execution_features]},
+            :resource_type => 'RemoteExecutionFeature'
+          permission :edit_remote_execution_features, { :remote_execution_features => [:update],
+                                                        :'api/v2/remote_execution_features' => [:update ]}, :resource_type => 'RemoteExecutionFeature'
           permission :destroy_job_templates, { :job_templates => [:destroy],
                                                :'api/v2/job_templates' => [:destroy] }, :resource_type => 'JobTemplate'
           permission :lock_job_templates, { :job_templates => [:lock, :unlock] }, :resource_type => 'JobTemplate'
@@ -204,6 +207,7 @@ module ForemanRemoteExecution
           :create_template_invocations,
           :view_hosts,
           :view_smart_proxies,
+          :view_remote_execution_features,
         ].freeze
         MANAGER_PERMISSIONS = USER_PERMISSIONS + [
           :cancel_job_invocations,


### PR DESCRIPTION
In a separate PR I want to try to deal with the issue that react#index paths dont get the correct auths, but I think we should first return the job buttons to Rex Users. 

Added also `view_remote_execution_features` permission because I think normal users should be able to view the features? just not edit them

test: have a user with only rex user role, open `/job_invocations` before: no button, now: yes button.
Also for job reruns inside `job_invocations/id`, and  in host details page (some hosts are `infrastructure_host` and will need extra permission to run job).
