### PR TITLE
use yum.tfm.o for foreman bits

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -31,7 +31,7 @@ jobs:
       centos-stream-8:
         additional_modules: "foreman-devel:el8"
         additional_repos:
-          - http://koji.katello.org/releases/yum/foreman-nightly/el8/x86_64/
+          - http://yum.theforeman.org/releases/nightly/el8/x86_64/
           - http://yum.theforeman.org/plugins/nightly/el8/x86_64/
     module_hotfixes: true
 


### PR DESCRIPTION
the old url will go away at some point as we're dropping koji and while we could use the relevant copr for this, it felt more natural to use released bits