### PR TITLE
Fixes #37082 - Show 'Awaiting start' as status

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -18,7 +18,7 @@ module RemoteExecutionHelper
   end
 
   def template_invocation_status(task, parent_task)
-    return(parent_task.result == 'cancelled' ? _('cancelled') : 'N/A') if task.nil?
+    return(parent_task.result == 'cancelled' ? _('cancelled') : _('Awaiting start')) if task.nil?
     return task.state if task.state == 'running' || task.state == 'planned'
     return _('error') if task.result == 'warning'
 


### PR DESCRIPTION
of template invocations when the backing task is not yet created.

![image](https://github.com/theforeman/foreman_remote_execution/assets/7326770/b3e4df8d-e67f-4636-8678-3176d043c7ae)
