### PR TITLE
Fix minitest warnings

### DIFF
--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -272,7 +272,7 @@ module Api
           assert_equal result['complete'], false
           assert_equal result['delayed'], true
           assert_nil result['output']
-          _(Time.parse(result['start_at']).to_f).must_be_close_to start_time.to_f
+          assert_in_delta start_time.to_f, Time.parse(result['start_at']).to_f, 0.001
           assert_response :success
         end
 
@@ -334,8 +334,8 @@ module Api
         assert_response :success
         result = ActiveSupport::JSON.decode(@response.body)
         targeting = Targeting.find(result['targeting_id'])
-        _(targeting.user_id).must_equal users(:admin).id
-        _(targeting.search_query).must_equal @invocation.targeting.search_query
+        assert_equal users(:admin).id, targeting.user_id
+        assert_equal @invocation.targeting.search_query, targeting.search_query
       end
 
       test 'should not raise an exception when reruning failed has no hosts' do
@@ -350,8 +350,8 @@ module Api
         assert_response :success
         result = ActiveSupport::JSON.decode(@response.body)
         targeting = Targeting.find(result['targeting_id'])
-        _(targeting.user_id).must_equal users(:admin).id
-        _(targeting.search_query).must_equal 'name ^ ()'
+        assert_equal users(:admin).id, targeting.user_id
+        assert_equal 'name ^ ()', targeting.search_query
       end
 
       test 'should rerun failed only' do
@@ -369,8 +369,8 @@ module Api
         result = ActiveSupport::JSON.decode(@response.body)
         targeting = Targeting.find(result['targeting_id'])
         hostnames = @invocation.template_invocations.map { |ti| ti.host.name }
-        _(targeting.user_id).must_equal users(:admin).id
-        _(targeting.search_query).must_equal "name ^ (#{hostnames.join(',')})"
+        assert_equal users(:admin).id, targeting.user_id
+        assert_equal "name ^ (#{hostnames.join(',')})", targeting.search_query
       end
 
       test 'should return 404 if template is not found' do

--- a/test/functional/api/v2/template_invocations_controller_test.rb
+++ b/test/functional/api/v2/template_invocations_controller_test.rb
@@ -13,8 +13,8 @@ module Api
       test 'should get template invocations belonging to job invocation' do
         get :template_invocations, params: { :id => @job.id }
         invocations = ActiveSupport::JSON.decode(@response.body)
-        _(invocations['results'].count).must_equal @job.template_invocations.count
-        _(invocations['total']).must_equal @job.template_invocations.count
+        assert_equal @job.template_invocations.count, invocations['results'].count
+        assert_equal @job.template_invocations.count, invocations['total']
 
         expected_result = {
           'id'                   => @template_invocation.id,
@@ -25,7 +25,7 @@ module Api
           'job_invocation_id'    => @job.id,
           'run_host_job_task_id' => @template_invocation.run_host_job_task_id,
         }
-        _(invocations['results']).must_equal [expected_result]
+        assert_equal [expected_result], invocations['results']
         assert_response :success
       end
     end

--- a/test/helpers/remote_execution_helper_test.rb
+++ b/test/helpers/remote_execution_helper_test.rb
@@ -15,13 +15,13 @@ class RemoteExecutionHelperTest < ActionView::TestCase
     it 'ensures the line sets end with new line' do
       new_line_sets = normalize_line_sets(line_sets)
       expected_output = ["one\r\n",
-                 "two\r\n",
-                 "\r\nthree\r\n",
-                 "four\r\n",
-                 "\r\n\r\n",
-                 "five\r\n",
-                 "Exit status: 0"]
-      assert_equal expected_output, new_line_sets.map { |s| s['output'] }
+                         "two\r\n",
+                         "\r\nthree\r\n",
+                         "four\r\n",
+                         "\r\n\r\n",
+                         "five\r\n",
+                         "Exit status: 0"]
+      assert_equal(expected_output, new_line_sets.map { |s| s['output'] })
     end
   end
 

--- a/test/helpers/remote_execution_helper_test.rb
+++ b/test/helpers/remote_execution_helper_test.rb
@@ -14,13 +14,14 @@ class RemoteExecutionHelperTest < ActionView::TestCase
 
     it 'ensures the line sets end with new line' do
       new_line_sets = normalize_line_sets(line_sets)
-      new_line_sets.map { |s| s['output'] }.must_equal(["one\r\n",
-                                                        "two\r\n",
-                                                        "\r\nthree\r\n",
-                                                        "four\r\n",
-                                                        "\r\n\r\n",
-                                                        "five\r\n",
-                                                        "Exit status: 0"])
+      expected_output = ["one\r\n",
+                 "two\r\n",
+                 "\r\nthree\r\n",
+                 "four\r\n",
+                 "\r\n\r\n",
+                 "five\r\n",
+                 "Exit status: 0"]
+      assert_equal expected_output, new_line_sets.map { |s| s['output'] }
     end
   end
 

--- a/test/unit/actions/run_host_job_test.rb
+++ b/test/unit/actions/run_host_job_test.rb
@@ -53,7 +53,7 @@ module ForemanRemoteExecution
         exception = assert_raises do
           action.send(:verify_permissions, template_invocation.host, template_invocation)
         end
-        _(exception.message).must_include "infrastructure host #{template_invocation.host.name}"
+        assert_includes exception.message, "infrastructure host #{template_invocation.host.name}"
       end
     end
 

--- a/test/unit/actions/run_hosts_job_test.rb
+++ b/test/unit/actions/run_hosts_job_test.rb
@@ -65,13 +65,13 @@ module ForemanRemoteExecution
         delayed
         assert_not targeting.resolved?
         planned
-        _(targeting.hosts).must_include(host)
+        assert_includes targeting.hosts, host
       end
 
       it 'resolves the hosts on static targeting in delay' do
         assert_not targeting.resolved?
         delayed
-        _(targeting.hosts).must_include(host)
+        assert_includes targeting.hosts, host
         # Verify Targeting#resolve_hosts! won't be hit again
         targeting.expects(:resolve_hosts!).never
         planned
@@ -79,7 +79,7 @@ module ForemanRemoteExecution
 
       it 'resolves the hosts on static targeting in plan phase if not resolved yet' do
         planned
-        _(targeting.hosts).must_include(host)
+        assert_includes targeting.hosts, host
       end
     end
 
@@ -91,16 +91,16 @@ module ForemanRemoteExecution
 
     it 'uses the BindJobInvocation middleware' do
       planned
-      _(job_invocation.task_id).must_equal uuid
+      assert_equal job_invocation.task_id, uuid
     end
 
     # In plan phase this is handled by #action_subject
     #   which is expected in tests
     it 'sets input in delay phase when delayed' do
       job_invocation_hash = delayed.input[:job_invocation]
-      _(job_invocation_hash['id']).must_equal job_invocation.id
-      _(job_invocation_hash['name']).must_equal job_invocation.job_category
-      _(job_invocation_hash['description']).must_equal job_invocation.description
+      assert_equal job_invocation_hash['id'], job_invocation.id
+      assert_equal job_invocation_hash['name'], job_invocation.job_category
+      assert_equal job_invocation_hash['description'], job_invocation.description
       planned # To make the expectations happy
     end
 
@@ -108,7 +108,7 @@ module ForemanRemoteExecution
       it 'defaults to Setting[foreman_tasks_proxy_batch_size]' do
         Setting.expects(:[]).with('foreman_tasks_proxy_batch_size').returns(14)
         planned
-        _(planned.proxy_batch_size).must_equal 14
+        assert_equal 14, planned.proxy_batch_size
       end
 
       it 'gets the provider value' do
@@ -116,7 +116,7 @@ module ForemanRemoteExecution
         provider.expects(:proxy_batch_size).returns(15)
         JobTemplate.any_instance.expects(:provider).returns(provider)
 
-        _(planned.proxy_batch_size).must_equal 15
+        assert_equal 15, planned.proxy_batch_size
       end
     end
 
@@ -124,12 +124,12 @@ module ForemanRemoteExecution
       let(:level) { 5 }
 
       it 'can be disabled' do
-        _(planned.concurrency_limit).must_equal nil
+        assert_nil planned.concurrency_limit
       end
 
       it 'can limit concurrency level' do
         job_invocation.expects(:concurrency_level).twice.returns(level)
-        _(planned.concurrency_limit).must_equal level
+        assert_equal level, planned.concurrency_limit
       end
     end
 

--- a/test/unit/concerns/foreman_tasks_cleaner_extensions_test.rb
+++ b/test/unit/concerns/foreman_tasks_cleaner_extensions_test.rb
@@ -13,17 +13,17 @@ class ForemanRemoteExecutionForemanTasksCleanerExtensionsTest < ActiveSupport::T
   it 'tries to delete associated job invocations' do
     job = FactoryBot.create(:job_invocation, :with_task)
     ForemanTasks::Cleaner.new(:filter => "id = #{job.task.id}").delete
-    JobInvocation.where(:id => job.id).must_be :empty?
+    assert_empty JobInvocation.where(:id => job.id)
   end
 
   it 'removes orphaned job invocations' do
     job = FactoryBot.create(:job_invocation, :with_task)
-    _(JobInvocation.where(:id => job.id).count).must_equal 1
+    assert_equal 1, JobInvocation.where(:id => job.id).count
     job.task.delete
     job.reload
-    _(job.task).must_be :nil?
-    _(job.task_id).wont_be :nil?
+    assert_nil job.task
+    refute_nil job.task_id
     ForemanTasks::Cleaner.new(:filter => '').delete
-    JobInvocation.where(:id => job.id).must_be :empty?
+    assert_empty JobInvocation.where(:id => job.id)
   end
 end

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -67,7 +67,7 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
     it 'should only have one execution interface' do
       host.interfaces << FactoryBot.build(:nic_managed)
       host.interfaces.each { |interface| interface.execution = true }
-      assert host.valid?
+      assert_predicate host, :valid?
       assert_equal 1, host.interfaces.count(&:execution?)
     end
 

--- a/test/unit/concerns/host_extensions_test.rb
+++ b/test/unit/concerns/host_extensions_test.rb
@@ -17,39 +17,39 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
     end
 
     it 'has ssh user in the parameters' do
-      _(host.host_param('remote_execution_ssh_user')).must_equal Setting[:remote_execution_ssh_user]
+      assert_equal Setting[:remote_execution_ssh_user], host.host_param('remote_execution_ssh_user')
     end
 
     it 'can override ssh user' do
       host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_user', :value => 'amy')
-      _(host.host_param('remote_execution_ssh_user')).must_equal 'amy'
+      assert_equal 'amy', host.host_param('remote_execution_ssh_user')
     end
 
     it 'has effective user method in the parameters' do
-      _(host.host_param('remote_execution_effective_user_method')).must_equal Setting[:remote_execution_effective_user_method]
+      assert_equal Setting[:remote_execution_effective_user_method], host.host_param('remote_execution_effective_user_method')
     end
 
     it 'can override effective user method' do
       host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_method', :value => 'su')
-      _(host.host_param('remote_execution_effective_user_method')).must_equal 'su'
+      assert_equal 'su', host.host_param('remote_execution_effective_user_method')
     end
 
     it 'has ssh keys in the parameters' do
-      _(host.remote_execution_ssh_keys).must_include sshkey
+      assert_includes host.remote_execution_ssh_keys, sshkey
     end
 
     it 'merges ssh keys from host parameters and proxies' do
       key = 'ssh-rsa not-even-a-key something@somewhere.com'
       host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_keys', :value => [key])
-      _(host.host_param('remote_execution_ssh_keys')).must_include key
-      _(host.host_param('remote_execution_ssh_keys')).must_include sshkey
+      assert_includes host.host_param('remote_execution_ssh_keys'), key
+      assert_includes host.host_param('remote_execution_ssh_keys'), sshkey
     end
 
     it 'merges ssh key as a string from host parameters and proxies' do
       key = 'ssh-rsa not-even-a-key something@somewhere.com'
       host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_keys', :value => key)
-      _(host.host_param('remote_execution_ssh_keys')).must_include key
-      _(host.host_param('remote_execution_ssh_keys')).must_include sshkey
+      assert_includes host.host_param('remote_execution_ssh_keys'), key
+      assert_includes host.host_param('remote_execution_ssh_keys'), sshkey
     end
 
     it 'has ssh keys in the parameters even when no user specified' do
@@ -57,7 +57,7 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
       FactoryBot.create(:smart_proxy, :ssh)
       host.interfaces.first.subnet.remote_execution_proxies.clear
       User.current = nil
-      _(host.remote_execution_ssh_keys).must_include sshkey
+      assert_includes host.remote_execution_ssh_keys, sshkey
     end
   end
 
@@ -67,12 +67,12 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
     it 'should only have one execution interface' do
       host.interfaces << FactoryBot.build(:nic_managed)
       host.interfaces.each { |interface| interface.execution = true }
-      _(host).must_be :valid?
-      _(host.interfaces.count(&:execution?)).must_equal 1
+      assert host.valid?
+      assert_equal 1, host.interfaces.count(&:execution?)
     end
 
     it 'returns the execution interface' do
-      _(host.execution_interface).must_be_kind_of Nic::Managed
+      assert_kind_of Nic::Managed, host.execution_interface
     end
   end
 
@@ -91,16 +91,16 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
 
     it 'finds hosts for job_invocation.id' do
       found_ids = Host.search_for("job_invocation.id = #{job.id}").map(&:id).sort
-      _(found_ids).must_equal job.template_invocations_host_ids.sort
+      assert_equal job.template_invocations_host_ids.sort, found_ids
     end
 
     it 'finds hosts by job_invocation.result' do
       success, failed = job.template_invocations
                            .partition { |template| template.run_host_job_task.result == 'success' }
       found_ids = Host.search_for('job_invocation.result = success').map(&:id)
-      _(found_ids).must_equal success.map(&:host_id)
+      assert_equal success.map(&:host_id), found_ids
       found_ids = Host.search_for('job_invocation.result = failed').map(&:id)
-      _(found_ids).must_equal failed.map(&:host_id)
+      assert_equal failed.map(&:host_id), found_ids
     end
 
     it 'finds hosts by job_invocation.id and job_invocation.result' do
@@ -108,24 +108,24 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
       job
       job2
 
-      _(Host.search_for("job_invocation.id = #{job.id}").count).must_equal 2
-      _(Host.search_for("job_invocation.id = #{job2.id}").count).must_equal 2
-      _(Host.search_for('job_invocation.result = success').count).must_equal 2
-      _(Host.search_for('job_invocation.result = failed').count).must_equal 2
+      assert_equal 2, Host.search_for("job_invocation.id = #{job.id}").count
+      assert_equal 2, Host.search_for("job_invocation.id = #{job2.id}").count
+      assert_equal 2, Host.search_for('job_invocation.result = success').count
+      assert_equal 2, Host.search_for('job_invocation.result = failed').count
 
       success, failed = job.template_invocations
                            .partition { |template| template.run_host_job_task.result == 'success' }
       found_ids = Host.search_for("job_invocation.id = #{job.id} AND job_invocation.result = success").map(&:id)
-      _(found_ids).must_equal success.map(&:host_id)
+      assert_equal success.map(&:host_id), found_ids
       found_ids = Host.search_for("job_invocation.id = #{job.id} AND job_invocation.result = failed").map(&:id)
-      _(found_ids).must_equal failed.map(&:host_id)
+      assert_equal failed.map(&:host_id), found_ids
     end
   end
 
   describe 'proxy determination strategies' do
     context 'subnet strategy' do
       let(:host) { FactoryBot.build(:host, :with_execution) }
-      it { host.remote_execution_proxies(provider)[:subnet].must_include host.subnet.remote_execution_proxies.first }
+      it { assert_includes host.remote_execution_proxies(provider)[:subnet], host.subnet.remote_execution_proxies.first }
     end
 
     context 'fallback strategy' do
@@ -138,7 +138,7 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
         end
 
         it 'returns a fallback proxy' do
-          host.remote_execution_proxies(provider)[:fallback].must_include host.subnet.tftp
+          assert_includes host.remote_execution_proxies(provider)[:fallback], host.subnet.tftp
         end
       end
 
@@ -149,7 +149,7 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
         end
 
         it 'returns no proxy' do
-          host.remote_execution_proxies(provider)[:fallback].must_be_empty
+          assert_empty host.remote_execution_proxies(provider)[:fallback]
         end
       end
     end
@@ -167,15 +167,15 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
         it 'returns correct proxies confined by taxonomies' do
           proxy_in_taxonomies
           proxy_no_taxonomies
-          host.remote_execution_proxies(provider)[:global].must_include proxy_in_taxonomies
-          host.remote_execution_proxies(provider)[:global].wont_include proxy_no_taxonomies
+          assert_includes host.remote_execution_proxies(provider)[:global], proxy_in_taxonomies
+          refute_includes host.remote_execution_proxies(provider)[:global], proxy_no_taxonomies
         end
       end
 
       context 'disabled' do
         before { Setting[:remote_execution_global_proxy] = false }
         it 'returns no proxy' do
-          host.remote_execution_proxies(provider)[:global].must_be_empty
+          assert_empty host.remote_execution_proxies(provider)[:global]
         end
       end
     end
@@ -195,8 +195,8 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
         setup_user('view', 'hosts')
 
         hosts = ::Host::Managed.execution_scope
-        hosts.must_include host
-        hosts.wont_include infra_host
+        assert_includes hosts, host
+        refute_includes hosts, infra_host
       end
     end
 
@@ -204,15 +204,15 @@ class ForemanRemoteExecutionHostExtensionsTest < ActiveSupport::TestCase
       it 'finds the host as admin' do
         assert User.current.admin?
         hosts = ::Host::Managed.execution_scope
-        hosts.must_include host
-        hosts.must_include infra_host
+        assert_includes hosts, host
+        assert_includes hosts, infra_host
       end
 
       it 'finds the host as user with needed permissions' do
         setup_user('execute_jobs_on', 'infrastructure_hosts')
         hosts = ::Host::Managed.execution_scope
-        hosts.must_include host
-        hosts.must_include infra_host
+        assert_includes hosts, host
+        assert_includes hosts, infra_host
       end
     end
   end

--- a/test/unit/concerns/nic_extensions_test.rb
+++ b/test/unit/concerns/nic_extensions_test.rb
@@ -4,6 +4,6 @@ class ForemanRemoteExecutionNicExtensionsTest < ActiveSupport::TestCase
   let(:host) { FactoryBot.create(:host) }
 
   it 'sets the first primary interface as the execution interface' do
-    _(host.execution_interface).must_equal host.interfaces.first
+    assert_equal host.interfaces.first, host.execution_interface
   end
 end

--- a/test/unit/execution_task_status_mapper_test.rb
+++ b/test/unit/execution_task_status_mapper_test.rb
@@ -5,11 +5,11 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
     let(:subject) { HostStatus::ExecutionStatus::ExecutionTaskStatusMapper }
 
     it 'accepts status number as well as string representation' do
-      _(subject.sql_conditions_for(HostStatus::ExecutionStatus::ERROR)).must_equal subject.sql_conditions_for('failed')
+      assert_equal subject.sql_conditions_for(HostStatus::ExecutionStatus::ERROR), subject.sql_conditions_for('failed')
     end
 
     it 'does not find any task for unknown state' do
-      _(subject.sql_conditions_for(-1)).must_equal [ '1 = 0' ]
+      assert_equal subject.sql_conditions_for(-1), [ '1 = 0' ]
     end
   end
 
@@ -22,12 +22,12 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
     describe 'is queued' do
       context 'when there is no task' do
         before { subject.task = nil }
-        specify { _(subject.status).must_equal HostStatus::ExecutionStatus::QUEUED }
+        specify { assert_equal subject.status, HostStatus::ExecutionStatus::QUEUED }
       end
 
       context 'when the task is scheduled in future' do
         before { subject.task.state = 'scheduled' }
-        specify { _(subject.status).must_equal HostStatus::ExecutionStatus::QUEUED }
+        specify { assert_equal subject.status, HostStatus::ExecutionStatus::QUEUED }
       end
     end
 
@@ -37,19 +37,19 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       describe 'is succeeded' do
         context 'without error' do
           before { subject.task.result = 'success' }
-          specify { _(subject.status).must_equal HostStatus::ExecutionStatus::OK }
+          specify { assert_equal subject.status, HostStatus::ExecutionStatus::OK }
         end
       end
 
       describe 'is failed' do
         context 'with error' do
           before { subject.task.result = 'error' }
-          specify { _(subject.status).must_equal HostStatus::ExecutionStatus::ERROR }
+          specify { assert_equal subject.status, HostStatus::ExecutionStatus::ERROR }
         end
 
         context 'without error but just with warning (sub task failed)' do
           before { subject.task.result = 'warning' }
-          specify { _(subject.status).must_equal HostStatus::ExecutionStatus::ERROR }
+          specify { assert_equal subject.status, HostStatus::ExecutionStatus::ERROR }
         end
       end
     end
@@ -58,7 +58,7 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       before { subject.task.state = 'running' }
 
       describe 'is pending' do
-        specify { _(subject.status).must_equal HostStatus::ExecutionStatus::RUNNING }
+        specify { assert_equal subject.status, HostStatus::ExecutionStatus::RUNNING }
       end
     end
   end
@@ -73,7 +73,7 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       end
 
       it 'returns ok label' do
-        _(subject).must_equal HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::OK]
+        assert_equal subject, HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::OK]
       end
     end
 
@@ -84,7 +84,7 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       end
 
       it 'returns failed label' do
-        _(subject).must_equal HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::ERROR]
+        assert_equal subject, HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::ERROR]
       end
     end
   end

--- a/test/unit/execution_task_status_mapper_test.rb
+++ b/test/unit/execution_task_status_mapper_test.rb
@@ -5,11 +5,11 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
     let(:subject) { HostStatus::ExecutionStatus::ExecutionTaskStatusMapper }
 
     it 'accepts status number as well as string representation' do
-      assert_equal subject.sql_conditions_for(HostStatus::ExecutionStatus::ERROR), subject.sql_conditions_for('failed')
+      assert_equal subject.sql_conditions_for('failed'), subject.sql_conditions_for(HostStatus::ExecutionStatus::ERROR)
     end
 
     it 'does not find any task for unknown state' do
-      assert_equal subject.sql_conditions_for(-1), [ '1 = 0' ]
+      assert_equal [ '1 = 0' ], subject.sql_conditions_for(-1)
     end
   end
 
@@ -22,12 +22,12 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
     describe 'is queued' do
       context 'when there is no task' do
         before { subject.task = nil }
-        specify { assert_equal subject.status, HostStatus::ExecutionStatus::QUEUED }
+        specify { assert_equal HostStatus::ExecutionStatus::QUEUED, subject.status }
       end
 
       context 'when the task is scheduled in future' do
         before { subject.task.state = 'scheduled' }
-        specify { assert_equal subject.status, HostStatus::ExecutionStatus::QUEUED }
+        specify { assert_equal HostStatus::ExecutionStatus::QUEUED, subject.status }
       end
     end
 
@@ -37,19 +37,19 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       describe 'is succeeded' do
         context 'without error' do
           before { subject.task.result = 'success' }
-          specify { assert_equal subject.status, HostStatus::ExecutionStatus::OK }
+          specify { assert_equal HostStatus::ExecutionStatus::OK, subject.status }
         end
       end
 
       describe 'is failed' do
         context 'with error' do
           before { subject.task.result = 'error' }
-          specify { assert_equal subject.status, HostStatus::ExecutionStatus::ERROR }
+          specify { assert_equal HostStatus::ExecutionStatus::ERROR, subject.status }
         end
 
         context 'without error but just with warning (sub task failed)' do
           before { subject.task.result = 'warning' }
-          specify { assert_equal subject.status, HostStatus::ExecutionStatus::ERROR }
+          specify { assert_equal HostStatus::ExecutionStatus::ERROR, subject.status }
         end
       end
     end
@@ -58,7 +58,7 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       before { subject.task.state = 'running' }
 
       describe 'is pending' do
-        specify { assert_equal subject.status, HostStatus::ExecutionStatus::RUNNING }
+        specify { assert_equal HostStatus::ExecutionStatus::RUNNING, subject.status }
       end
     end
   end
@@ -73,7 +73,7 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       end
 
       it 'returns ok label' do
-        assert_equal subject, HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::OK]
+        assert_equal HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::OK], subject
       end
     end
 
@@ -84,7 +84,7 @@ class ExecutionTaskStatusMapperTest < ActiveSupport::TestCase
       end
 
       it 'returns failed label' do
-        assert_equal subject, HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::ERROR]
+        assert_equal HostStatus::ExecutionStatus::STATUS_NAMES[HostStatus::ExecutionStatus::ERROR], subject
       end
     end
   end

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -7,17 +7,17 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
     let(:renderer) { InputTemplateRenderer.new(FactoryBot.build(:job_template, :template => 'id <%= preview? %>')) }
 
     it 'should render the content' do
-      _(renderer.render).must_equal 'id false'
+      assert_equal 'id false', renderer.render
     end
 
     it 'should render preview' do
-      _(renderer.preview).must_equal 'id true'
+      assert_equal 'id true', renderer.preview
     end
 
     it 'should allow accessing current_user' do
       setup_user(:view_job_templates)
       renderer = InputTemplateRenderer.new(FactoryBot.build(:job_template, :template => "They call me '<%= current_user %>'"))
-      _(renderer.preview).must_equal "They call me '#{User.current.login}'"
+      assert_equal "They call me '#{User.current.login}'", renderer.preview
     end
   end
 
@@ -28,23 +28,27 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
     context 'but without input defined' do
       describe 'rendering' do
         let(:result) { renderer.render }
-        it { _(result).must_equal false }
+        it 'should return false' do
+          assert_equal false, result
+        end
 
-        it 'registers an error' do
+        it 'should register an error' do
           result # let is lazy
-          _(renderer.error_message).wont_be_nil
-          _(renderer.error_message).wont_be_empty
+          assert_not_nil renderer.error_message
+          assert_not_empty renderer.error_message
         end
       end
 
       describe 'preview' do
         let(:result) { renderer.preview }
-        it { _(result).must_equal false }
+        it 'should return false' do
+          assert_equal false, result
+        end
 
-        it 'registers an error' do
+        it 'should register an error' do
           result # let is lazy
-          _(renderer.error_message).wont_be_nil
-          _(renderer.error_message).wont_be_empty
+          assert_not_nil renderer.error_message
+          assert_not_empty renderer.error_message
         end
       end
     end
@@ -62,7 +66,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
       describe 'rendering' do
         it 'can preview' do
-          _(renderer.preview).must_equal 'service restart $USER_INPUT[service_name]'
+          assert_equal 'service restart $USER_INPUT[service_name]', renderer.preview
         end
 
         context 'with invocation specified and a required input' do
@@ -74,8 +78,8 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
           it 'cannot render the content' do
             assert_not result
-            _(renderer.error_message).wont_be_nil
-            _(renderer.error_message).wont_be_empty
+            refute_nil renderer.error_message
+            refute_empty renderer.error_message
           end
         end
 
@@ -90,13 +94,13 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
           end
 
           it 'can render with job invocation with corresponding value' do
-            _(renderer.render).must_equal 'service restart foreman'
+            assert_equal 'service restart foreman', renderer.render
           end
         end
 
         it 'renders even without an input value' do
           renderer.invocation = template_invocation
-          _(renderer.render).must_equal 'service restart '
+          assert_equal 'service restart ', renderer.render
         end
 
         describe 'with circular reference' do
@@ -126,7 +130,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
             renderer.invocation = FactoryBot.build(:template_invocation, :template => template_without_inputs)
             renderer.template = template_without_inputs
             assert_not renderer.render
-            _(renderer.error_message).must_include 'Recursive rendering of templates detected'
+            assert_includes renderer.error_message, 'Recursive rendering of templates detected'
           end
 
           it 'handles circular references in inputs' do
@@ -194,8 +198,8 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
           end
 
           it 'includes all inputs from the imported template' do
-            _(template.template_inputs_with_foreign.map(&:name).sort).must_equal ['action', 'debug', 'package']
-            _(template_2.template_inputs_with_foreign.map(&:name).sort).must_equal ['action', 'debug', 'package']
+            assert_equal ['action', 'debug', 'package'], template.template_inputs_with_foreign.map(&:name).sort
+            assert_equal ['action', 'debug', 'package'], template_2.template_inputs_with_foreign.map(&:name).sort
           end
         end
 
@@ -207,7 +211,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
           end
 
           it 'includes all inputs from the imported template except the listed once' do
-            _(template.template_inputs_with_foreign.map(&:name).sort).must_equal ['package']
+            assert_equal ['package'], template.template_inputs_with_foreign.map(&:name).sort
           end
         end
 
@@ -220,7 +224,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
           end
 
           it 'includes all inputs from the imported template' do
-            _(template.template_inputs_with_foreign.map(&:name).sort).must_equal ['package']
+            assert_equal ['package'], template.template_inputs_with_foreign.map(&:name).sort
           end
         end
       end
@@ -237,8 +241,8 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
         it 'can render with job invocation with corresponding value' do
           rendered = renderer.render
-          _(renderer.error_message).must_be_nil
-          _(rendered).must_equal 'yum -y install zsh'
+          assert_nil renderer.error_message
+          assert_equal 'yum -y install zsh', rendered
         end
       end
 
@@ -255,16 +259,16 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
         it 'can render with job invocation with corresponding value' do
           rendered = renderer.render
-          _(renderer.error_message).must_be_nil
-          _(rendered).must_equal 'yum -y install zsh'
+          assert_nil renderer.error_message
+          assert_equal 'yum -y install zsh', rendered
         end
       end
 
       it 'renders even without an input value' do
         renderer.invocation = template_invocation
         rendered = renderer.render
-        _(renderer.error_message).must_be_nil
-        _(rendered).must_equal 'yum -y install '
+        assert_nil renderer.error_message
+        assert_equal 'yum -y install ', rendered
       end
     end
 
@@ -291,7 +295,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
       context 'with a valid input defined' do
         context 'with an optional input' do
           it 'can render with job invocation with corresponding value' do
-            _(result).must_equal 'service restart foreman'
+            assert_equal 'service restart foreman', result
           end
         end
 
@@ -299,7 +303,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
           let(:required) { true }
 
           it 'renders the template when the input is provided' do
-            _(result).must_equal 'service restart foreman'
+            assert_equal 'service restart foreman', result
           end
         end
       end
@@ -309,7 +313,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
         context 'with optional input' do
           it 'renders the template' do
-            _(result).must_equal 'service restart '
+            assert_equal 'service restart ', result
           end
         end
 
@@ -340,8 +344,8 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
         it 'registers an error' do
           result # let is lazy
-          _(renderer.error_message).wont_be_nil
-          _(renderer.error_message).wont_be_empty
+          assert_not_nil renderer.error_message
+          assert_not_empty renderer.error_message
         end
 
         context 'with host specified' do
@@ -354,14 +358,14 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
             it 'registers an error' do
               result # let is lazy
-              _(renderer.error_message).wont_be_nil
-              _(renderer.error_message).wont_be_empty
+              assert_not_nil renderer.error_message
+              assert_not_empty renderer.error_message
             end
           end
 
           describe 'preview' do
             it 'should render preview' do
-              _(renderer.preview).must_equal 'echo $FACT_INPUT[issue] > /etc/issue'
+              assert_equal 'echo $FACT_INPUT[issue] > /etc/issue', renderer.preview
             end
           end
 
@@ -376,14 +380,14 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
               it 'registers an error' do
                 result # let is lazy
-                _(renderer.error_message).wont_be_nil
-                _(renderer.error_message).wont_be_empty
+                assert_not_nil renderer.error_message
+                assert_not_empty renderer.error_message
               end
             end
 
             describe 'preview' do
               it 'should render preview' do
-                _(renderer.preview).must_equal 'echo $FACT_INPUT[issue] > /etc/issue'
+                assert_equal 'echo $FACT_INPUT[issue] > /etc/issue', renderer.preview
               end
             end
 
@@ -393,7 +397,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
               let(:result) { renderer.render }
 
               it 'can render with job invocation with corresponding value' do
-                _(result).must_equal 'echo banner > /etc/issue'
+                assert_equal 'echo banner > /etc/issue', result
               end
             end
           end
@@ -402,7 +406,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
       describe 'preview' do
         it 'should render preview' do
-          _(renderer.preview).must_equal 'echo $FACT_INPUT[issue] > /etc/issue'
+          assert_equal 'echo $FACT_INPUT[issue] > /etc/issue', renderer.preview
         end
 
         context 'with host specified' do
@@ -416,7 +420,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
           let(:result) { renderer.render }
 
           it 'uses the value even in preview' do
-            _(result).must_equal 'echo banner > /etc/issue'
+            assert_equal 'echo banner > /etc/issue', result
           end
         end
       end
@@ -438,8 +442,8 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
         it 'registers an error' do
           result # let is lazy
-          _(renderer.error_message).wont_be_nil
-          _(renderer.error_message).wont_be_empty
+          refute_nil renderer.error_message
+          refute_empty renderer.error_message
         end
 
         context 'with host specified' do
@@ -455,14 +459,14 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
             it 'registers an error' do
               result # let is lazy
-              _(renderer.error_message).wont_be_nil
-              _(renderer.error_message).wont_be_empty
+              refute_nil renderer.error_message
+              refute_empty renderer.error_message
             end
           end
 
           describe 'preview' do
             it 'should render preview' do
-              _(renderer.preview).must_equal 'echo $VARIABLE_INPUT[client_key] > /etc/chef/client.pem'
+              assert_equal 'echo $VARIABLE_INPUT[client_key] > /etc/chef/client.pem', renderer.preview
             end
           end
 
@@ -474,7 +478,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
               it 'renders the value from host parameter' do
                 parameter
                 renderer.host.reload
-                _(result).must_equal 'echo RSA KEY > /etc/chef/client.pem'
+                assert_equal 'echo RSA KEY > /etc/chef/client.pem', result
               end
             end
 
@@ -482,7 +486,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
               it 'should render preview' do
                 parameter
                 renderer.host.reload
-                _(renderer.preview).must_equal 'echo RSA KEY > /etc/chef/client.pem'
+                assert_equal 'echo RSA KEY > /etc/chef/client.pem', renderer.preview
               end
             end
           end
@@ -490,7 +494,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
 
         describe 'preview' do
           it 'should render preview' do
-            _(renderer.preview).must_equal 'echo $VARIABLE_INPUT[client_key] > /etc/chef/client.pem'
+            assert_equal 'echo $VARIABLE_INPUT[client_key] > /etc/chef/client.pem', renderer.preview
           end
         end
       end

--- a/test/unit/input_template_renderer_test.rb
+++ b/test/unit/input_template_renderer_test.rb
@@ -29,7 +29,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
       describe 'rendering' do
         let(:result) { renderer.render }
         it 'should return false' do
-          assert_equal false, result
+          refute result
         end
 
         it 'should register an error' do
@@ -42,7 +42,7 @@ class InputTemplateRendererTest < ActiveSupport::TestCase
       describe 'preview' do
         let(:result) { renderer.preview }
         it 'should return false' do
-          assert_equal false, result
+          refute result
         end
 
         it 'should register an error' do

--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -176,19 +176,19 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
       describe '#rerun_possible?' do
         it 'is true when not rerunning' do
-          assert composer.rerun_possible?
+          assert_predicate composer, :rerun_possible?
         end
 
         it 'is true when rerunning with pattern tempalte invocations' do
           composer.expects(:reruns).returns(1)
           composer.job_invocation.expects(:pattern_template_invocations).returns([1])
-          assert composer.rerun_possible?
+          assert_predicate composer, :rerun_possible?
         end
 
         it 'is false when rerunning without pattern template invocations' do
           composer.expects(:reruns).returns(1)
           composer.job_invocation.expects(:pattern_template_invocations).returns([])
-          refute composer.rerun_possible?
+          refute_predicate composer, :rerun_possible?
         end
       end
 
@@ -826,7 +826,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
       end
 
       it 'handles errors' do
-        assert input3.required
+        assert_predicate input3, :required
 
         error = assert_raises(ActiveRecord::RecordNotSaved) do
           composer.save!

--- a/test/unit/job_invocation_composer_test.rb
+++ b/test/unit/job_invocation_composer_test.rb
@@ -75,13 +75,13 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
       describe '#available_templates_for(job_category)' do
         it 'find the templates only for a given job name' do
           results = composer.available_templates_for(trying_job_template_1.job_category)
-          _(results).must_include trying_job_template_1
-          _(results).wont_include trying_job_template_2
+          assert_includes results, trying_job_template_1
+          refute_includes results, trying_job_template_2
         end
 
         it 'it respects view permissions' do
           results = composer.available_templates_for(trying_job_template_1.job_category)
-          _(results).wont_include unauthorized_job_template_1
+          refute_includes results, unauthorized_job_template_1
         end
       end
 
@@ -89,13 +89,13 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         let(:job_categories) { composer.available_job_categories }
 
         it 'find only job names that user is granted to view' do
-          _(job_categories).must_include trying_job_template_1.job_category
-          _(job_categories).must_include trying_job_template_2.job_category
-          _(job_categories).wont_include unauthorized_job_template_2.job_category
+          assert_includes job_categories, trying_job_template_1.job_category
+          assert_includes job_categories, trying_job_template_2.job_category
+          refute_includes job_categories, unauthorized_job_template_2.job_category
         end
 
         it 'every job name is listed just once' do
-          _(job_categories.uniq).must_equal job_categories
+          assert_equal job_categories.uniq, job_categories
         end
       end
 
@@ -104,13 +104,13 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
         it 'finds only providers which user is granted to view' do
           composer.job_invocation.job_category = 'trying_job_template_1'
-          _(provider_types).must_include 'SSH'
-          _(provider_types).wont_include 'Mcollective'
-          _(provider_types).wont_include 'Ansible'
+          assert_includes provider_types, 'SSH'
+          refute_includes provider_types, 'Mcollective'
+          refute_includes provider_types, 'Ansible'
         end
 
         it 'every provider type is listed just once' do
-          _(provider_types.uniq).must_equal provider_types
+          assert_equal provider_types.uniq, provider_types
         end
       end
 
@@ -122,9 +122,9 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         end
 
         it 'returns only authorized inputs based on templates' do
-          _(composer.available_template_inputs).must_include(input1)
-          _(composer.available_template_inputs).must_include(input2)
-          _(composer.available_template_inputs).wont_include(unauthorized_input1)
+          assert_includes composer.available_template_inputs, input1
+          assert_includes composer.available_template_inputs, input2
+          refute_includes composer.available_template_inputs, unauthorized_input1
         end
 
         context 'params contains job template ids' do
@@ -134,9 +134,9 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:params) { { :job_invocation => providers_params }.with_indifferent_access }
 
           it 'finds the inputs only specified job templates' do
-            _(composer.available_template_inputs).must_include(input1)
-            _(composer.available_template_inputs).wont_include(input2)
-            _(composer.available_template_inputs).wont_include(unauthorized_input1)
+            assert_includes composer.available_template_inputs, input1
+            refute_includes composer.available_template_inputs, input2
+            refute_includes composer.available_template_inputs, unauthorized_input1
           end
         end
       end
@@ -149,7 +149,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
         it 'returns false if there is one provider' do
           composer.stubs(:available_provider_types => [ 'SSH' ])
-          assert_not composer.needs_provider_type_selection?
+          refute composer.needs_provider_type_selection?
         end
       end
 
@@ -161,40 +161,40 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         it 'returns all templates for a given provider respecting template permissions' do
           trying_job_template_4 = FactoryBot.create(:job_template, :job_category => 'trying_job_template_1', :name => 'trying4', :provider_type => 'Ansible')
           result = composer.templates_for_provider('SSH')
-          _(result).must_include trying_job_template_1
-          _(result).must_include trying_job_template_3
-          _(result).wont_include unauthorized_job_template_1
-          _(result).wont_include trying_job_template_4
+          assert_includes result, trying_job_template_1
+          assert_includes result, trying_job_template_3
+          refute_includes result, unauthorized_job_template_1
+          refute_includes result, trying_job_template_4
 
           result = composer.templates_for_provider('Ansible')
-          _(result).wont_include trying_job_template_1
-          _(result).wont_include trying_job_template_3
-          _(result).wont_include unauthorized_job_template_2
-          _(result).must_include trying_job_template_4
+          refute_includes result, trying_job_template_1
+          refute_includes result, trying_job_template_3
+          refute_includes result, unauthorized_job_template_2
+          assert_includes result, trying_job_template_4
         end
       end
 
       describe '#rerun_possible?' do
         it 'is true when not rerunning' do
-          _(composer).must_be :rerun_possible?
+          assert composer.rerun_possible?
         end
 
         it 'is true when rerunning with pattern tempalte invocations' do
           composer.expects(:reruns).returns(1)
           composer.job_invocation.expects(:pattern_template_invocations).returns([1])
-          _(composer).must_be :rerun_possible?
+          assert composer.rerun_possible?
         end
 
         it 'is false when rerunning without pattern template invocations' do
           composer.expects(:reruns).returns(1)
           composer.job_invocation.expects(:pattern_template_invocations).returns([])
-          _(composer).wont_be :rerun_possible?
+          refute composer.rerun_possible?
         end
       end
 
       describe '#selected_job_templates' do
         it 'returns no template if none was selected through params' do
-          _(composer.selected_job_templates).must_be_empty
+          assert_empty composer.selected_job_templates
         end
 
         context 'extra unavailable templates id were selected' do
@@ -207,14 +207,14 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
           it 'ignores unauthorized template' do
             unauthorized # make sure unautorized exists
-            _(composer.selected_job_templates).wont_include unauthorized
+            refute_includes composer.selected_job_templates, unauthorized
           end
 
           it 'contains only authorized template specified in params' do
             mcollective_authorized # make sure mcollective_authorized exists
-            _(composer.selected_job_templates).must_include trying_job_template_1
-            _(composer.selected_job_templates).must_include mcollective_authorized
-            _(composer.selected_job_templates).wont_include trying_job_template_3
+            assert_includes composer.selected_job_templates, trying_job_template_1
+            assert_includes composer.selected_job_templates, mcollective_authorized
+            refute_includes composer.selected_job_templates, trying_job_template_3
           end
         end
       end
@@ -222,7 +222,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
       describe '#preselected_template_for_provider(provider_type)' do
         context 'none template was selected through params' do
           it 'returns nil' do
-            _(composer.preselected_template_for_provider('SSH')).must_be_nil
+            assert_nil composer.preselected_template_for_provider('SSH')
           end
         end
 
@@ -231,7 +231,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:params) { { :job_invocation => providers_params }.with_indifferent_access }
 
           it 'returns the selected template because it is available for provider' do
-            _(composer.preselected_template_for_provider('SSH')).must_equal trying_job_template_1
+            assert_equal trying_job_template_1, composer.preselected_template_for_provider('SSH')
           end
         end
       end
@@ -249,9 +249,9 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         let(:invocations) { composer.pattern_template_invocations }
 
         it 'builds pattern template invocations based on passed params and it filters out wrong inputs' do
-          _(invocations.size).must_equal 1
-          _(invocations.first.input_values.size).must_equal 1
-          _(invocations.first.input_values.first.value).must_equal 'value1'
+          assert_equal 1, invocations.size
+          assert_equal 1, invocations.first.input_values.size
+          assert_equal 'value1', invocations.first.input_values.first.value
         end
       end
 
@@ -275,7 +275,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:invocation_effective_user) { 'invocation user' }
 
           it 'takes the value from the template invocation' do
-            _(template_invocation.effective_user).must_equal 'invocation user'
+            assert_equal 'invocation user', template_invocation.effective_user
           end
         end
 
@@ -284,7 +284,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:invocation_effective_user) { '' }
 
           it 'takes the value from the job template' do
-            _(template_invocation.effective_user).must_equal 'template user'
+            assert_equal 'template user', template_invocation.effective_user
           end
         end
 
@@ -293,14 +293,14 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:invocation_effective_user) { 'invocation user' }
 
           it 'takes the value from the job template' do
-            _(template_invocation.effective_user).must_equal 'template user'
+            assert_equal 'template user', template_invocation.effective_user
           end
         end
       end
 
       describe '#displayed_search_query' do
         it 'is empty by default' do
-          _(composer.displayed_search_query).must_be_empty
+          assert_empty composer.displayed_search_query
         end
 
         let(:host) { FactoryBot.create(:host) }
@@ -310,7 +310,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:params) { { :targeting => { :search_query => 'a', :bookmark_id => bookmark.id }, :host_ids => [ host.id ] }.with_indifferent_access }
 
           it 'explicit search query has highest priority' do
-            _(composer.displayed_search_query).must_equal 'a'
+            assert_equal 'a', composer.displayed_search_query
           end
         end
 
@@ -318,7 +318,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:params) { { :targeting => { :bookmark_id => bookmark.id }, :host_ids => [ host.id ] }.with_indifferent_access }
 
           it 'hosts will be used instead of a bookmark' do
-            _(composer.displayed_search_query).must_include host.name
+            assert_includes composer.displayed_search_query, host.name
           end
         end
 
@@ -327,20 +327,20 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
           it 'bookmark query is used if it is available for the user' do
             bookmark.update_attribute :public, false
-            _(composer.displayed_search_query).must_equal bookmark.query
+            assert_equal bookmark.query, composer.displayed_search_query
           end
 
           it 'bookmark query is used if the bookmark is public' do
             bookmark.owner = nil
             bookmark.save(:validate => false) # skip validations so owner remains nil
-            _(composer.displayed_search_query).must_equal bookmark.query
+            assert_equal bookmark.query, composer.displayed_search_query
           end
 
           it 'empty search is returned if bookmark is not owned by the user and is not public' do
             bookmark.public = false
             bookmark.owner = nil
             bookmark.save(:validate => false) # skip validations so owner remains nil
-            _(composer.displayed_search_query).must_be_empty
+            assert_empty composer.displayed_search_query
           end
         end
       end
@@ -355,9 +355,9 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
             hosts
             dashboard
             hostgroups
-            _(composer.available_bookmarks).must_include hosts
-            _(composer.available_bookmarks).must_include dashboard
-            _(composer.available_bookmarks).wont_include hostgroups
+            assert_includes composer.available_bookmarks, hosts
+            assert_includes composer.available_bookmarks, dashboard
+            refute_includes composer.available_bookmarks, hostgroups
           end
         end
       end
@@ -375,17 +375,17 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
         it 'searches hosts based on displayed_search_query' do
           composer.stubs(:displayed_search_query => "name = #{host.name}")
-          _(composer.targeted_hosts_count).must_equal 1
+          assert_equal 1, composer.targeted_hosts_count
         end
 
         it 'returns 0 for queries with syntax errors' do
           composer.stubs(:displayed_search_query => 'name = ')
-          _(composer.targeted_hosts_count).must_equal 0
+          assert_equal 0, composer.targeted_hosts_count
         end
 
         it 'returns 0 when no query is present' do
           composer.stubs(:displayed_search_query => '')
-          _(composer.targeted_hosts_count).must_equal 0
+          assert_equal 0, composer.targeted_hosts_count
         end
       end
 
@@ -393,7 +393,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         let(:value1) { composer.input_value_for(input1) }
         it 'returns new empty input value if there is no invocation' do
           assert value1.new_record?
-          _(value1.value).must_be_empty
+          assert_empty value1.value
         end
 
         context 'there are invocations without input values for a given input' do
@@ -409,7 +409,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
           it 'returns new empty input value' do
             assert value1.new_record?
-            _(value1.value).must_be_empty
+            assert_empty value1.value
           end
         end
 
@@ -425,7 +425,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           let(:params) { { :job_invocation => { :providers => { :ssh => ssh_params } } }.with_indifferent_access }
 
           it 'finds the value among template invocations' do
-            _(value1.value).must_equal 'value1'
+            assert_equal 'value1', value1.value
           end
         end
       end
@@ -462,12 +462,12 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
           end
 
           it 'accepts the concurrency options' do
-            _(composer.job_invocation.concurrency_level).must_equal 5
+            assert_equal 5, composer.job_invocation.concurrency_level
           end
         end
 
         it 'can be disabled' do
-          _(composer.job_invocation.concurrency_level).must_be_nil
+          assert_nil composer.job_invocation.concurrency_level
         end
       end
 
@@ -477,11 +477,11 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         end
 
         it 'accepts the triggering params' do
-          _(composer.job_invocation.triggering.mode).must_equal :future
+          assert_equal :future, composer.job_invocation.triggering.mode
         end
 
         it 'formats the triggering end time when its unordered' do
-          _(composer.job_invocation.triggering.end_time).must_equal Time.local(3,2,1,4,5)
+          assert_equal Time.local(3,2,1,4,5), composer.job_invocation.triggering.end_time
         end
       end
 
@@ -515,7 +515,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
         it 'sets the password properly' do
           composer
-          _(composer.job_invocation.password).must_equal password
+          assert_equal password, composer.job_invocation.password
         end
       end
 
@@ -527,7 +527,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
         it 'sets the key passphrase properly' do
           composer
-          _(composer.job_invocation.key_passphrase).must_equal key_passphrase
+          assert_equal key_passphrase, composer.job_invocation.key_passphrase
         end
       end
 
@@ -539,7 +539,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
         it 'sets the effective_user_password password properly' do
           composer
-          _(composer.job_invocation.effective_user_password).must_equal effective_user_password
+          assert_equal effective_user_password, composer.job_invocation.effective_user_password
         end
       end
 
@@ -581,29 +581,29 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         end
 
         it 'sets the same job name' do
-          _(new_composer.job_category).must_equal existing.job_category
+          assert_equal existing.job_category, new_composer.job_category
         end
 
         it 'accepts additional host ids' do
           new_composer = JobInvocationComposer.from_job_invocation(composer.job_invocation, { :host_ids => [host.id] })
-          _(new_composer.search_query).must_equal("name ^ (#{host.name})")
+          assert_equal "name ^ (#{host.name})", new_composer.search_query
         end
 
         it 'builds new targeting object which keeps search query' do
-          _(new_composer.targeting).wont_equal existing.targeting
-          _(new_composer.search_query).must_equal existing.targeting.search_query
+          refute_equal existing.targeting, new_composer.targeting
+          assert_equal existing.targeting.search_query, new_composer.search_query
         end
 
         it 'keeps job template ids' do
-          _(new_composer.job_template_ids).must_equal existing.pattern_template_invocations.map(&:template_id)
+          assert_equal existing.pattern_template_invocations.map(&:template_id), new_composer.job_template_ids
         end
 
         it 'keeps template invocations and their values' do
-          _(new_composer.pattern_template_invocations.size).must_equal existing.pattern_template_invocations.size
+          assert_equal existing.pattern_template_invocations.size, new_composer.pattern_template_invocations.size
         end
 
         it 'sets the same concurrency control options' do
-          _(new_composer.job_invocation.concurrency_level).must_equal existing.concurrency_level
+          assert_equal existing.concurrency_level, new_composer.job_invocation.concurrency_level
         end
 
       end
@@ -701,7 +701,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
       it 'sets the effective user based on the input' do
         assert composer.save!
-        _(template_invocation.effective_user).must_equal 'invocation user'
+        assert_equal 'invocation user', template_invocation.effective_user
       end
     end
 
@@ -720,7 +720,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
       it 'sets the concurrency level based on the input' do
         assert composer.save!
-        _(composer.job_invocation.concurrency_level).must_equal level
+        assert_equal level, composer.job_invocation.concurrency_level
       end
     end
 
@@ -737,7 +737,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
 
       it 'sets the remote execution feature based on the input' do
         assert composer.save!
-        _(composer.job_invocation.remote_execution_feature).must_equal feature
+        assert_equal feature, composer.job_invocation.remote_execution_feature
       end
 
       it 'sets the remote execution_feature id based on `feature` param' do
@@ -747,7 +747,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         refute_equal feature.job_template, trying_job_template_1
 
         assert composer.save!
-        _(composer.job_invocation.remote_execution_feature).must_equal feature
+        assert_equal feature, composer.job_invocation.remote_execution_feature
       end
     end
 
@@ -797,7 +797,7 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
         error = assert_raises(ActiveRecord::RecordNotSaved) do
           composer.save!
         end
-        _(error.message).must_include "Template #{trying_job_template_1.name}: Input #{input3.name.downcase}: Value can't be blank"
+        assert_includes error.message, "Template #{trying_job_template_1.name}: Input #{input3.name.downcase}: Value can't be blank"
       end
     end
 
@@ -826,13 +826,13 @@ class JobInvocationComposerTest < ActiveSupport::TestCase
       end
 
       it 'handles errors' do
-        _(input3).must_be :required
+        assert input3.required
 
         error = assert_raises(ActiveRecord::RecordNotSaved) do
           composer.save!
         end
 
-        _(error.message).must_include "Template #{trying_job_template_1.name}: Not all required inputs have values. Missing inputs: #{input3.name}"
+        assert_includes error.message, "Template #{trying_job_template_1.name}: Not all required inputs have values. Missing inputs: #{input3.name}"
       end
     end
   end

--- a/test/unit/job_invocation_test.rb
+++ b/test/unit/job_invocation_test.rb
@@ -139,7 +139,7 @@ class JobInvocationTest < ActiveSupport::TestCase
       before { task.state = 'scheduled' }
 
       specify { assert_equal HostStatus::ExecutionStatus::QUEUED, job_invocation.status }
-      specify { assert_equal true, job_invocation.queued? }
+      specify { assert job_invocation.queued? }
       specify { assert_equal 0, job_invocation.progress }
       specify { assert_equal progress_report_without_sub_tasks, job_invocation.progress_report }
     end
@@ -164,7 +164,7 @@ class JobInvocationTest < ActiveSupport::TestCase
       end
 
       specify { assert_equal HostStatus::ExecutionStatus::OK, job_invocation.status }
-      specify { assert_equal false, job_invocation.queued? }
+      specify { refute job_invocation.queued? }
 
       it 'calculates the progress correctly' do
         sub_tasks = [ForemanTasks::Task.new]

--- a/test/unit/job_template_effective_user_test.rb
+++ b/test/unit/job_template_effective_user_test.rb
@@ -19,19 +19,19 @@ class JobTemplateEffectiveUserTest < ActiveSupport::TestCase
       user = FactoryBot.create(:user)
       User.current = user
       effective_user.current_user = true
-      _(effective_user.compute_value).must_equal user.login
+      assert_equal user.login, effective_user.compute_value
     end
 
     it 'returns the value when not current user is set to true' do
       effective_user.current_user = false
       effective_user.value = 'testuser'
-      _(effective_user.compute_value).must_equal 'testuser'
+      assert_equal 'testuser', effective_user.compute_value
     end
 
     it 'returns a default value when no value is specified for the user' do
       effective_user.value = ''
       Setting[:remote_execution_effective_user] = 'myuser'
-      _(effective_user.compute_value).must_equal 'myuser'
+      assert_equal 'myuser', effective_user.compute_value
     end
   end
 end

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -30,7 +30,7 @@ class JobTemplateTest < ActiveSupport::TestCase
       job_template.foreign_input_sets << FactoryBot.build(:foreign_input_set, :target_template => template_with_inputs)
       job_template.foreign_input_sets << FactoryBot.build(:foreign_input_set, :target_template => template_with_inputs)
       assert_not job_template.valid?
-      _(job_template.errors.full_messages.first).must_include 'Duplicated inputs detected: ["command"]'
+      refute_nil job_template.errors.full_messages.first&.include?('Duplicated inputs detected: ["command"]')
     end
   end
 
@@ -40,21 +40,21 @@ class JobTemplateTest < ActiveSupport::TestCase
     let(:minimal_template) { FactoryBot.build(:job_template) }
 
     it 'uses the description_format attribute if set' do
-      _(template_with_description.generate_description_format).must_equal template_with_description.description_format
+      assert_equal template_with_description.generate_description_format, template_with_description.description_format
     end
 
     it 'uses the job name as description_format if not set or blank and has no inputs' do
-      _(minimal_template.generate_description_format).must_equal '%{template_name}'
+      assert_equal minimal_template.generate_description_format, '%{template_name}'
       minimal_template.description_format = ''
-      _(minimal_template.generate_description_format).must_equal '%{template_name}'
+      assert_equal minimal_template.generate_description_format, '%{template_name}'
     end
 
     it 'generates the description_format if not set or blank and has inputs' do
       input_name = template.template_inputs.first.name
       expected_result = %(%{template_name} with inputs #{input_name}="%{#{input_name}}")
-      _(template.generate_description_format).must_equal expected_result
+      assert_equal template.generate_description_format, expected_result
       template.description_format = ''
-      _(template.generate_description_format).must_equal expected_result
+      assert_equal template.generate_description_format, expected_result
     end
   end
 
@@ -64,10 +64,10 @@ class JobTemplateTest < ActiveSupport::TestCase
     describe '#dup' do
       it 'duplicates also template inputs' do
         duplicate = job_template.dup
-        _(duplicate).wont_equal job_template
-        _(duplicate.template_inputs).wont_be_empty
-        _(duplicate.template_inputs.first).wont_equal job_template.template_inputs.first
-        _(duplicate.template_inputs.first.name).must_equal job_template.template_inputs.first.name
+        refute_equal duplicate, job_template
+        refute_empty duplicate.template_inputs
+        refute_equal duplicate.template_inputs.first, job_template.template_inputs.first
+        assert_equal duplicate.template_inputs.first.name, job_template.template_inputs.first.name
       end
     end
   end
@@ -120,30 +120,30 @@ class JobTemplateTest < ActiveSupport::TestCase
     end
 
     it 'sets the name' do
-      _(template.name).must_equal 'Service Restart'
+      assert_equal template.name, 'Service Restart'
     end
 
     it 'has a template' do
-      _(template.template.squish).must_equal 'service <%= input("service_name") %> restart <%# test comment %>'
+      assert_equal template.template.squish, 'service <%= input("service_name") %> restart <%# test comment %>'
     end
 
     it 'imports inputs' do
-      _(template.template_inputs.first.name).must_equal 'service_name'
+      assert_equal template.template_inputs.first.name, 'service_name'
     end
 
     it 'imports input sets' do
-      _(template_with_input_sets.foreign_input_sets.first.target_template).must_equal template
-      _(template_with_input_sets.template_inputs_with_foreign.map(&:name)).must_equal ['service_name']
+      assert_equal template_with_input_sets.foreign_input_sets.first.target_template, template
+      assert_equal template_with_input_sets.template_inputs_with_foreign.map(&:name), ['service_name']
     end
 
     it 'imports feature' do
       template # let is lazy
       remote_execution_feature.reload
-      _(remote_execution_feature.job_template).must_equal template
+      assert_equal remote_execution_feature.job_template, template
     end
 
     it 'sets additional options' do
-      _(template.default).must_equal true
+      assert_equal template.default, true
     end
   end
 
@@ -226,16 +226,16 @@ class JobTemplateTest < ActiveSupport::TestCase
 
     it 'syncs inputs' do
       hostname = synced_template.template_inputs.find { |input| input.name == 'hostname' }
-      _(hostname.options).must_equal 'www.redhat.com'
+      assert_equal hostname.options, 'www.redhat.com'
     end
 
     it 'syncs content' do
-      _(synced_template.template).must_match(/ping -c <%= input\('count'\) %> <%= input\('hostname'\) %>/m)
+      assert_match(/ping -c <%= input\('count'\) %> <%= input\('hostname'\) %>/m, synced_template.template)
     end
 
     it 'syncs input sets' do
-      _(synced_template.foreign_input_sets.first.target_template).must_equal included
-      _(synced_template.template_inputs_with_foreign.map(&:name)).must_equal ['hostname', 'count']
+      assert_equal synced_template.foreign_input_sets.first.target_template, included
+      assert_equal synced_template.template_inputs_with_foreign.map(&:name), ['hostname', 'count']
     end
   end
 
@@ -249,15 +249,15 @@ class JobTemplateTest < ActiveSupport::TestCase
     end
 
     it 'exports name' do
-      _(erb).must_match(/^name: #{exportable_template.name}$/)
+      assert_match(/^name: #{exportable_template.name}$/, erb)
     end
 
     it 'includes template inputs' do
-      _(erb).must_match(/^template_inputs:$/)
+      assert_match(/^template_inputs:$/, erb)
     end
 
     it 'includes template contents' do
-      _(erb).must_include exportable_template.template
+      assert_includes erb, exportable_template.template
     end
 
     it 'is importable' do
@@ -266,8 +266,8 @@ class JobTemplateTest < ActiveSupport::TestCase
       exportable_template.update(:name => "#{old_name}_renamed")
 
       imported = JobTemplate.import_raw!(erb)
-      _(imported.name).must_equal old_name
-      _(imported.template_inputs.first.to_export).must_equal exportable_template.template_inputs.first.to_export
+      assert_equal imported.name, old_name
+      assert_equal imported.template_inputs.first.to_export, exportable_template.template_inputs.first.to_export
     end
 
     it 'has taxonomies in metadata' do
@@ -282,7 +282,7 @@ class JobTemplateTest < ActiveSupport::TestCase
 
     describe 'job template deletion' do
       it 'succeeds' do
-        _(job_template.pattern_template_invocations).wont_be_empty
+        refute_empty job_template.pattern_template_invocations
         assert job_template.destroy
       end
     end
@@ -310,7 +310,7 @@ class JobTemplateTest < ActiveSupport::TestCase
         template_invocation.host,
         template_invocation
       result = renderer.render
-      _(result).must_equal "<wrap>#{inner.template}</wrap>"
+      assert_equal result, "<wrap>#{inner.template}</wrap>"
     end
   end
 end

--- a/test/unit/job_template_test.rb
+++ b/test/unit/job_template_test.rb
@@ -30,7 +30,7 @@ class JobTemplateTest < ActiveSupport::TestCase
       job_template.foreign_input_sets << FactoryBot.build(:foreign_input_set, :target_template => template_with_inputs)
       job_template.foreign_input_sets << FactoryBot.build(:foreign_input_set, :target_template => template_with_inputs)
       assert_not job_template.valid?
-      refute_nil job_template.errors.full_messages.first&.include?('Duplicated inputs detected: ["command"]')
+      assert_includes job_template.errors.full_messages.first, 'Duplicated inputs detected: ["command"]'
     end
   end
 

--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -57,7 +57,7 @@ class RemoteExecutionFeatureTest < ActiveSupport::TestCase
   describe '.register' do
     it "creates a feature if it's missing" do
       feature = RemoteExecutionFeature.register('new_feature_that_does_not_exist', 'name')
-      assert feature.persisted?
+      assert_predicate feature, :persisted?
       assert_equal 'new_feature_that_does_not_exist', feature.label
       assert_equal 'name', feature.name
       assert_not feature.host_action_button
@@ -65,7 +65,7 @@ class RemoteExecutionFeatureTest < ActiveSupport::TestCase
 
     it 'creates a feature with host action flag' do
       feature = RemoteExecutionFeature.register('new_feature_that_does_not_exist_button', 'name', :host_action_button => true)
-      assert feature.persisted?
+      assert_predicate feature, :persisted?
       assert feature.host_action_button
     end
 
@@ -78,7 +78,7 @@ class RemoteExecutionFeatureTest < ActiveSupport::TestCase
     it 'updates a feature if it exists' do
       existing = FactoryBot.create(:remote_execution_feature, :name => 'existing_feature_withou_action_button')
       feature = RemoteExecutionFeature.register(existing.label, existing.name, :host_action_button => true)
-      assert feature.persisted?
+      assert_predicate feature, :persisted?
       existing.reload
       assert existing.host_action_button
     end

--- a/test/unit/remote_execution_feature_test.rb
+++ b/test/unit/remote_execution_feature_test.rb
@@ -31,16 +31,16 @@ class RemoteExecutionFeatureTest < ActiveSupport::TestCase
     it 'prepares composer for given feature based on the mapping' do
       composer = JobInvocationComposer.for_feature(:katello_install_package, host, :package => 'zsh')
       assert composer.valid?
-      _(composer.pattern_template_invocations.size).must_equal 1
+      assert_equal 1, composer.pattern_template_invocations.size
       template_invocation = composer.pattern_template_invocations.first
-      _(template_invocation.template).must_equal package_template
-      _(template_invocation.input_values.size).must_equal 1
+      assert_equal package_template, template_invocation.template
+      assert_equal 1, template_invocation.input_values.size
 
       input_value = template_invocation.input_values.first
-      _(input_value.value).must_equal 'zsh'
-      _(input_value.template_input.name).must_equal 'package'
+      assert_equal 'zsh', input_value.value
+      assert_equal 'package', input_value.template_input.name
 
-      _(composer.targeting.search_query).must_equal "name ^ (#{host.name})"
+      assert_equal "name ^ (#{host.name})", composer.targeting.search_query
     end
 
     it 'updates the feature when attributes change' do
@@ -48,24 +48,24 @@ class RemoteExecutionFeatureTest < ActiveSupport::TestCase
         :description => 'New description',
         :provided_inputs => ['package', 'force'])
       updated_feature.reload
-      _(updated_feature.id).must_equal(install_feature.id)
-      _(updated_feature.description).must_equal 'New description'
-      _(updated_feature.provided_input_names).must_equal ['package', 'force']
+      assert_equal install_feature.id, updated_feature.id
+      assert_equal 'New description', updated_feature.description
+      assert_equal ['package', 'force'], updated_feature.provided_input_names
     end
   end
 
   describe '.register' do
     it "creates a feature if it's missing" do
       feature = RemoteExecutionFeature.register('new_feature_that_does_not_exist', 'name')
-      _(feature).must_be :persisted?
-      _(feature.label).must_equal 'new_feature_that_does_not_exist'
-      _(feature.name).must_equal 'name'
+      assert feature.persisted?
+      assert_equal 'new_feature_that_does_not_exist', feature.label
+      assert_equal 'name', feature.name
       assert_not feature.host_action_button
     end
 
     it 'creates a feature with host action flag' do
       feature = RemoteExecutionFeature.register('new_feature_that_does_not_exist_button', 'name', :host_action_button => true)
-      _(feature).must_be :persisted?
+      assert feature.persisted?
       assert feature.host_action_button
     end
 
@@ -78,7 +78,7 @@ class RemoteExecutionFeatureTest < ActiveSupport::TestCase
     it 'updates a feature if it exists' do
       existing = FactoryBot.create(:remote_execution_feature, :name => 'existing_feature_withou_action_button')
       feature = RemoteExecutionFeature.register(existing.label, existing.name, :host_action_button => true)
-      _(feature).must_be :persisted?
+      assert feature.persisted?
       existing.reload
       assert existing.host_action_button
     end

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -15,271 +15,271 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
   end
 
   describe '.register_provider' do
-      before { RemoteExecutionProvider.providers.delete(:new) }
-      let(:new_provider) { RemoteExecutionProvider.providers[:new] }
-      it { assert_nil new_provider }
+    before { RemoteExecutionProvider.providers.delete(:new) }
+    let(:new_provider) { RemoteExecutionProvider.providers[:new] }
+    it { assert_nil new_provider }
 
-      context 'registers a provider under key :new' do
-        before { RemoteExecutionProvider.register(:new, String) }
-        it { assert_equal String, new_provider }
+    context 'registers a provider under key :new' do
+      before { RemoteExecutionProvider.register(:new, String) }
+      it { assert_equal String, new_provider }
+    end
+  end
+
+  describe '.provider_for' do
+    it 'accepts symbols' do
+      assert_equal SSHExecutionProvider, RemoteExecutionProvider.provider_for(:SSH)
+    end
+
+    it 'accepts strings' do
+      assert_equal SSHExecutionProvider, RemoteExecutionProvider.provider_for('SSH')
+    end
+
+    it 'returns a default one if unknown value is provided' do
+      assert_equal ScriptExecutionProvider, RemoteExecutionProvider.provider_for('WinRM')
+    end
+  end
+
+  describe '.provider_names' do
+    let(:provider_names) { RemoteExecutionProvider.provider_names }
+
+    it 'returns only strings' do
+      provider_names.each do |name|
+        assert_kind_of String, name
       end
     end
 
-    describe '.provider_for' do
-      it 'accepts symbols' do
-        assert_equal SSHExecutionProvider, RemoteExecutionProvider.provider_for(:SSH)
+    context 'provider is registetered under :custom symbol' do
+      before { RemoteExecutionProvider.register(:Custom, String) }
+
+      it { assert_includes provider_names, 'SSH' }
+      it { assert_includes provider_names, 'Custom' }
+    end
+  end
+
+  describe '.proxy_feature' do
+    # rubocop:disable Naming/ConstantName
+    it 'handles provider subclasses properly' do
+      old = ::RemoteExecutionProvider
+
+      class P2 < old
+      end
+      ::RemoteExecutionProvider = P2
+
+      class CustomProvider < ::RemoteExecutionProvider
       end
 
-      it 'accepts strings' do
-        assert_equal SSHExecutionProvider, RemoteExecutionProvider.provider_for('SSH')
-      end
+      ::RemoteExecutionProvider.register('custom', CustomProvider)
 
-      it 'returns a default one if unknown value is provided' do
-        assert_equal ScriptExecutionProvider, RemoteExecutionProvider.provider_for('WinRM')
+      feature = CustomProvider.proxy_feature
+      assert_equal 'custom', feature
+    ensure
+      ::RemoteExecutionProvider = old
+    end
+    # rubocop:enable Naming/ConstantName
+  end
+
+  describe '.provider_proxy_features' do
+    it 'returns correct values' do
+      RemoteExecutionProvider.stubs(:providers).returns(
+        :SSH => SSHExecutionProvider,
+        :script => ScriptExecutionProvider
+      )
+
+      features = RemoteExecutionProvider.provider_proxy_features
+      assert_includes features, 'SSH'
+      assert_includes features, 'Script'
+      RemoteExecutionProvider.unstub(:providers)
+    end
+
+    it 'can deal with non-arrays' do
+      provider = OpenStruct.new(proxy_feature: 'Testing')
+      RemoteExecutionProvider.stubs(:providers).returns(:testing => provider)
+      features = RemoteExecutionProvider.provider_proxy_features
+      assert_includes features, 'Testing'
+      RemoteExecutionProvider.unstub(:providers)
+    end
+  end
+
+  describe '.host_setting' do
+    let(:host) { FactoryBot.create(:host) }
+
+    it 'honors falsey values set as a host parameter' do
+      key = 'remote_execution_connect_by_ip'
+      Setting[key] = true
+      host.parameters << HostParameter.new(name: key, value: false)
+
+      refute RemoteExecutionProvider.host_setting(host, key)
+    end
+  end
+
+  describe SSHExecutionProvider do
+    before { User.current = FactoryBot.build(:user, :admin) }
+    after { User.current = nil }
+
+    let(:job_invocation) { FactoryBot.create(:job_invocation, :with_template) }
+    let(:template_invocation) { job_invocation.pattern_template_invocations.first }
+    let(:host) { FactoryBot.create(:host) }
+    let(:proxy_options) { SSHExecutionProvider.proxy_command_options(template_invocation, host) }
+    let(:secrets) { SSHExecutionProvider.secrets(host) }
+
+    describe 'effective user' do
+      it 'takes the effective user from value from the template invocation' do
+        template_invocation.effective_user = 'my user'
+        assert_equal 'my user', proxy_options[:effective_user]
       end
     end
 
-    describe '.provider_names' do
-      let(:provider_names) { RemoteExecutionProvider.provider_names }
-
-      it 'returns only strings' do
-        provider_names.each do |name|
-          assert_kind_of String, name
-        end
-      end
-
-      context 'provider is registetered under :custom symbol' do
-        before { RemoteExecutionProvider.register(:Custom, String) }
-
-        it { assert_includes provider_names, 'SSH' }
-        it { assert_includes provider_names, 'Custom' }
+    describe 'ssh user' do
+      it 'uses the remote_execution_ssh_user on the host param' do
+        host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_user', :value => 'my user')
+        assert_equal 'my user', proxy_options[:ssh_user]
       end
     end
 
-    describe '.proxy_feature' do
-      # rubocop:disable Naming/ConstantName
-      it 'handles provider subclasses properly' do
-        old = ::RemoteExecutionProvider
-
-        class P2 < old
-        end
-        ::RemoteExecutionProvider = P2
-
-        class CustomProvider < ::RemoteExecutionProvider
-        end
-
-        ::RemoteExecutionProvider.register('custom', CustomProvider)
-
-        feature = CustomProvider.proxy_feature
-        assert_equal 'custom', feature
-      ensure
-        ::RemoteExecutionProvider = old
-      end
-      # rubocop:enable Naming/ConstantName
-    end
-
-    describe '.provider_proxy_features' do
-      it 'returns correct values' do
-        RemoteExecutionProvider.stubs(:providers).returns(
-          :SSH => SSHExecutionProvider,
-          :script => ScriptExecutionProvider
-        )
-
-        features = RemoteExecutionProvider.provider_proxy_features
-        assert_includes features, 'SSH'
-        assert_includes features, 'Script'
-        RemoteExecutionProvider.unstub(:providers)
-      end
-
-      it 'can deal with non-arrays' do
-        provider = OpenStruct.new(proxy_feature: 'Testing')
-        RemoteExecutionProvider.stubs(:providers).returns(:testing => provider)
-        features = RemoteExecutionProvider.provider_proxy_features
-        assert_includes features, 'Testing'
-        RemoteExecutionProvider.unstub(:providers)
+    describe 'effective user password' do
+      it 'uses the remote_execution_effective_user_password on the host param' do
+        host.params['remote_execution_effective_user_password'] = 'mypassword'
+        host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_password', :value => 'mypassword')
+        assert_nil proxy_options[:effective_user_password]
+        assert_equal 'mypassword', secrets[:effective_user_password]
       end
     end
 
-    describe '.host_setting' do
-      let(:host) { FactoryBot.create(:host) }
-
-      it 'honors falsey values set as a host parameter' do
-        key = 'remote_execution_connect_by_ip'
-        Setting[key] = true
-        host.parameters << HostParameter.new(name: key, value: false)
-
-        refute RemoteExecutionProvider.host_setting(host, key)
+    describe 'sudo' do
+      it 'uses the remote_execution_effective_user_method on the host param' do
+        host.params['remote_execution_effective_user_method'] = 'sudo'
+        method_param = FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_method', :value => 'sudo')
+        host.host_parameters << method_param
+        assert_equal 'sudo', proxy_options[:effective_user_method]
+        method_param.update!(:value => 'su')
+        host.clear_host_parameters_cache!
+        proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
+        assert_equal 'su', proxy_options[:effective_user_method]
+        method_param.update!(:value => 'dzdo')
+        host.clear_host_parameters_cache!
+        proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
+        assert_equal 'dzdo', proxy_options[:effective_user_method]
       end
     end
 
-    describe SSHExecutionProvider do
-      before { User.current = FactoryBot.build(:user, :admin) }
-      after { User.current = nil }
-
-      let(:job_invocation) { FactoryBot.create(:job_invocation, :with_template) }
-      let(:template_invocation) { job_invocation.pattern_template_invocations.first }
-      let(:host) { FactoryBot.create(:host) }
-      let(:proxy_options) { SSHExecutionProvider.proxy_command_options(template_invocation, host) }
-      let(:secrets) { SSHExecutionProvider.secrets(host) }
-
-      describe 'effective user' do
-        it 'takes the effective user from value from the template invocation' do
-          template_invocation.effective_user = 'my user'
-          assert_equal 'my user', proxy_options[:effective_user]
-        end
+    describe 'ssh port from settings' do
+      before do
+        Setting[:remote_execution_ssh_port] = '66'
       end
 
-      describe 'ssh user' do
-        it 'uses the remote_execution_ssh_user on the host param' do
-          host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_user', :value => 'my user')
-          assert_equal 'my user', proxy_options[:ssh_user]
-        end
+      it 'has ssh port changed in settings and check return type' do
+        assert_kind_of Integer, proxy_options[:ssh_port]
+        assert_equal 66, proxy_options[:ssh_port]
+      end
+    end
+
+    describe 'ssh port from params' do
+      it 'takes ssh port number from params and check return type' do
+        host.params['remote_execution_ssh_port'] = '30'
+        host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_ssh_port', :value => '30')
+        host.clear_host_parameters_cache!
+        assert_kind_of Integer, proxy_options[:ssh_port]
+        assert_equal 30, proxy_options[:ssh_port]
+      end
+    end
+
+    describe 'cleanup working directories setting' do
+      before do
+        Setting[:remote_execution_cleanup_working_dirs] = false
       end
 
-      describe 'effective user password' do
-        it 'uses the remote_execution_effective_user_password on the host param' do
-          host.params['remote_execution_effective_user_password'] = 'mypassword'
-          host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_password', :value => 'mypassword')
-          assert_nil proxy_options[:effective_user_password]
-          assert_equal 'mypassword', secrets[:effective_user_password]
-        end
+      it 'updates the value via settings' do
+        refute proxy_options[:cleanup_working_dirs]
+      end
+    end
+
+    describe 'cleanup working directories from parameters' do
+      it 'takes the value from host parameters' do
+        host.params['remote_execution_cleanup_working_dirs'] = 'false'
+        host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_cleanup_working_dirs', :value => 'false')
+        host.clear_host_parameters_cache!
+        refute proxy_options[:cleanup_working_dirs]
+      end
+    end
+
+    describe '#find_ip_or_hostname' do
+      let(:host) do
+        FactoryBot.create(:host) do |host|
+          host.interfaces = [FactoryBot.build(:nic_managed, flags.merge(:ip => nil, :name => 'somehost.somedomain.org', :primary => true)),
+                             FactoryBot.build(:nic_managed, flags.merge(:ip => '127.0.0.1'))]
+        end.reload
+        # Reassigning the interfaces triggers the on-deletion ssh key removal for the interface which is being replaced
+        # This has an undesired side effect of caching the original interface as execution one which made the tests
+        # give wrong results. Reloading the host wipes the cache
       end
 
-      describe 'sudo' do
-        it 'uses the remote_execution_effective_user_method on the host param' do
-          host.params['remote_execution_effective_user_method'] = 'sudo'
-          method_param = FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_method', :value => 'sudo')
-          host.host_parameters << method_param
-          assert_equal 'sudo', proxy_options[:effective_user_method]
-          method_param.update!(:value => 'su')
-          host.clear_host_parameters_cache!
-          proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
-          assert_equal 'su', proxy_options[:effective_user_method]
-          method_param.update!(:value => 'dzdo')
-          host.clear_host_parameters_cache!
-          proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
-          assert_equal 'dzdo', proxy_options[:effective_user_method]
-        end
+      let(:flags) do
+        { :primary => false, :provision => false, :execution => false }
       end
 
-      describe 'ssh port from settings' do
-        before do
-          Setting[:remote_execution_ssh_port] = '66'
-        end
+      it 'gets fqdn from flagged interfaces if not preferring ips' do
+        # falling to primary interface
+        assert_equal 'somehost.somedomain.org', SSHExecutionProvider.find_ip_or_hostname(host)
 
-        it 'has ssh port changed in settings and check return type' do
-          assert_kind_of Integer, proxy_options[:ssh_port]
-          assert_equal 66, proxy_options[:ssh_port]
-        end
+        # execution wins if present
+        execution_interface = FactoryBot.build(:nic_managed,
+          flags.merge(:execution => true, :name => 'special.somedomain.org'))
+        host.interfaces << execution_interface
+        host.primary_interface.update(:execution => false)
+        host.interfaces.each(&:save)
+        host.reload
+        assert_equal execution_interface.fqdn, SSHExecutionProvider.find_ip_or_hostname(host)
       end
 
-      describe 'ssh port from params' do
-        it 'takes ssh port number from params and check return type' do
-          host.params['remote_execution_ssh_port'] = '30'
-          host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_ssh_port', :value => '30')
-          host.clear_host_parameters_cache!
-          assert_kind_of Integer, proxy_options[:ssh_port]
-          assert_equal 30, proxy_options[:ssh_port]
-        end
+      it 'gets ip from flagged interfaces' do
+        host.host_params['remote_execution_connect_by_ip'] = true
+        # no ip address set on relevant interface - fallback to fqdn
+        assert_equal 'somehost.somedomain.org', SSHExecutionProvider.find_ip_or_hostname(host)
+
+        # provision interface with ip while primary without
+        provision_interface = FactoryBot.build(:nic_managed,
+          flags.merge(:provision => true, :ip => '10.0.0.1'))
+        host.interfaces << provision_interface
+        host.primary_interface.update(:provision => false)
+        host.interfaces.each(&:save)
+        host.reload
+        assert_equal provision_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
+
+        # both primary and provision interface have IPs: the primary wins
+        host.primary_interface.update(:ip => '10.0.0.2', :execution => false)
+        host.reload
+        assert_equal host.primary_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
+
+        # there is an execution interface with IP: it wins
+        execution_interface = FactoryBot.build(:nic_managed,
+          flags.merge(:execution => true, :ip => '10.0.0.3'))
+        host.interfaces << execution_interface
+        host.primary_interface.update(:execution => false)
+        host.interfaces.each(&:save)
+        host.reload
+        assert_equal execution_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
+
+        # there is an execution interface with both IPv6 and IPv4: IPv4 is being preferred over IPv6 by default
+        execution_interface = FactoryBot.build(:nic_managed,
+          flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
+        host.interfaces = [execution_interface]
+        host.interfaces.each(&:save)
+        host.reload
+        assert_equal execution_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
       end
 
-      describe 'cleanup working directories setting' do
-        before do
-          Setting[:remote_execution_cleanup_working_dirs] = false
-        end
+      it 'gets ipv6 from flagged interfaces with IPv6 preference' do
+        host.host_params['remote_execution_connect_by_ip_prefer_ipv6'] = true
+        host.host_params['remote_execution_connect_by_ip'] = true
 
-        it 'updates the value via settings' do
-          assert_equal false, proxy_options[:cleanup_working_dirs]
-        end
+        # there is an execution interface with both IPv6 and IPv4: IPv6 is being preferred over IPv4 by host parameter configuration
+        execution_interface = FactoryBot.build(:nic_managed,
+          flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
+        host.interfaces = [execution_interface]
+        host.interfaces.each(&:save)
+        host.reload
+        assert_equal execution_interface.ip6, SSHExecutionProvider.find_ip_or_hostname(host)
       end
-
-      describe 'cleanup working directories from parameters' do
-        it 'takes the value from host parameters' do
-          host.params['remote_execution_cleanup_working_dirs'] = 'false'
-          host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_cleanup_working_dirs', :value => 'false')
-          host.clear_host_parameters_cache!
-          assert_equal false, proxy_options[:cleanup_working_dirs]
-        end
-      end
-
-      describe '#find_ip_or_hostname' do
-        let(:host) do
-          FactoryBot.create(:host) do |host|
-            host.interfaces = [FactoryBot.build(:nic_managed, flags.merge(:ip => nil, :name => 'somehost.somedomain.org', :primary => true)),
-                               FactoryBot.build(:nic_managed, flags.merge(:ip => '127.0.0.1'))]
-          end.reload
-          # Reassigning the interfaces triggers the on-deletion ssh key removal for the interface which is being replaced
-          # This has an undesired side effect of caching the original interface as execution one which made the tests
-          # give wrong results. Reloading the host wipes the cache
-        end
-
-        let(:flags) do
-          { :primary => false, :provision => false, :execution => false }
-        end
-
-        it 'gets fqdn from flagged interfaces if not preferring ips' do
-          # falling to primary interface
-          assert_equal 'somehost.somedomain.org', SSHExecutionProvider.find_ip_or_hostname(host)
-
-          # execution wins if present
-          execution_interface = FactoryBot.build(:nic_managed,
-            flags.merge(:execution => true, :name => 'special.somedomain.org'))
-          host.interfaces << execution_interface
-          host.primary_interface.update(:execution => false)
-          host.interfaces.each(&:save)
-          host.reload
-          assert_equal execution_interface.fqdn, SSHExecutionProvider.find_ip_or_hostname(host)
-        end
-
-        it 'gets ip from flagged interfaces' do
-          host.host_params['remote_execution_connect_by_ip'] = true
-          # no ip address set on relevant interface - fallback to fqdn
-          assert_equal 'somehost.somedomain.org', SSHExecutionProvider.find_ip_or_hostname(host)
-
-          # provision interface with ip while primary without
-          provision_interface = FactoryBot.build(:nic_managed,
-            flags.merge(:provision => true, :ip => '10.0.0.1'))
-          host.interfaces << provision_interface
-          host.primary_interface.update(:provision => false)
-          host.interfaces.each(&:save)
-          host.reload
-          assert_equal provision_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
-
-          # both primary and provision interface have IPs: the primary wins
-          host.primary_interface.update(:ip => '10.0.0.2', :execution => false)
-          host.reload
-          assert_equal host.primary_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
-
-          # there is an execution interface with IP: it wins
-          execution_interface = FactoryBot.build(:nic_managed,
-            flags.merge(:execution => true, :ip => '10.0.0.3'))
-          host.interfaces << execution_interface
-          host.primary_interface.update(:execution => false)
-          host.interfaces.each(&:save)
-          host.reload
-          assert_equal execution_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
-
-          # there is an execution interface with both IPv6 and IPv4: IPv4 is being preferred over IPv6 by default
-          execution_interface = FactoryBot.build(:nic_managed,
-            flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
-          host.interfaces = [execution_interface]
-          host.interfaces.each(&:save)
-          host.reload
-          assert_equal execution_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
-        end
-
-        it 'gets ipv6 from flagged interfaces with IPv6 preference' do
-          host.host_params['remote_execution_connect_by_ip_prefer_ipv6'] = true
-          host.host_params['remote_execution_connect_by_ip'] = true
-
-          # there is an execution interface with both IPv6 and IPv4: IPv6 is being preferred over IPv4 by host parameter configuration
-          execution_interface = FactoryBot.build(:nic_managed,
-            flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
-          host.interfaces = [execution_interface]
-          host.interfaces.each(&:save)
-          host.reload
-          assert_equal execution_interface.ip6, SSHExecutionProvider.find_ip_or_hostname(host)
-        end
 
       it 'gets ipv6 from flagged interfaces with IPv4 preference but without IPv4 address' do
         host.host_params['remote_execution_connect_by_ip_prefer_ipv6'] = false

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -3,283 +3,283 @@ require 'test_plugin_helper'
 class RemoteExecutionProviderTest < ActiveSupport::TestCase
   describe '.providers' do
     let(:providers) { RemoteExecutionProvider.providers }
-    it { _(providers).must_be_kind_of HashWithIndifferentAccess }
+    it { assert_kind_of HashWithIndifferentAccess, providers }
     it 'makes providers accessible using symbol' do
-      _(providers[:SSH]).must_equal SSHExecutionProvider
-      _(providers[:script]).must_equal ScriptExecutionProvider
+      assert_equal SSHExecutionProvider, providers[:SSH]
+      assert_equal ScriptExecutionProvider, providers[:script]
     end
     it 'makes providers accessible using string' do
-      _(providers['SSH']).must_equal SSHExecutionProvider
-      _(providers['script']).must_equal ScriptExecutionProvider
+      assert_equal SSHExecutionProvider, providers['SSH']
+      assert_equal ScriptExecutionProvider, providers['script']
     end
   end
 
   describe '.register_provider' do
-    before { RemoteExecutionProvider.providers.delete(:new) }
-    let(:new_provider) { RemoteExecutionProvider.providers[:new] }
-    it { _(new_provider).must_be_nil }
+      before { RemoteExecutionProvider.providers.delete(:new) }
+      let(:new_provider) { RemoteExecutionProvider.providers[:new] }
+      it { assert_nil new_provider }
 
-    context 'registers a provider under key :new' do
-      before { RemoteExecutionProvider.register(:new, String) }
-      it { _(new_provider).must_equal String }
-    end
-  end
-
-  describe '.provider_for' do
-    it 'accepts symbols' do
-      RemoteExecutionProvider.provider_for(:SSH).must_equal SSHExecutionProvider
-    end
-
-    it 'accepts strings' do
-      RemoteExecutionProvider.provider_for('SSH').must_equal SSHExecutionProvider
-    end
-
-    it 'returns a default one if unknown value is provided' do
-      RemoteExecutionProvider.provider_for('WinRM').must_equal ScriptExecutionProvider
-    end
-  end
-
-  describe '.provider_names' do
-    let(:provider_names) { RemoteExecutionProvider.provider_names }
-
-    it 'returns only strings' do
-      provider_names.each do |name|
-        _(name).must_be_kind_of String
+      context 'registers a provider under key :new' do
+        before { RemoteExecutionProvider.register(:new, String) }
+        it { assert_equal String, new_provider }
       end
     end
 
-    context 'provider is registetered under :custom symbol' do
-      before { RemoteExecutionProvider.register(:Custom, String) }
-
-      it { _(provider_names).must_include 'SSH' }
-      it { _(provider_names).must_include 'Custom' }
-    end
-  end
-
-  describe '.proxy_feature' do
-    # rubocop:disable Naming/ConstantName
-    it 'handles provider subclasses properly' do
-      old = ::RemoteExecutionProvider
-
-      class P2 < old
-      end
-      ::RemoteExecutionProvider = P2
-
-      class CustomProvider < ::RemoteExecutionProvider
+    describe '.provider_for' do
+      it 'accepts symbols' do
+        assert_equal SSHExecutionProvider, RemoteExecutionProvider.provider_for(:SSH)
       end
 
-      ::RemoteExecutionProvider.register('custom', CustomProvider)
+      it 'accepts strings' do
+        assert_equal SSHExecutionProvider, RemoteExecutionProvider.provider_for('SSH')
+      end
 
-      feature = CustomProvider.proxy_feature
-      _(feature).must_equal 'custom'
-    ensure
-      ::RemoteExecutionProvider = old
-    end
-    # rubocop:enable Naming/ConstantName
-  end
-
-  describe '.provider_proxy_features' do
-    it 'returns correct values' do
-      RemoteExecutionProvider.stubs(:providers).returns(
-        :SSH => SSHExecutionProvider,
-        :script => ScriptExecutionProvider
-      )
-
-      features = RemoteExecutionProvider.provider_proxy_features
-      _(features).must_include 'SSH'
-      _(features).must_include 'Script'
-      RemoteExecutionProvider.unstub(:providers)
-    end
-
-    it 'can deal with non-arrays' do
-      provider = OpenStruct.new(proxy_feature: 'Testing')
-      RemoteExecutionProvider.stubs(:providers).returns(:testing => provider)
-      features = RemoteExecutionProvider.provider_proxy_features
-      _(features).must_include 'Testing'
-      RemoteExecutionProvider.unstub(:providers)
-    end
-  end
-
-  describe '.host_setting' do
-    let(:host) { FactoryBot.create(:host) }
-
-    it 'honors falsey values set as a host parameter' do
-      key = 'remote_execution_connect_by_ip'
-      Setting[key] = true
-      host.parameters << HostParameter.new(name: key, value: false)
-
-      refute RemoteExecutionProvider.host_setting(host, key)
-    end
-  end
-
-  describe SSHExecutionProvider do
-    before { User.current = FactoryBot.build(:user, :admin) }
-    after { User.current = nil }
-
-    let(:job_invocation) { FactoryBot.create(:job_invocation, :with_template) }
-    let(:template_invocation) { job_invocation.pattern_template_invocations.first }
-    let(:host) { FactoryBot.create(:host) }
-    let(:proxy_options) { SSHExecutionProvider.proxy_command_options(template_invocation, host) }
-    let(:secrets) { SSHExecutionProvider.secrets(host) }
-
-    describe 'effective user' do
-      it 'takes the effective user from value from the template invocation' do
-        template_invocation.effective_user = 'my user'
-        _(proxy_options[:effective_user]).must_equal 'my user'
+      it 'returns a default one if unknown value is provided' do
+        assert_equal ScriptExecutionProvider, RemoteExecutionProvider.provider_for('WinRM')
       end
     end
 
-    describe 'ssh user' do
-      it 'uses the remote_execution_ssh_user on the host param' do
-        host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_user', :value => 'my user')
-        _(proxy_options[:ssh_user]).must_equal 'my user'
+    describe '.provider_names' do
+      let(:provider_names) { RemoteExecutionProvider.provider_names }
+
+      it 'returns only strings' do
+        provider_names.each do |name|
+          assert_kind_of String, name
+        end
+      end
+
+      context 'provider is registetered under :custom symbol' do
+        before { RemoteExecutionProvider.register(:Custom, String) }
+
+        it { assert_includes provider_names, 'SSH' }
+        it { assert_includes provider_names, 'Custom' }
       end
     end
 
-    describe 'effective user password' do
-      it 'uses the remote_execution_effective_user_password on the host param' do
-        host.params['remote_execution_effective_user_password'] = 'mypassword'
-        host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_password', :value => 'mypassword')
-        assert_not proxy_options.key?(:effective_user_password)
-        _(secrets[:effective_user_password]).must_equal 'mypassword'
+    describe '.proxy_feature' do
+      # rubocop:disable Naming/ConstantName
+      it 'handles provider subclasses properly' do
+        old = ::RemoteExecutionProvider
+
+        class P2 < old
+        end
+        ::RemoteExecutionProvider = P2
+
+        class CustomProvider < ::RemoteExecutionProvider
+        end
+
+        ::RemoteExecutionProvider.register('custom', CustomProvider)
+
+        feature = CustomProvider.proxy_feature
+        assert_equal 'custom', feature
+      ensure
+        ::RemoteExecutionProvider = old
+      end
+      # rubocop:enable Naming/ConstantName
+    end
+
+    describe '.provider_proxy_features' do
+      it 'returns correct values' do
+        RemoteExecutionProvider.stubs(:providers).returns(
+          :SSH => SSHExecutionProvider,
+          :script => ScriptExecutionProvider
+        )
+
+        features = RemoteExecutionProvider.provider_proxy_features
+        assert_includes features, 'SSH'
+        assert_includes features, 'Script'
+        RemoteExecutionProvider.unstub(:providers)
+      end
+
+      it 'can deal with non-arrays' do
+        provider = OpenStruct.new(proxy_feature: 'Testing')
+        RemoteExecutionProvider.stubs(:providers).returns(:testing => provider)
+        features = RemoteExecutionProvider.provider_proxy_features
+        assert_includes features, 'Testing'
+        RemoteExecutionProvider.unstub(:providers)
       end
     end
 
-    describe 'sudo' do
-      it 'uses the remote_execution_effective_user_method on the host param' do
-        host.params['remote_execution_effective_user_method'] = 'sudo'
-        method_param = FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_method', :value => 'sudo')
-        host.host_parameters << method_param
-        _(proxy_options[:effective_user_method]).must_equal 'sudo'
-        method_param.update!(:value => 'su')
-        host.clear_host_parameters_cache!
-        proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
-        _(proxy_options[:effective_user_method]).must_equal 'su'
-        method_param.update!(:value => 'dzdo')
-        host.clear_host_parameters_cache!
-        proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
-        _(proxy_options[:effective_user_method]).must_equal 'dzdo'
+    describe '.host_setting' do
+      let(:host) { FactoryBot.create(:host) }
+
+      it 'honors falsey values set as a host parameter' do
+        key = 'remote_execution_connect_by_ip'
+        Setting[key] = true
+        host.parameters << HostParameter.new(name: key, value: false)
+
+        refute RemoteExecutionProvider.host_setting(host, key)
       end
     end
 
-    describe 'ssh port from settings' do
-      before do
-        Setting[:remote_execution_ssh_port] = '66'
+    describe SSHExecutionProvider do
+      before { User.current = FactoryBot.build(:user, :admin) }
+      after { User.current = nil }
+
+      let(:job_invocation) { FactoryBot.create(:job_invocation, :with_template) }
+      let(:template_invocation) { job_invocation.pattern_template_invocations.first }
+      let(:host) { FactoryBot.create(:host) }
+      let(:proxy_options) { SSHExecutionProvider.proxy_command_options(template_invocation, host) }
+      let(:secrets) { SSHExecutionProvider.secrets(host) }
+
+      describe 'effective user' do
+        it 'takes the effective user from value from the template invocation' do
+          template_invocation.effective_user = 'my user'
+          assert_equal 'my user', proxy_options[:effective_user]
+        end
       end
 
-      it 'has ssh port changed in settings and check return type' do
-        _(proxy_options[:ssh_port]).must_be_kind_of Integer
-        _(proxy_options[:ssh_port]).must_equal 66
-      end
-    end
-
-    describe 'ssh port from params' do
-      it 'takes ssh port number from params and check return type' do
-        host.params['remote_execution_ssh_port'] = '30'
-        host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_ssh_port', :value => '30')
-        host.clear_host_parameters_cache!
-        _(proxy_options[:ssh_port]).must_be_kind_of Integer
-        _(proxy_options[:ssh_port]).must_equal 30
-      end
-    end
-
-    describe 'cleanup working directories setting' do
-      before do
-        Setting[:remote_execution_cleanup_working_dirs] = false
+      describe 'ssh user' do
+        it 'uses the remote_execution_ssh_user on the host param' do
+          host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_ssh_user', :value => 'my user')
+          assert_equal 'my user', proxy_options[:ssh_user]
+        end
       end
 
-      it 'updates the value via settings' do
-        _(proxy_options[:cleanup_working_dirs]).must_equal false
-      end
-    end
-
-    describe 'cleanup working directories from parameters' do
-      it 'takes the value from host parameters' do
-        host.params['remote_execution_cleanup_working_dirs'] = 'false'
-        host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_cleanup_working_dirs', :value => 'false')
-        host.clear_host_parameters_cache!
-        _(proxy_options[:cleanup_working_dirs]).must_equal false
-      end
-    end
-
-    describe '#find_ip_or_hostname' do
-      let(:host) do
-        FactoryBot.create(:host) do |host|
-          host.interfaces = [FactoryBot.build(:nic_managed, flags.merge(:ip => nil, :name => 'somehost.somedomain.org', :primary => true)),
-                             FactoryBot.build(:nic_managed, flags.merge(:ip => '127.0.0.1'))]
-        end.reload
-        # Reassigning the interfaces triggers the on-deletion ssh key removal for the interface which is being replaced
-        # This has an undesired side effect of caching the original interface as execution one which made the tests
-        # give wrong results. Reloading the host wipes the cache
+      describe 'effective user password' do
+        it 'uses the remote_execution_effective_user_password on the host param' do
+          host.params['remote_execution_effective_user_password'] = 'mypassword'
+          host.host_parameters << FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_password', :value => 'mypassword')
+          assert_nil proxy_options[:effective_user_password]
+          assert_equal 'mypassword', secrets[:effective_user_password]
+        end
       end
 
-      let(:flags) do
-        { :primary => false, :provision => false, :execution => false }
+      describe 'sudo' do
+        it 'uses the remote_execution_effective_user_method on the host param' do
+          host.params['remote_execution_effective_user_method'] = 'sudo'
+          method_param = FactoryBot.create(:host_parameter, :host => host, :name => 'remote_execution_effective_user_method', :value => 'sudo')
+          host.host_parameters << method_param
+          assert_equal 'sudo', proxy_options[:effective_user_method]
+          method_param.update!(:value => 'su')
+          host.clear_host_parameters_cache!
+          proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
+          assert_equal 'su', proxy_options[:effective_user_method]
+          method_param.update!(:value => 'dzdo')
+          host.clear_host_parameters_cache!
+          proxy_options = SSHExecutionProvider.proxy_command_options(template_invocation, host)
+          assert_equal 'dzdo', proxy_options[:effective_user_method]
+        end
       end
 
-      it 'gets fqdn from flagged interfaces if not preferring ips' do
-        # falling to primary interface
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal 'somehost.somedomain.org'
+      describe 'ssh port from settings' do
+        before do
+          Setting[:remote_execution_ssh_port] = '66'
+        end
 
-        # execution wins if present
-        execution_interface = FactoryBot.build(:nic_managed,
-          flags.merge(:execution => true, :name => 'special.somedomain.org'))
-        host.interfaces << execution_interface
-        host.primary_interface.update(:execution => false)
-        host.interfaces.each(&:save)
-        host.reload
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal execution_interface.fqdn
+        it 'has ssh port changed in settings and check return type' do
+          assert_kind_of Integer, proxy_options[:ssh_port]
+          assert_equal 66, proxy_options[:ssh_port]
+        end
       end
 
-      it 'gets ip from flagged interfaces' do
-        host.host_params['remote_execution_connect_by_ip'] = true
-        # no ip address set on relevant interface - fallback to fqdn
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal 'somehost.somedomain.org'
-
-        # provision interface with ip while primary without
-        provision_interface = FactoryBot.build(:nic_managed,
-          flags.merge(:provision => true, :ip => '10.0.0.1'))
-        host.interfaces << provision_interface
-        host.primary_interface.update(:provision => false)
-        host.interfaces.each(&:save)
-        host.reload
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal provision_interface.ip
-
-        # both primary and provision interface have IPs: the primary wins
-        host.primary_interface.update(:ip => '10.0.0.2', :execution => false)
-        host.reload
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal host.primary_interface.ip
-
-        # there is an execution interface with IP: it wins
-        execution_interface = FactoryBot.build(:nic_managed,
-          flags.merge(:execution => true, :ip => '10.0.0.3'))
-        host.interfaces << execution_interface
-        host.primary_interface.update(:execution => false)
-        host.interfaces.each(&:save)
-        host.reload
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal execution_interface.ip
-
-        # there is an execution interface with both IPv6 and IPv4: IPv4 is being preferred over IPv6 by default
-        execution_interface = FactoryBot.build(:nic_managed,
-          flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
-        host.interfaces = [execution_interface]
-        host.interfaces.each(&:save)
-        host.reload
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal execution_interface.ip
+      describe 'ssh port from params' do
+        it 'takes ssh port number from params and check return type' do
+          host.params['remote_execution_ssh_port'] = '30'
+          host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_ssh_port', :value => '30')
+          host.clear_host_parameters_cache!
+          assert_kind_of Integer, proxy_options[:ssh_port]
+          assert_equal 30, proxy_options[:ssh_port]
+        end
       end
 
-      it 'gets ipv6 from flagged interfaces with IPv6 preference' do
-        host.host_params['remote_execution_connect_by_ip_prefer_ipv6'] = true
-        host.host_params['remote_execution_connect_by_ip'] = true
+      describe 'cleanup working directories setting' do
+        before do
+          Setting[:remote_execution_cleanup_working_dirs] = false
+        end
 
-        # there is an execution interface with both IPv6 and IPv4: IPv6 is being preferred over IPv4 by host parameter configuration
-        execution_interface = FactoryBot.build(:nic_managed,
-          flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
-        host.interfaces = [execution_interface]
-        host.interfaces.each(&:save)
-        host.reload
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal execution_interface.ip6
+        it 'updates the value via settings' do
+          assert_equal false, proxy_options[:cleanup_working_dirs]
+        end
       end
+
+      describe 'cleanup working directories from parameters' do
+        it 'takes the value from host parameters' do
+          host.params['remote_execution_cleanup_working_dirs'] = 'false'
+          host.host_parameters << FactoryBot.build(:host_parameter, :name => 'remote_execution_cleanup_working_dirs', :value => 'false')
+          host.clear_host_parameters_cache!
+          assert_equal false, proxy_options[:cleanup_working_dirs]
+        end
+      end
+
+      describe '#find_ip_or_hostname' do
+        let(:host) do
+          FactoryBot.create(:host) do |host|
+            host.interfaces = [FactoryBot.build(:nic_managed, flags.merge(:ip => nil, :name => 'somehost.somedomain.org', :primary => true)),
+                               FactoryBot.build(:nic_managed, flags.merge(:ip => '127.0.0.1'))]
+          end.reload
+          # Reassigning the interfaces triggers the on-deletion ssh key removal for the interface which is being replaced
+          # This has an undesired side effect of caching the original interface as execution one which made the tests
+          # give wrong results. Reloading the host wipes the cache
+        end
+
+        let(:flags) do
+          { :primary => false, :provision => false, :execution => false }
+        end
+
+        it 'gets fqdn from flagged interfaces if not preferring ips' do
+          # falling to primary interface
+          assert_equal 'somehost.somedomain.org', SSHExecutionProvider.find_ip_or_hostname(host)
+
+          # execution wins if present
+          execution_interface = FactoryBot.build(:nic_managed,
+            flags.merge(:execution => true, :name => 'special.somedomain.org'))
+          host.interfaces << execution_interface
+          host.primary_interface.update(:execution => false)
+          host.interfaces.each(&:save)
+          host.reload
+          assert_equal execution_interface.fqdn, SSHExecutionProvider.find_ip_or_hostname(host)
+        end
+
+        it 'gets ip from flagged interfaces' do
+          host.host_params['remote_execution_connect_by_ip'] = true
+          # no ip address set on relevant interface - fallback to fqdn
+          assert_equal 'somehost.somedomain.org', SSHExecutionProvider.find_ip_or_hostname(host)
+
+          # provision interface with ip while primary without
+          provision_interface = FactoryBot.build(:nic_managed,
+            flags.merge(:provision => true, :ip => '10.0.0.1'))
+          host.interfaces << provision_interface
+          host.primary_interface.update(:provision => false)
+          host.interfaces.each(&:save)
+          host.reload
+          assert_equal provision_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
+
+          # both primary and provision interface have IPs: the primary wins
+          host.primary_interface.update(:ip => '10.0.0.2', :execution => false)
+          host.reload
+          assert_equal host.primary_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
+
+          # there is an execution interface with IP: it wins
+          execution_interface = FactoryBot.build(:nic_managed,
+            flags.merge(:execution => true, :ip => '10.0.0.3'))
+          host.interfaces << execution_interface
+          host.primary_interface.update(:execution => false)
+          host.interfaces.each(&:save)
+          host.reload
+          assert_equal execution_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
+
+          # there is an execution interface with both IPv6 and IPv4: IPv4 is being preferred over IPv6 by default
+          execution_interface = FactoryBot.build(:nic_managed,
+            flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
+          host.interfaces = [execution_interface]
+          host.interfaces.each(&:save)
+          host.reload
+          assert_equal execution_interface.ip, SSHExecutionProvider.find_ip_or_hostname(host)
+        end
+
+        it 'gets ipv6 from flagged interfaces with IPv6 preference' do
+          host.host_params['remote_execution_connect_by_ip_prefer_ipv6'] = true
+          host.host_params['remote_execution_connect_by_ip'] = true
+
+          # there is an execution interface with both IPv6 and IPv4: IPv6 is being preferred over IPv4 by host parameter configuration
+          execution_interface = FactoryBot.build(:nic_managed,
+            flags.merge(:execution => true, :ip => '10.0.0.4', :ip6 => 'fd00::4'))
+          host.interfaces = [execution_interface]
+          host.interfaces.each(&:save)
+          host.reload
+          assert_equal execution_interface.ip6, SSHExecutionProvider.find_ip_or_hostname(host)
+        end
 
       it 'gets ipv6 from flagged interfaces with IPv4 preference but without IPv4 address' do
         host.host_params['remote_execution_connect_by_ip_prefer_ipv6'] = false
@@ -291,7 +291,7 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
         host.interfaces = [execution_interface]
         host.interfaces.each(&:save)
         host.reload
-        SSHExecutionProvider.find_ip_or_hostname(host).must_equal execution_interface.ip6
+        assert_equal execution_interface.ip6, SSHExecutionProvider.find_ip_or_hostname(host)
       end
     end
   end

--- a/test/unit/renderer_scope_input_test.rb
+++ b/test/unit/renderer_scope_input_test.rb
@@ -13,15 +13,15 @@ class RendererScopeInputTest < ActiveSupport::TestCase
     it 'caches the value under given key' do
       i = 1
       result = input.cached('some_key') { i }
-      _(result).must_equal 1
+      assert_equal 1, result
 
       i += 1
       result = input.cached('some_key') { i }
-      _(result).must_equal 1
+      assert_equal 1, result
 
       i += 1
       result = input.cached('different_key') { i }
-      _(result).must_equal 3
+      assert_equal 3, result
     end
   end
 
@@ -35,15 +35,15 @@ class RendererScopeInputTest < ActiveSupport::TestCase
     it 'does not cache the value' do
       i = 1
       result = input.cached('some_key') { i }
-      _(result).must_equal 1
+      assert_equal 1, result
 
       i += 1
       result = input.cached('some_key') { i }
-      _(result).must_equal 2
+      assert_equal 2, result
 
       i += 1
       result = input.cached('different_key') { i }
-      _(result).must_equal 3
+      assert_equal 3, result
     end
   end
 end

--- a/test/unit/targeting_test.rb
+++ b/test/unit/targeting_test.rb
@@ -51,7 +51,7 @@ class TargetingTest < ActiveSupport::TestCase
       targeting.resolve_hosts!
     end
 
-    it { _(targeting.hosts).must_include(host) }
+    it { assert_includes targeting.hosts, host }
   end
 
   context 'can delete a user' do
@@ -63,7 +63,7 @@ class TargetingTest < ActiveSupport::TestCase
 
     it { assert_nil targeting.reload.user }
     it do
-      -> { targeting.resolve_hosts! }.must_raise(Foreman::Exception)
+      assert_raises(Foreman::Exception) { targeting.resolve_hosts! }
     end
   end
 
@@ -74,7 +74,7 @@ class TargetingTest < ActiveSupport::TestCase
       host.destroy
     end
 
-    it { _(targeting.reload.hosts).must_be_empty }
+    it { assert_empty targeting.reload.hosts }
   end
 
   describe '#resolve_hosts!' do
@@ -100,9 +100,9 @@ class TargetingTest < ActiveSupport::TestCase
         targeting.user = User.current
         targeting.resolve_hosts!
 
-        targeting.hosts.must_include host
-        targeting.hosts.must_include second_host
-        targeting.hosts.must_include infra_host
+        assert_includes targeting.hosts, host
+        assert_includes targeting.hosts, second_host
+        assert_includes targeting.hosts, infra_host
       end
     end
 
@@ -115,9 +115,9 @@ class TargetingTest < ActiveSupport::TestCase
         targeting.user = User.current
         targeting.resolve_hosts!
 
-        targeting.hosts.must_include host
-        targeting.hosts.must_include second_host
-        targeting.hosts.wont_include infra_host
+        assert_includes targeting.hosts, host
+        assert_includes targeting.hosts, second_host
+        refute_includes targeting.hosts, infra_host
       end
     end
   end
@@ -136,14 +136,14 @@ class TargetingTest < ActiveSupport::TestCase
       let(:query) { Targeting.build_query_from_hosts([ host.id, second_host.id, infra_host.id ]) }
 
       it 'builds query using host names joining inside ^' do
-        _(query).must_include host.name
-        _(query).must_include second_host.name
-        _(query).must_include infra_host.name
-        _(query).must_include 'name ^'
+        assert_includes query, host.name
+        assert_includes query, second_host.name
+        assert_includes query, infra_host.name
+        assert_includes query, 'name ^'
 
-        Host.search_for(query).must_include host
-        Host.search_for(query).must_include second_host
-        Host.search_for(query).must_include infra_host
+        assert_includes Host.search_for(query), host
+        assert_includes Host.search_for(query), second_host
+        assert_includes Host.search_for(query), infra_host
       end
     end
 
@@ -151,10 +151,10 @@ class TargetingTest < ActiveSupport::TestCase
       let(:query) { Targeting.build_query_from_hosts([ host.id ]) }
 
       it 'builds query using host name' do
-        _(query).must_equal "name ^ (#{host.name})"
-        Host.search_for(query).must_include host
-        Host.search_for(query).wont_include second_host
-        Host.search_for(query).wont_include infra_host
+        assert_equal "name ^ (#{host.name})", query
+        assert_includes Host.search_for(query), host
+        refute_includes Host.search_for(query), second_host
+        refute_includes Host.search_for(query), infra_host
       end
     end
 
@@ -162,9 +162,9 @@ class TargetingTest < ActiveSupport::TestCase
       let(:query) { Targeting.build_query_from_hosts([]) }
 
       it 'builds query to find all hosts' do
-        Host.search_for(query).must_include host
-        Host.search_for(query).must_include second_host
-        Host.search_for(query).must_include infra_host
+        assert_includes Host.search_for(query), host
+        assert_includes Host.search_for(query), second_host
+        assert_includes Host.search_for(query), infra_host
       end
     end
 
@@ -173,14 +173,14 @@ class TargetingTest < ActiveSupport::TestCase
 
       it 'ignores the infrastructure host' do
         query = Targeting.build_query_from_hosts([host.id, second_host.id, infra_host.id])
-        _(query).must_include host.name
-        _(query).must_include second_host.name
-        _(query).wont_include infra_host.name
-        _(query).must_include 'name ^'
+        assert_includes query, host.name
+        assert_includes query, second_host.name
+        refute_includes query, infra_host.name
+        assert_includes query, 'name ^'
 
-        Host.search_for(query).must_include host
-        Host.search_for(query).must_include second_host
-        Host.search_for(query).wont_include infra_host
+        assert_includes Host.search_for(query), host
+        assert_includes Host.search_for(query), second_host
+        refute_includes Host.search_for(query), infra_host
       end
     end
   end


### PR DESCRIPTION
Like
```
Use _(obj).must_equal instead. This will fail in Minitest 6.
```