### PR TITLE
Revert "Pin @adobe/css-tools to ~4.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "url": "http://projects.theforeman.org/projects/foreman_remote_execution/issues"
   },
   "devDependencies": {
-    "@adobe/css-tools": "~4.2.0",
     "@babel/core": "^7.7.0",
     "@theforeman/builder": "^12.0.1",
     "@theforeman/eslint-plugin-foreman": "^12.0.1",


### PR DESCRIPTION
Reverts theforeman/foreman_remote_execution#833

We do not need to pin to a Node 12 compatible version, and I need a change to test Webpack 5 ;-)