### PR TITLE
Fixes #37286 - Add global actions to job invocation detail page

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -139,6 +139,7 @@ module Api
       api :POST, '/job_invocations/:id/rerun', N_('Rerun job on failed hosts')
       param :id, :identifier, :required => true
       param :failed_only, :bool
+      param :succeeded_only, :bool
       def rerun
         composer = JobInvocationComposer.from_job_invocation(@job_invocation, params)
         if composer.rerun_possible?

--- a/app/models/job_invocation_composer.rb
+++ b/app/models/job_invocation_composer.rb
@@ -232,6 +232,8 @@ class JobInvocationComposer
         @host_ids = params[:host_ids]
       elsif params[:failed_only]
         @host_ids = job_invocation.failed_host_ids
+      elsif params[:succeeded_only]
+        @host_ids = job_invocation.succeeded_host_ids
       end
     end
 

--- a/app/views/api/v2/job_invocations/base.json.rabl
+++ b/app/views/api/v2/job_invocations/base.json.rabl
@@ -25,9 +25,10 @@ end
 if params.key?(:include_permissions)
   node :permissions do |invocation|
     authorizer = Authorizer.new(User.current)
-    edit_job_templates_permission = Permission.where(name: "edit_job_templates", resource_type: "JobTemplate").first
     {
-      "edit_job_templates" => (edit_job_templates_permission && authorizer.can?("edit_job_templates", invocation, false)),
+      "edit_job_templates" => authorizer.can?("edit_job_templates", invocation, false),
+      "view_foreman_tasks" => authorizer.can?("view_foreman_tasks", invocation.task, false),
+      "edit_recurring_logics" => authorizer.can?("edit_recurring_logics", invocation.recurring_logic, false),
     }
   end
 end

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "prettier": "^1.19.1",
     "redux-mock-store": "^1.2.2",
     "graphql-tag": "^2.11.0",
-    "graphql": "^15.5.0"
+    "graphql": "^15.5.0",
+    "victory-core": "~36.8.6"
   },
   "peerDependencies": {
     "@theforeman/vendor": ">= 12.0.1"

--- a/webpack/JobInvocationDetail/JobInvocationActions.js
+++ b/webpack/JobInvocationDetail/JobInvocationActions.js
@@ -1,9 +1,19 @@
-import { get } from 'foremanReact/redux/API';
+import { translate as __, sprintf } from 'foremanReact/common/I18n';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { addToast } from 'foremanReact/components/ToastsList';
+import { APIActions, get } from 'foremanReact/redux/API';
 import {
-  withInterval,
   stopInterval,
+  withInterval,
 } from 'foremanReact/redux/middlewares/IntervalMiddleware';
-import { JOB_INVOCATION_KEY } from './JobInvocationConstants';
+import {
+  CANCEL_JOB,
+  CANCEL_RECURRING_LOGIC,
+  CHANGE_ENABLED_RECURRING_LOGIC,
+  GET_TASK,
+  JOB_INVOCATION_KEY,
+  UPDATE_JOB,
+} from './JobInvocationConstants';
 
 export const getData = url => dispatch => {
   const fetchData = withInterval(
@@ -19,4 +29,125 @@ export const getData = url => dispatch => {
   );
 
   dispatch(fetchData);
+};
+
+export const updateJob = jobId => dispatch => {
+  const url = foremanUrl(`/api/job_invocations/${jobId}`);
+  dispatch(
+    APIActions.get({
+      url,
+      key: UPDATE_JOB,
+    })
+  );
+};
+
+export const cancelJob = (jobId, force) => dispatch => {
+  const infoToast = () =>
+    force
+      ? sprintf(__('Trying to abort the job %s.'), jobId)
+      : sprintf(__('Trying to cancel the job %s.'), jobId);
+  const errorToast = response =>
+    force
+      ? sprintf(__(`Could not abort the job %s: ${response}`), jobId)
+      : sprintf(__(`Could not cancel the job %s: ${response}`), jobId);
+  const url = force
+    ? `/job_invocations/${jobId}/cancel?force=true`
+    : `/job_invocations/${jobId}/cancel`;
+
+  dispatch(
+    APIActions.post({
+      url,
+      key: CANCEL_JOB,
+      errorToast: ({ response }) =>
+        errorToast(
+          // eslint-disable-next-line camelcase
+          response?.data?.error?.full_messages ||
+            response?.data?.error?.message ||
+            'Unknown error.'
+        ),
+      handleSuccess: () => {
+        dispatch(
+          addToast({
+            key: `cancel-job-error`,
+            type: 'info',
+            message: infoToast(),
+          })
+        );
+        dispatch(updateJob(jobId));
+      },
+    })
+  );
+};
+
+export const getTask = taskId => dispatch => {
+  dispatch(
+    get({
+      key: GET_TASK,
+      url: `/foreman_tasks/api/tasks/${taskId}`,
+    })
+  );
+};
+
+export const enableRecurringLogic = (
+  recurrenceId,
+  enabled,
+  jobId
+) => dispatch => {
+  const successToast = () =>
+    enabled
+      ? sprintf(__('Recurring logic %s disabled successfully.'), recurrenceId)
+      : sprintf(__('Recurring logic %s enabled successfully.'), recurrenceId);
+  const errorToast = response =>
+    enabled
+      ? sprintf(
+          __(`Could not disable recurring logic %s: ${response}`),
+          recurrenceId
+        )
+      : sprintf(
+          __(`Could not enable recurring logic %s: ${response}`),
+          recurrenceId
+        );
+  const url = `/foreman_tasks/api/recurring_logics/${recurrenceId}`;
+  dispatch(
+    APIActions.put({
+      url,
+      key: CHANGE_ENABLED_RECURRING_LOGIC,
+      params: { recurring_logic: { enabled: !enabled } },
+      successToast,
+      errorToast: ({ response }) =>
+        errorToast(
+          // eslint-disable-next-line camelcase
+          response?.data?.error?.full_messages ||
+            response?.data?.error?.message ||
+            'Unknown error.'
+        ),
+      handleSuccess: () => dispatch(updateJob(jobId)),
+    })
+  );
+};
+
+export const cancelRecurringLogic = (recurrenceId, jobId) => dispatch => {
+  const successToast = () =>
+    sprintf(__('Recurring logic %s cancelled successfully.'), recurrenceId);
+  const errorToast = response =>
+    sprintf(
+      __(`Could not cancel recurring logic %s: ${response}`),
+      recurrenceId
+    );
+  const url = `/foreman_tasks/recurring_logics/${recurrenceId}/cancel`;
+  dispatch(
+    APIActions.post({
+      url,
+      key: CANCEL_RECURRING_LOGIC,
+      successToast,
+      errorToast: ({ response }) =>
+        errorToast(
+          // eslint-disable-next-line camelcase
+          response?.data?.error?.full_messages ||
+            response?.data?.error?.message ||
+            'Unknown error.'
+        ),
+      handleSuccess: () => dispatch(updateJob(jobId)),
+    })
+  );
 };

--- a/webpack/JobInvocationDetail/JobInvocationConstants.js
+++ b/webpack/JobInvocationDetail/JobInvocationConstants.js
@@ -1,9 +1,23 @@
+import { foremanUrl } from 'foremanReact/common/helpers';
+
 export const JOB_INVOCATION_KEY = 'JOB_INVOCATION_KEY';
+export const CURRENT_PERMISSIONS = 'CURRENT_PERMISSIONS';
+export const UPDATE_JOB = 'UPDATE_JOB';
+export const CANCEL_JOB = 'CANCEL_JOB';
+export const GET_TASK = 'GET_TASK';
+export const CHANGE_ENABLED_RECURRING_LOGIC = 'CHANGE_ENABLED_RECURRING_LOGIC';
+export const CANCEL_RECURRING_LOGIC = 'CANCEL_RECURRING_LOGIC';
+export const GET_REPORT_TEMPLATES = 'GET_REPORT_TEMPLATES';
+export const GET_REPORT_TEMPLATE_INPUTS = 'GET_REPORT_TEMPLATE_INPUTS';
+export const currentPermissionsUrl = foremanUrl(
+  '/api/v2/permissions/current_permissions'
+);
 
 export const STATUS = {
   PENDING: 'pending',
   SUCCEEDED: 'succeeded',
   FAILED: 'failed',
+  CANCELLED: 'cancelled',
 };
 
 export const DATE_OPTIONS = {

--- a/webpack/JobInvocationDetail/JobInvocationDetail.scss
+++ b/webpack/JobInvocationDetail/JobInvocationDetail.scss
@@ -1,6 +1,8 @@
-.job-invocation-detail-page-section {
+.job-invocation-detail-flex {
   $chart_size: 105px;
-  
+  padding-top: 0px;
+  padding-left: 10px;
+
   .chart-donut {
     height: $chart_size;
     width: $chart_size;
@@ -36,3 +38,4 @@
     height: $chart_size;
   }
 }
+  

--- a/webpack/JobInvocationDetail/JobInvocationSelectors.js
+++ b/webpack/JobInvocationDetail/JobInvocationSelectors.js
@@ -3,3 +3,8 @@ import { JOB_INVOCATION_KEY } from './JobInvocationConstants';
 
 export const selectItems = state =>
   selectAPIResponse(state, JOB_INVOCATION_KEY);
+
+export const selectTask = state => selectAPIResponse(state, 'GET_TASK');
+
+export const selectTaskCancelable = state =>
+  selectTask(state).available_actions?.cancellable || false;

--- a/webpack/JobInvocationDetail/JobInvocationSystemStatusChart.js
+++ b/webpack/JobInvocationDetail/JobInvocationSystemStatusChart.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
 import { translate as __, sprintf } from 'foremanReact/common/I18n';
+import DefaultLoaderEmptyState from 'foremanReact/components/HostDetails/DetailsCard/DefaultLoaderEmptyState';
 import {
   ChartDonut,
   ChartLabel,
@@ -9,20 +10,19 @@ import {
 } from '@patternfly/react-charts';
 import {
   DescriptionList,
-  DescriptionListTerm,
-  DescriptionListGroup,
   DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
   FlexItem,
   Text,
 } from '@patternfly/react-core';
 import {
-  global_palette_green_500 as successedColor,
-  global_palette_red_100 as failedColor,
-  global_palette_blue_300 as inProgressColor,
   global_palette_black_600 as canceledColor,
   global_palette_black_500 as emptyChartDonut,
+  global_palette_red_100 as failedColor,
+  global_palette_blue_300 as inProgressColor,
+  global_palette_green_500 as successedColor,
 } from '@patternfly/react-tokens';
-import DefaultLoaderEmptyState from 'foremanReact/components/HostDetails/DetailsCard/DefaultLoaderEmptyState';
 import './JobInvocationDetail.scss';
 
 const JobInvocationSystemStatusChart = ({
@@ -35,9 +35,9 @@ const JobInvocationSystemStatusChart = ({
     failed,
     pending,
     cancelled,
-    total,
     total_hosts: totalHosts, // includes scheduled
   } = data;
+  const total = succeeded + failed + pending + cancelled;
   const chartData = [
     { title: __('Succeeded:'), count: succeeded, color: successedColor.value },
     { title: __('Failed:'), count: failed, color: failedColor.value },
@@ -82,7 +82,11 @@ const JobInvocationSystemStatusChart = ({
             total > 0 ? chartData.map(d => d.color) : [emptyChartDonut.value]
           }
           labelComponent={
-            <ChartTooltip pointerLength={0} constrainToVisibleArea />
+            <ChartTooltip
+              pointerLength={0}
+              constrainToVisibleArea
+              renderInPortal={false}
+            />
           }
           title={chartDonutTitle}
           titleComponent={

--- a/webpack/JobInvocationDetail/JobInvocationToolbarButtons.js
+++ b/webpack/JobInvocationDetail/JobInvocationToolbarButtons.js
@@ -1,0 +1,268 @@
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  DropdownSeparator,
+  DropdownToggle,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { STATUS as APIStatus } from 'foremanReact/constants';
+import { get } from 'foremanReact/redux/API';
+import {
+  cancelJob,
+  cancelRecurringLogic,
+  enableRecurringLogic,
+} from './JobInvocationActions';
+import {
+  STATUS,
+  GET_REPORT_TEMPLATES,
+  GET_REPORT_TEMPLATE_INPUTS,
+} from './JobInvocationConstants';
+import { selectTaskCancelable } from './JobInvocationSelectors';
+
+const JobInvocationToolbarButtons = ({
+  jobId,
+  data,
+  currentPermissions,
+  permissionsStatus,
+}) => {
+  const { succeeded, failed, task, recurrence, permissions } = data;
+  const recurringEnabled = recurrence?.state === 'active';
+  const canViewForemanTasks = permissions
+    ? permissions.view_foreman_tasks
+    : false;
+  const canEditRecurringLogic = permissions
+    ? permissions.edit_recurring_logics
+    : false;
+  const isTaskCancelable = useSelector(selectTaskCancelable);
+  const [isActionOpen, setIsActionOpen] = useState(false);
+  const [reportTemplateJobId, setReportTemplateJobId] = useState(undefined);
+  const [templateInputId, setTemplateInputId] = useState(undefined);
+  const queryParams = new URLSearchParams({
+    [`report_template_report[input_values][${templateInputId}][value]`]: jobId,
+  });
+  const dispatch = useDispatch();
+
+  const onActionFocus = () => {
+    const element = document.getElementById(
+      `toggle-split-button-action-primary-${jobId}`
+    );
+    element.focus();
+  };
+  const onActionSelect = () => {
+    setIsActionOpen(false);
+    onActionFocus();
+  };
+  const hasPermission = permissionRequired =>
+    permissionsStatus === APIStatus.RESOLVED
+      ? currentPermissions?.some(
+          permission => permission.name === permissionRequired
+        )
+      : false;
+
+  useEffect(() => {
+    dispatch(
+      get({
+        key: GET_REPORT_TEMPLATES,
+        url: '/api/report_templates',
+        handleSuccess: ({ data: { results } }) => {
+          setReportTemplateJobId(
+            results.find(result => result.name === 'Job - Invocation Report')
+              ?.id
+          );
+        },
+        handleError: () => {
+          setReportTemplateJobId(undefined);
+        },
+      })
+    );
+  }, [dispatch]);
+  useEffect(() => {
+    if (reportTemplateJobId !== undefined) {
+      dispatch(
+        get({
+          key: GET_REPORT_TEMPLATE_INPUTS,
+          url: `/api/templates/${reportTemplateJobId}/template_inputs`,
+          handleSuccess: ({ data: { results } }) => {
+            setTemplateInputId(
+              results.find(result => result.name === 'job_id')?.id
+            );
+          },
+          handleError: () => {
+            setTemplateInputId(undefined);
+          },
+        })
+      );
+    }
+  }, [dispatch, reportTemplateJobId]);
+
+  const recurrenceDropdownItems = recurrence
+    ? [
+        <DropdownSeparator ouiaId="dropdown-separator-1" key="separator-1" />,
+        <DropdownItem
+          ouiaId="change-enabled-recurring-dropdown-item"
+          onClick={() =>
+            dispatch(
+              enableRecurringLogic(recurrence?.id, recurringEnabled, jobId)
+            )
+          }
+          key="change-enabled-recurring"
+          component="button"
+          isDisabled={
+            recurrence?.id === undefined ||
+            recurrence?.state === 'cancelled' ||
+            !canEditRecurringLogic
+          }
+        >
+          {recurringEnabled ? __('Disable recurring') : __('Enable recurring')}
+        </DropdownItem>,
+        <DropdownItem
+          ouiaId="cancel-recurring-dropdown-item"
+          onClick={() => dispatch(cancelRecurringLogic(recurrence?.id, jobId))}
+          key="cancel-recurring"
+          component="button"
+          isDisabled={
+            recurrence?.id === undefined ||
+            recurrence?.state === 'cancelled' ||
+            !canEditRecurringLogic
+          }
+        >
+          {__('Cancel recurring')}
+        </DropdownItem>,
+      ]
+    : [];
+
+  const dropdownItems = [
+    <DropdownItem
+      ouiaId="rerun-succeeded-dropdown-item"
+      href={foremanUrl(`/job_invocations/${jobId}/rerun?succeeded_only=1`)}
+      key="rerun-succeeded"
+      isDisabled={!(succeeded > 0) || !hasPermission('create_job_invocations')}
+      description="Rerun job on successful hosts"
+    >
+      {__('Rerun successful')}
+    </DropdownItem>,
+    <DropdownItem
+      ouiaId="rerun-failed-dropdown-item"
+      href={foremanUrl(`/job_invocations/${jobId}/rerun?failed_only=1`)}
+      key="rerun-failed"
+      isDisabled={!(failed > 0) || !hasPermission('create_job_invocations')}
+      description="Rerun job on failed hosts"
+    >
+      {__('Rerun failed')}
+    </DropdownItem>,
+    <DropdownItem
+      ouiaId="view-task-dropdown-item"
+      href={foremanUrl(`/foreman_tasks/tasks/${task?.id}`)}
+      key="view-task"
+      isDisabled={!canViewForemanTasks || task === undefined}
+      description="See details of latest task"
+    >
+      {__('View task')}
+    </DropdownItem>,
+    <DropdownSeparator ouiaId="dropdown-separator-0" key="separator-0" />,
+    <DropdownItem
+      ouiaId="cancel-dropdown-item"
+      onClick={() => dispatch(cancelJob(jobId, false))}
+      key="cancel"
+      component="button"
+      isDisabled={!isTaskCancelable || !hasPermission('cancel_job_invocations')}
+      description="Cancel job gracefully"
+    >
+      {__('Cancel')}
+    </DropdownItem>,
+    <DropdownItem
+      ouiaId="abort-dropdown-item"
+      onClick={() => dispatch(cancelJob(jobId, true))}
+      key="abort"
+      component="button"
+      isDisabled={!isTaskCancelable || !hasPermission('cancel_job_invocations')}
+      description="Cancel job immediately"
+    >
+      {__('Abort')}
+    </DropdownItem>,
+    ...recurrenceDropdownItems,
+    <DropdownSeparator ouiaId="dropdown-separator-2" key="separator-2" />,
+    <DropdownItem
+      ouiaId="legacy-ui-dropdown-item"
+      href={`/job_invocations/${jobId}`}
+      key="legacy-ui"
+    >
+      {__('Legacy UI')}
+    </DropdownItem>,
+  ];
+
+  return (
+    <>
+      <Split hasGutter>
+        <SplitItem>
+          <Button
+            component="a"
+            ouiaId="button-create-report"
+            className="button-create-report"
+            href={foremanUrl(
+              `/templates/report_templates/${reportTemplateJobId}/generate?${queryParams.toString()}`
+            )}
+            variant="secondary"
+            isDisabled={
+              task?.state === STATUS.PENDING ||
+              templateInputId === undefined ||
+              !hasPermission('generate_report_templates')
+            }
+          >
+            {__(`Create report`)}
+          </Button>
+        </SplitItem>
+        <SplitItem>
+          <Dropdown
+            ouiaId="job-invocation-global-actions-dropdown"
+            onSelect={onActionSelect}
+            position={DropdownPosition.right}
+            toggle={
+              <DropdownToggle
+                ouiaId="toggle-button-action-primary"
+                id={`toggle-split-button-action-primary-${jobId}`}
+                splitButtonItems={[
+                  <Button
+                    component="a"
+                    ouiaId="button-rerun-all"
+                    key="rerun"
+                    href={foremanUrl(`/job_invocations/${jobId}/rerun`)}
+                    variant="control"
+                    isDisabled={!hasPermission('create_job_invocations')}
+                  >
+                    {__(`Rerun all`)}
+                  </Button>,
+                ]}
+                splitButtonVariant="action"
+                onToggle={setIsActionOpen}
+              />
+            }
+            isOpen={isActionOpen}
+            dropdownItems={dropdownItems}
+          />
+        </SplitItem>
+      </Split>
+    </>
+  );
+};
+
+JobInvocationToolbarButtons.propTypes = {
+  jobId: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  currentPermissions: PropTypes.array,
+  permissionsStatus: PropTypes.string,
+};
+JobInvocationToolbarButtons.defaultProps = {
+  currentPermissions: undefined,
+  permissionsStatus: undefined,
+};
+
+export default JobInvocationToolbarButtons;

--- a/webpack/JobInvocationDetail/__tests__/MainInformation.test.js
+++ b/webpack/JobInvocationDetail/__tests__/MainInformation.test.js
@@ -1,0 +1,259 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { fireEvent, render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import * as api from 'foremanReact/redux/API';
+import JobInvocationDetailPage from '../index';
+import {
+  jobInvocationData,
+  jobInvocationDataScheduled,
+  jobInvocationDataRecurring,
+  mockPermissionsData,
+  mockReportTemplatesResponse,
+  mockReportTemplateInputsResponse,
+} from './fixtures';
+import {
+  cancelJob,
+  enableRecurringLogic,
+  cancelRecurringLogic,
+} from '../JobInvocationActions';
+import {
+  CANCEL_JOB,
+  CANCEL_RECURRING_LOGIC,
+  CHANGE_ENABLED_RECURRING_LOGIC,
+  GET_REPORT_TEMPLATES,
+  GET_REPORT_TEMPLATE_INPUTS,
+  JOB_INVOCATION_KEY,
+} from '../JobInvocationConstants';
+
+jest.spyOn(api, 'get');
+
+jest.mock('foremanReact/common/hooks/API/APIHooks', () => ({
+  useAPI: jest.fn(() => ({
+    response: mockPermissionsData,
+  })),
+}));
+
+jest.mock('foremanReact/routes/common/PageLayout/PageLayout', () =>
+  jest.fn(props => (
+    <div>
+      {props.header && <h1>{props.header}</h1>}
+      {props.toolbarButtons && <div>{props.toolbarButtons}</div>}
+      {props.children}
+    </div>
+  ))
+);
+
+const initialState = {
+  JOB_INVOCATION_KEY: {
+    response: jobInvocationData,
+  },
+  GET_REPORT_TEMPLATES: mockReportTemplatesResponse,
+};
+
+const initialStateScheduled = {
+  JOB_INVOCATION_KEY: {
+    response: jobInvocationDataScheduled,
+  },
+};
+
+api.get.mockImplementation(({ handleSuccess, ...action }) => {
+  if (action.key === 'GET_REPORT_TEMPLATES') {
+    handleSuccess &&
+      handleSuccess({
+        data: mockReportTemplatesResponse,
+      });
+  } else if (action.key === 'GET_REPORT_TEMPLATE_INPUTS') {
+    handleSuccess &&
+      handleSuccess({
+        data: mockReportTemplateInputsResponse,
+      });
+  }
+
+  return { type: 'get', ...action };
+});
+
+const reportTemplateJobId = mockReportTemplatesResponse.results[0].id;
+
+const mockStore = configureMockStore([thunk]);
+
+describe('JobInvocationDetailPage', () => {
+  it('renders main information', async () => {
+    const jobId = jobInvocationData.id;
+    const store = mockStore(initialState);
+
+    const { container } = render(
+      <Provider store={store}>
+        <JobInvocationDetailPage match={{ params: { id: `${jobId}` } }} />
+      </Provider>
+    );
+
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(
+      container.querySelector('.chart-donut .pf-c-chart')
+    ).toBeInTheDocument();
+    expect(screen.getByText('2/6')).toBeInTheDocument();
+    expect(screen.getByText('Systems')).toBeInTheDocument();
+    expect(screen.getByText('System status')).toBeInTheDocument();
+    expect(screen.getByText('Succeeded: 2')).toBeInTheDocument();
+    expect(screen.getByText('Failed: 4')).toBeInTheDocument();
+    expect(screen.getByText('In Progress: 0')).toBeInTheDocument();
+    expect(screen.getByText('Canceled: 0')).toBeInTheDocument();
+
+    const informationToCheck = {
+      'Effective user:': jobInvocationData.effective_user,
+      'Started at:': 'Jan 1, 2024, 11:34 UTC',
+      'SSH user:': 'Not available',
+      'Template:': jobInvocationData.template_name,
+    };
+
+    Object.entries(informationToCheck).forEach(([term, expectedText]) => {
+      const termContainers = container.querySelectorAll(
+        '.pf-c-description-list__term .pf-c-description-list__text'
+      );
+      termContainers.forEach(termContainer => {
+        if (termContainer.textContent.includes(term)) {
+          let descriptionContainer;
+          if (term === 'SSH user:') {
+            descriptionContainer = termContainer
+              .closest('.pf-c-description-list__group')
+              .querySelector(
+                '.pf-c-description-list__description .pf-c-description-list__text .disabled-text'
+              );
+          } else {
+            descriptionContainer = termContainer
+              .closest('.pf-c-description-list__group')
+              .querySelector(
+                '.pf-c-description-list__description .pf-c-description-list__text'
+              );
+          }
+          expect(descriptionContainer.textContent).toContain(expectedText);
+        }
+      });
+    });
+
+    // checks the global actions and if they link to the correct url
+    expect(screen.getByText('Create report').getAttribute('href')).toEqual(
+      foremanUrl(
+        `/templates/report_templates/${mockReportTemplatesResponse.results[0].id}/generate?report_template_report%5Binput_values%5D%5B${mockReportTemplateInputsResponse.results[0].id}%5D%5Bvalue%5D=${jobId}`
+      )
+    );
+    expect(screen.getByText('Rerun all').getAttribute('href')).toEqual(
+      foremanUrl(`/job_invocations/${jobId}/rerun`)
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Select' }));
+    });
+    expect(
+      screen
+        .getByText('Rerun successful')
+        .closest('a')
+        .getAttribute('href')
+    ).toEqual(foremanUrl(`/job_invocations/${jobId}/rerun?succeeded_only=1`));
+    expect(
+      screen
+        .getByText('Rerun failed')
+        .closest('a')
+        .getAttribute('href')
+    ).toEqual(foremanUrl(`/job_invocations/${jobId}/rerun?failed_only=1`));
+    expect(
+      screen
+        .getByText('View task')
+        .closest('a')
+        .getAttribute('href')
+    ).toEqual(foremanUrl(`/foreman_tasks/tasks/${jobInvocationData.task.id}`));
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Abort')).toBeInTheDocument();
+    expect(screen.queryByText('Enable recurring')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cancel recurring')).not.toBeInTheDocument();
+    expect(
+      screen
+        .getByText('Legacy UI')
+        .closest('a')
+        .getAttribute('href')
+    ).toEqual(`/job_invocations/${jobId}`);
+  });
+
+  it('shows scheduled date', async () => {
+    const store = mockStore(initialStateScheduled);
+    render(
+      <Provider store={store}>
+        <JobInvocationDetailPage
+          match={{ params: { id: `${jobInvocationDataScheduled.id}` } }}
+        />
+      </Provider>
+    );
+
+    expect(screen.getByText('Scheduled at:')).toBeInTheDocument();
+    expect(screen.getByText('Jan 1, 3000, 11:34 UTC')).toBeInTheDocument();
+    expect(screen.getByText('Not yet')).toBeInTheDocument();
+  });
+
+  it('should dispatch global actions', async () => {
+    // recurring in the future
+    const jobId = jobInvocationDataRecurring.id;
+    const recurrenceId = jobInvocationDataRecurring.recurrence.id;
+    const store = mockStore(jobInvocationDataRecurring);
+    render(
+      <Provider store={store}>
+        <JobInvocationDetailPage match={{ params: { id: `${jobId}` } }} />
+      </Provider>
+    );
+
+    const expectedActions = [
+      { key: GET_REPORT_TEMPLATES, url: '/api/report_templates' },
+      {
+        key: JOB_INVOCATION_KEY,
+        url: `/api/job_invocations/${jobId}`,
+      },
+      {
+        key: GET_REPORT_TEMPLATE_INPUTS,
+        url: `/api/templates/${reportTemplateJobId}/template_inputs`,
+      },
+      {
+        key: CANCEL_JOB,
+        url: `/job_invocations/${jobId}/cancel`,
+      },
+      {
+        key: CANCEL_JOB,
+        url: `/job_invocations/${jobId}/cancel?force=true`,
+      },
+      {
+        key: CHANGE_ENABLED_RECURRING_LOGIC,
+        url: `/foreman_tasks/api/recurring_logics/${recurrenceId}`,
+      },
+      {
+        key: CHANGE_ENABLED_RECURRING_LOGIC,
+        url: `/foreman_tasks/api/recurring_logics/${recurrenceId}`,
+      },
+      {
+        key: CANCEL_RECURRING_LOGIC,
+        url: `/foreman_tasks/recurring_logics/${recurrenceId}/cancel`,
+      },
+    ];
+
+    store.dispatch(cancelJob(jobId, false));
+    store.dispatch(cancelJob(jobId, true));
+    store.dispatch(enableRecurringLogic(recurrenceId, true, jobId));
+    store.dispatch(enableRecurringLogic(recurrenceId, false, jobId));
+    store.dispatch(cancelRecurringLogic(recurrenceId, jobId));
+
+    const actualActions = store.getActions();
+    expect(actualActions).toHaveLength(expectedActions.length);
+
+    expectedActions.forEach((expectedAction, index) => {
+      if (actualActions[index].type === 'WITH_INTERVAL') {
+        expect(actualActions[index].key.key).toEqual(expectedAction.key);
+        expect(actualActions[index].key.url).toEqual(expectedAction.url);
+      } else {
+        expect(actualActions[index].key).toEqual(expectedAction.key);
+        if (expectedAction.url) {
+          expect(actualActions[index].url).toEqual(expectedAction.url);
+        }
+      }
+    });
+  });
+});

--- a/webpack/JobInvocationDetail/__tests__/fixtures.js
+++ b/webpack/JobInvocationDetail/__tests__/fixtures.js
@@ -1,0 +1,117 @@
+export const jobInvocationData = {
+  id: 123,
+  description: 'Description',
+  job_category: 'Commands',
+  targeting_id: 123,
+  status: 1,
+  start_at: '2024-01-01 12:34:56 +0100',
+  status_label: 'failed',
+  ssh_user: null,
+  time_to_pickup: null,
+  template_id: 321,
+  template_name: 'Run Command - Script Default',
+  effective_user: 'root',
+  succeeded: 2,
+  failed: 4,
+  pending: 0,
+  cancelled: 0,
+  total: 6,
+  missing: 5,
+  total_hosts: 6,
+  task: {
+    id: '37ad5ead-51de-4798-bc73-a17687c4d5aa',
+    state: 'stopped',
+  },
+  template_invocations: [
+    {
+      template_id: 321,
+      template_name: 'Run Command - Script Default',
+      host_id: 1,
+      template_invocation_input_values: [
+        {
+          template_input_name: 'command',
+          template_input_id: 59,
+          value:
+            'echo start; for i in $(seq 1 120); do echo $i; sleep 1; done; echo done',
+        },
+      ],
+    },
+  ],
+};
+
+export const jobInvocationDataScheduled = {
+  id: 456,
+  description: 'Description',
+  job_category: 'Commands',
+  targeting_id: 456,
+  status: 1,
+  start_at: '3000-01-01 12:34:56 +0100',
+  status_label: 'failed',
+  ssh_user: null,
+  time_to_pickup: null,
+  template_id: 321,
+  template_name: 'Run Command - Script Default',
+  effective_user: 'root',
+  succeeded: 2,
+  failed: 4,
+  pending: 0,
+  cancelled: 0,
+  total: 6,
+  missing: 5,
+  total_hosts: 6,
+};
+
+export const jobInvocationDataRecurring = {
+  id: 789,
+  description: 'Description',
+  job_category: 'Commands',
+  targeting_id: 456,
+  status: 2,
+  start_at: '3000-01-01 12:00:00 +0100',
+  status_label: 'queued',
+  ssh_user: null,
+  time_to_pickup: null,
+  template_id: 321,
+  template_name: 'Run Command - Script Default',
+  effective_user: 'root',
+  succeeded: 0,
+  failed: 0,
+  pending: 0,
+  cancelled: 0,
+  total: 'N/A',
+  missing: 0,
+  total_hosts: 1,
+  task: {
+    id: '37ad5ead-51de-4798-bc73-a17687c4d5aa',
+    state: 'scheduled',
+  },
+  mode: 'recurring',
+  recurrence: {
+    id: 1,
+    cron_line: '00 12 * * *',
+    end_time: null,
+    iteration: 1,
+    task_group_id: 12,
+    state: 'active',
+    max_iteration: null,
+    purpose: null,
+    task_count: 1,
+    action: 'Run hosts job:',
+    last_occurence: null,
+    next_occurence: '3000-01-01 12:00:00 +0100',
+  },
+};
+
+export const mockPermissionsData = {
+  edit_job_templates: true,
+  view_foreman_tasks: true,
+  edit_recurring_logics: true,
+};
+
+export const mockReportTemplatesResponse = {
+  results: [{ id: '12', name: 'Job - Invocation Report' }],
+};
+
+export const mockReportTemplateInputsResponse = {
+  results: [{ id: '34', name: 'job_id' }],
+};

--- a/webpack/JobWizard/JobWizardPageRerun.js
+++ b/webpack/JobWizard/JobWizardPageRerun.js
@@ -1,15 +1,15 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import URI from 'urijs';
-import { Alert, Divider, Skeleton, Button } from '@patternfly/react-core';
-import { sprintf, translate as __ } from 'foremanReact/common/I18n';
-import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
-import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
-import { STATUS } from 'foremanReact/constants';
+import { Alert, Button, Divider, Skeleton } from '@patternfly/react-core';
 import {
-  useForemanOrganization,
   useForemanLocation,
+  useForemanOrganization,
 } from 'foremanReact/Root/Context/ForemanContext';
+import { translate as __, sprintf } from 'foremanReact/common/I18n';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { STATUS } from 'foremanReact/constants';
+import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { JobWizard } from './JobWizard';
 import { JOB_API_KEY } from './JobWizardConstants';
 
@@ -21,11 +21,16 @@ const JobWizardPageRerun = ({
 }) => {
   const uri = new URI(search);
   const { failed_only: failedOnly } = uri.search(true);
+  const { succeeded_only: succeededOnly } = uri.search(true);
+  let queryParams = '';
+  if (failedOnly) {
+    queryParams = '&failed_only=1';
+  } else if (succeededOnly) {
+    queryParams = '&succeeded_only=1';
+  }
   const { response, status } = useAPI(
     'get',
-    `/ui_job_wizard/job_invocation?id=${id}${
-      failedOnly ? '&failed_only=1' : ''
-    }`,
+    `/ui_job_wizard/job_invocation?id=${id}${queryParams}`,
     JOB_API_KEY
   );
   const title = __('Run job');

--- a/webpack/__mocks__/foremanReact/components/BreadcrumbBar/index.js
+++ b/webpack/__mocks__/foremanReact/components/BreadcrumbBar/index.js
@@ -1,0 +1,4 @@
+import React from 'react';
+
+const BreadcrumbBar = () => <div />;
+export default BreadcrumbBar;

--- a/webpack/__mocks__/foremanReact/components/Head/index.js
+++ b/webpack/__mocks__/foremanReact/components/Head/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Head = ({ children }) => <div>{children}</div>;
+
+Head.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Head;

--- a/webpack/__mocks__/foremanReact/components/HostDetails/DetailsCard/DefaultLoaderEmptyState.js
+++ b/webpack/__mocks__/foremanReact/components/HostDetails/DetailsCard/DefaultLoaderEmptyState.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { translate as __ } from '../../../common/I18n';
+
+const DefaultLoaderEmptyState = () => (
+  <span className="disabled-text">{__('Not available')}</span>
+);
+
+export default DefaultLoaderEmptyState;

--- a/webpack/__mocks__/foremanReact/components/ToastsList/index.js
+++ b/webpack/__mocks__/foremanReact/components/ToastsList/index.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const ToastsList = () => <div />;

--- a/webpack/__mocks__/foremanReact/redux/API/APIActions.js
+++ b/webpack/__mocks__/foremanReact/redux/API/APIActions.js
@@ -1,0 +1,21 @@
+import { API_OPERATIONS } from 'foremanReact/redux/API/APIConstants';
+
+const { GET, POST, PUT, DELETE, PATCH } = API_OPERATIONS;
+
+const apiAction = (type, payload) => ({ type, payload });
+
+export const get = payload => apiAction(GET, payload);
+
+export const post = payload => apiAction(POST, payload);
+
+export const put = payload => apiAction(PUT, payload);
+
+export const patch = payload => apiAction(PATCH, payload);
+
+export const APIActions = {
+  get,
+  post,
+  put,
+  patch,
+  delete: payload => apiAction(DELETE, payload),
+};

--- a/webpack/__mocks__/foremanReact/redux/API/APIConstants.js
+++ b/webpack/__mocks__/foremanReact/redux/API/APIConstants.js
@@ -1,0 +1,7 @@
+export const API_OPERATIONS = {
+  GET: 'API_GET',
+  POST: 'API_POST',
+  PUT: 'API_PUT',
+  DELETE: 'API_DELETE',
+  PATCH: 'API_PATCH',
+};

--- a/webpack/__mocks__/foremanReact/redux/API/index.js
+++ b/webpack/__mocks__/foremanReact/redux/API/index.js
@@ -1,5 +1,19 @@
 export const API = {
   get: jest.fn(),
+  put: jest.fn(),
+  post: jest.fn(),
+  delete: jest.fn(),
+  patch: jest.fn(),
 };
 
 export const get = data => ({ type: 'get-some-type', ...data });
+export const post = data => ({ type: 'post-some-type', ...data });
+export const put = data => ({ type: 'put-some-type', ...data });
+export const patch = data => ({ type: 'patch-some-type', ...data });
+
+export const APIActions = {
+  get,
+  post,
+  put,
+  patch,
+};

--- a/webpack/__mocks__/foremanReact/redux/middlewares/IntervalMiddleware/index.js
+++ b/webpack/__mocks__/foremanReact/redux/middlewares/IntervalMiddleware/index.js
@@ -1,0 +1,9 @@
+export const stopInterval = key => ({
+  type: 'STOP_INTERVAL',
+  key,
+});
+
+export const withInterval = key => ({
+  type: 'WITH_INTERVAL',
+  key,
+});


### PR DESCRIPTION
Adds global actions to the new job invocation detail page header:

![image](https://github.com/theforeman/foreman_remote_execution/assets/78563507/a2d3e411-2a17-4b2b-9d20-6ce19dfdac04)