### PR TITLE
Fixes #37185 - webpack 5 adjustments

### DIFF
--- a/app/views/job_invocations/show.html.erb
+++ b/app/views/job_invocations/show.html.erb
@@ -1,9 +1,9 @@
 <% title @job_invocation.description %>
-<% stylesheet 'foreman_remote_execution/foreman_remote_execution' %>
-<% javascript 'foreman_remote_execution/template_invocation' %>
-<% javascript *webpack_asset_paths('foreman_remote_execution', :extension => 'js') %>
+<%= webpacked_plugins_js_for :foreman_remote_execution %>
+<% content_for(:javascripts) do -%>
+  <% javascript 'foreman_remote_execution/template_invocation' %><% end %>
 <% content_for(:stylesheets) do %>
-  <%= webpacked_plugins_css_for :foreman_remote_execution %>
+  <% stylesheet 'foreman_remote_execution/foreman_remote_execution' %>
 <% end %>
 
 <%= breadcrumbs name_field: 'description' %>
@@ -47,6 +47,13 @@
 
 <script id="job_invocation_refresh" data-refresh-url="<%= job_invocation_path(@job_invocation) %>">
   <% if @auto_refresh %>
-    delayed_refresh($('script#job_invocation_refresh').data('refresh-url'), {});
+    if(window.allJsLoaded){
+      delayed_refresh($('script#job_invocation_refresh').data('refresh-url'), {})
+    }
+    else {
+      $(document).on('loadJS', function() {
+        delayed_refresh($('script#job_invocation_refresh').data('refresh-url'), {})
+      });
+    }
   <% end %>
 </script>

--- a/app/views/job_invocations/show.js.erb
+++ b/app/views/job_invocations/show.js.erb
@@ -1,5 +1,12 @@
 $('div#title_action div.btn-group').html('<%= button_group(job_invocation_task_buttons(@job_invocation.task)).html_safe %>');
 
 <% if @auto_refresh %>
-  delayed_refresh($('script#job_invocation_refresh').data('refresh-url'), job_invocation_refresh_data());
+  if(window.allJsLoaded){
+    delayed_refresh($('script#job_invocation_refresh').data('refresh-url'), job_invocation_refresh_data())
+  }
+  else {
+    $(document).on('loadJS', function() {
+      delayed_refresh($('script#job_invocation_refresh').data('refresh-url'), job_invocation_refresh_data())
+    });
+  }
 <% end %>

--- a/app/views/template_invocations/_refresh.js.erb
+++ b/app/views/template_invocations/_refresh.js.erb
@@ -1,7 +1,13 @@
 <% if @auto_refresh %>
-$(function() {
-  delayed_refresh($("div.terminal").data('refresh-url'),
-          {"since": "<%= @line_sets.last.try(:[], 'timestamp') || @since %>", "line_counter": $("div.terminal div.line").size()});
-});
+   if(window.allJsLoaded){
+    delayed_refresh($("div.terminal").data('refresh-url'),
+          {"since": "<%= @line_sets.last.try(:[], 'timestamp') || @since %>", "line_counter": $("div.terminal div.line").size()})
+  }
+  else {
+    $(document).on('loadJS', function() {
+      delayed_refresh($("div.terminal").data('refresh-url'),
+          {"since": "<%= @line_sets.last.try(:[], 'timestamp') || @since %>", "line_counter": $("div.terminal div.line").size()})
+    });
+  }
 <% end %>
 


### PR DESCRIPTION
* to ensure correct loading order we need to wrap js scripts into content for
* '`webpack_asset_paths` is deprecated, use `content_for(:javascripts) { webpacked_plugins_js_for(plugin_name) }` instead.')
* `webpacked_plugins_css_for` is deprecated, plugin css is already loaded