### PR TITLE
Fixes #37042 - Validate concurrency level is positive

### DIFF
--- a/app/models/job_invocation.rb
+++ b/app/models/job_invocation.rb
@@ -77,6 +77,11 @@ class JobInvocation < ApplicationRecord
     :ext_method => :search_by_recurring_logic, :only_explicit => true,
     :complete_value => { :true => true, :false => false }
 
+  validates :concurrency_level, :numericality => {
+    :allow_nil => true,
+    :greater_than => 0,
+  }
+
   default_scope -> { order('job_invocations.id DESC') }
 
   scope :latest_jobs, -> { unscoped.joins(:task).order('foreman_tasks_tasks.start_at DESC').authorized(:view_job_invocations).limit(5) }


### PR DESCRIPTION
```
# hammer job-invocation create --job-template-id 170 --inputs 'command=true' --search-query 'name ~ *' --ssh-user root --organization-id 1 --location-id 2 --concurrency-level 0
Validation failed: Concurrency level: must be greater than 0
# echo $?
70