### PR TITLE
Fixes #37447 - Add rerun job error

### DIFF
--- a/webpack/JobWizard/JobWizardSelectors.js
+++ b/webpack/JobWizard/JobWizardSelectors.js
@@ -14,7 +14,14 @@ import {
   JOB_TEMPLATE,
   HOSTS_API,
   JOB_INVOCATION,
+  JOB_API_KEY,
 } from './JobWizardConstants';
+
+export const selectRerunJobInvocationResponse = state =>
+  selectAPIResponse(state, JOB_API_KEY) || {};
+
+export const selectRerunJobInvocationStatus = state =>
+  selectAPIStatus(state, JOB_API_KEY);
 
 export const selectJobTemplatesStatus = state =>
   selectAPIStatus(state, JOB_TEMPLATES);

--- a/webpack/JobWizard/__tests__/fixtures.js
+++ b/webpack/JobWizard/__tests__/fixtures.js
@@ -114,6 +114,8 @@ export const jobCategories = ['Services', 'Ansible Commands', 'Puppet'];
 
 export const testSetup = (selectors, api) => {
   jest.spyOn(api, 'get');
+  jest.spyOn(selectors, 'selectRerunJobInvocationResponse');
+  jest.spyOn(selectors, 'selectRerunJobInvocationStatus');
   jest.spyOn(selectors, 'selectJobTemplate');
   jest.spyOn(selectors, 'selectJobTemplates');
   jest.spyOn(selectors, 'selectJobCategories');
@@ -123,6 +125,10 @@ export const testSetup = (selectors, api) => {
 
   jest.spyOn(selectors, 'selectTemplateInputs');
   jest.spyOn(selectors, 'selectAdvancedTemplateInputs');
+  selectors.selectRerunJobInvocationResponse.mockImplementation(
+    () => jobInvocation
+  );
+  selectors.selectRerunJobInvocationStatus.mockImplementation(() => 'RESOLVED');
   selectors.selectWithKatello.mockImplementation(() => true);
   selectors.selectTemplateInputs.mockImplementation(
     () => jobTemplateResponse.template_inputs

--- a/webpack/JobWizard/steps/ReviewDetails/ReviewDetails.test.js
+++ b/webpack/JobWizard/steps/ReviewDetails/ReviewDetails.test.js
@@ -14,16 +14,17 @@ import {
   jobInvocation,
 } from '../../__tests__/fixtures';
 
+jest.useFakeTimers();
 const store = testSetup(selectors, api);
 mockApi(api);
 jest.spyOn(APIHooks, 'useAPI');
+store.dispatch = jest.fn();
 APIHooks.useAPI.mockImplementation((action, url) => {
   if (url === '/ui_job_wizard/job_invocation?id=57') {
     return { response: jobInvocation, status: 'RESOLVED' };
   }
   return {};
 });
-jest.useFakeTimers();
 
 describe('ReviewDetails', () => {
   it('should call goToStepByName function when StepButton is clicked', async () => {


### PR DESCRIPTION
Added a meaningful error message when trying to rerun a job with a nonexistent job template.

![image](https://github.com/theforeman/foreman_remote_execution/assets/78563507/d8f86707-78af-457d-98e7-62f77f671c72)

I think I may have overcomplicated it a bit - it was easy to display a "404" message, but I wanted the more concrete one.

TODO: fix the tests accordingly