### PR TITLE
Fixes #37242 - Fix live output appearing multiple times

### DIFF
--- a/app/lib/actions/remote_execution/proxy_action.rb
+++ b/app/lib/actions/remote_execution/proxy_action.rb
@@ -43,7 +43,7 @@ module Actions
           }
         end
         events.each_slice(1000) do |batch|
-          TemplateInvocationEvent.upsert_all(batch, unique_by: [:template_invocation_id, :sequence_id]) # rubocop:disable Rails/SkipsModelValidations
+          TemplateInvocationEvent.insert_all(batch, unique_by: [:template_invocation_id, :sequence_id]) # rubocop:disable Rails/SkipsModelValidations
         end
       end
     end

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -98,7 +98,6 @@ module Actions
 
       def live_output
         continuous_output.sort!
-        continuous_output.raw_outputs
       end
 
       def humanized_input


### PR DESCRIPTION
The result of calling continuous_output was not persisted, so the original code didn't make much sense. `ContinuousOutput#sort!` returns the same thing as `ContinuousOutput#raw_outputs` so we can skip the second line completely.

`upsert_all` was updating the already existing values, so `exit_status` got updated multiple times with different timestamps. `insert_all` should just skip over the already existing values.