### PR TITLE
Fix naming of Convert2RHEL job category

### DIFF
--- a/app/views/templates/script/convert2rhel_analyze.erb
+++ b/app/views/templates/script/convert2rhel_analyze.erb
@@ -11,7 +11,7 @@ template_inputs:
     default: 'yes'
     hidden_value: false
 model: JobTemplate
-job_category: Convert 2 RHEL
+job_category: Convert2RHEL
 provider_type: script
 kind: job_template
 %>


### PR DESCRIPTION
From `Convert 2 RHEL` to `Convert2RHEL`

See https://github.com/theforeman/foreman_ansible/pull/708