### PR TITLE
Only package a static list of files

### DIFF
--- a/foreman_remote_execution.gemspec
+++ b/foreman_remote_execution.gemspec
@@ -15,12 +15,8 @@ Gem::Specification.new do |s|
   s.description = 'A plugin bringing remote execution to the Foreman, completing the config ' +
                   'management functionality with remote management functionality.'
 
-  s.files = `git ls-files`.split("\n").reject do |file|
-    file.start_with?('scripts')
-  end
-
-  s.test_files =       `git ls-files test`.split("\n")
-  s.extra_rdoc_files = Dir['README*', 'LICENSE']
+  s.files = Dir['{app,config,db,extra,lib,locale,webpack}/**/*'] + ['LICENSE', 'Rakefile', 'README.md', 'package.json']
+  s.extra_rdoc_files = Dir['README.md', 'LICENSE']
 
   s.required_ruby_version = '>= 2.7', '< 4'
 


### PR DESCRIPTION
This copies the static list of files from the plugin template. It avoids calling git, which means it works in more environments, but it can cause local files not tracked in git to be included. test_files is avoided because it's deprecated.

Primary motivation was packit builds where we temporarily need to include gemfile.d to test against another PR, but don't want that to show up in the final packit RPMs.