### PR TITLE
Fixes #37493 - Store smart proxy id in template invocations

### DIFF
--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -49,8 +49,6 @@ module Actions
         provider_type = provider.proxy_feature
         proxy = determine_proxy!(proxy_selector, provider_type, host)
         link!(proxy)
-        # TODO: Remove this for Foreman 3.16
-        input[:proxy_id] = proxy.id
         template_invocation.smart_proxy_id = proxy.id
         template_invocation.save!
 

--- a/app/lib/actions/remote_execution/run_host_job.rb
+++ b/app/lib/actions/remote_execution/run_host_job.rb
@@ -49,7 +49,10 @@ module Actions
         provider_type = provider.proxy_feature
         proxy = determine_proxy!(proxy_selector, provider_type, host)
         link!(proxy)
+        # TODO: Remove this for Foreman 3.16
         input[:proxy_id] = proxy.id
+        template_invocation.smart_proxy_id = proxy.id
+        template_invocation.save!
 
         renderer = InputTemplateRenderer.new(template_invocation.template, host, template_invocation)
         script = renderer.render

--- a/app/models/concerns/foreman_remote_execution/smart_proxy_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/smart_proxy_extensions.rb
@@ -3,6 +3,7 @@ module ForemanRemoteExecution
     def self.prepended(base)
       base.instance_eval do
         has_many :host_proxy_invocations, :dependent => :destroy
+        has_many :template_invocations, :dependent => :nullify
       end
     end
 

--- a/app/models/template_invocation.rb
+++ b/app/models/template_invocation.rb
@@ -18,6 +18,7 @@ class TemplateInvocation < ApplicationRecord
   belongs_to :run_host_job_task, :class_name => 'ForemanTasks::Task'
   has_many :remote_execution_features, :through => :template
   has_many :template_invocation_events, :dependent => :destroy
+  belongs_to :smart_proxy, :class_name => '::SmartProxy', :inverse_of => :template_invocations
 
   validates_associated :input_values
   validate :provides_required_input_values

--- a/app/views/template_invocations/show.html.erb
+++ b/app/views/template_invocations/show.html.erb
@@ -28,10 +28,10 @@ end
   </div>
 </div>
 <% if @host %>
-  <% proxy_id = @template_invocation_task.input[:proxy_id] %>
+  <% proxy = @template_invocation.smart_proxy %>
   <h3>
     <%= _('Target: ') %><%= link_to(@host, current_host_details_path(@host)) %>
-    <% if proxy_id && proxy = SmartProxy.find_by(id: proxy_id) %>
+    <% if proxy %>
       <%= _('using Smart Proxy') %> <%= link_to(proxy.name, smart_proxy_path(proxy)) %>
     <% end %>
   </h3>

--- a/db/migrate/20240522093412_add_smart_proxy_id_to_template_invocation.rb
+++ b/db/migrate/20240522093412_add_smart_proxy_id_to_template_invocation.rb
@@ -1,0 +1,7 @@
+class AddSmartProxyIdToTemplateInvocation < ActiveRecord::Migration[6.0]
+  def change
+    change_table :template_invocations do |t|
+      t.references :smart_proxy, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20240522093413_migrate_smart_proxy_ids_to_template_invocations.rb
+++ b/db/migrate/20240522093413_migrate_smart_proxy_ids_to_template_invocations.rb
@@ -1,0 +1,16 @@
+class MigrateSmartProxyIdsToTemplateInvocations < ActiveRecord::Migration[6.0]
+  def up
+    ForemanTasks::Link.joins(:task)
+                      .where(resource_type: 'SmartProxy', task: { label: 'Actions::RemoteExecution::RunHostJob' })
+                      .where.not(resource_id: nil)
+                      .find_in_batches do |batch|
+      batch.group_by(&:resource_id).each do |resource_id, links|
+        template_invocation_ids = ForemanTasks::Link.where(resource_type: 'TemplateInvocation', task_id: links.map(&:task_id)).select(:resource_id)
+        TemplateInvocation.where(id: template_invocation_ids).update_all(smart_proxy_id: resource_id)
+      end
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
Up until now we only stored it somewhere in the depths of tasks and it served us reasonably well, because we only showed the in template invocation's details.