### PR TITLE
Fixes #37706 - Add a template that enables download and run of a script

### DIFF
--- a/app/views/templates/script/run_downloaded_script.erb
+++ b/app/views/templates/script/run_downloaded_script.erb
@@ -1,0 +1,15 @@
+<%#
+kind: job_template
+name: Download and run a script
+model: JobTemplate
+job_category: Commands
+description_format: "Download the script from %{url} and run it locally"
+provider_type: script
+template_inputs:
+- name: url
+  description: URL of the script to download and execute
+  input_type: user
+  required: true
+%>
+
+set -o pipefail && curl -sS '<%= input("url") %>' | bash


### PR DESCRIPTION
The main idea is to execute scripts from the Foreman server, similar to https://github.com/theforeman/foreman/pull/10208.