### PR TITLE
Use consistent phrasing

### DIFF
--- a/webpack/JobWizard/JobWizardPageRerun.js
+++ b/webpack/JobWizard/JobWizardPageRerun.js
@@ -53,7 +53,7 @@ const JobWizardPageRerun = ({
           component="a"
           href={`/old/job_invocations/${id}/rerun${search}`}
         >
-          {__('Use old form')}
+          {__('Use legacy form')}
         </Button>
       }
     >


### PR DESCRIPTION
Both of the following should use the same phrasing:

webpack/JobWizard/JobWizardPageRerun.js
webpack/JobWizard/index.js

Right now the user experience is as follows:

When Creating a new Job through Monitor → Jobs → Run Job, while in the creation wizard, there is an option to “Use Legacy Form”

After Submitting the Job I land on the Job Result Page and click on Rerun which sends me back to the Job wizard, and now the option that was “Use Legacy Form” says " Use old Form"