### PR TITLE
Fixes #37594 - "Scroll to bottom/top" javascript links on job details page

### DIFF
--- a/app/views/template_invocations/show.html.erb
+++ b/app/views/template_invocations/show.html.erb
@@ -44,13 +44,13 @@ end
     <% if @error %>
       <div class="line error"><%= @error %></div>
     <% else %>
-      <%= link_to_function(_('Scroll to bottom'), '$("html, body").animate({ scrollTop: $(document).height() }, "slow");', :class => 'pull-right scroll-link-bottom') %>
+      <%= link_to_function(_('Scroll to bottom'), '$("#rails-app-content").scrollTop($("#rails-app-content").prop("scrollHeight"));', :class => 'pull-right scroll-link-bottom') %>
 
       <div class="printable">
         <%= render :partial => 'output_line_set', :collection => normalize_line_sets(@line_sets) %>
       </div>
 
-      <%= link_to_function(_('Scroll to top'), '$("html, body").animate({ scrollTop: 0 }, "slow");', :class => 'pull-right scroll-link-top') %>
+      <%= link_to_function(_('Scroll to top'), '$("#rails-app-content").scrollTop(0);', :class => 'pull-right scroll-link-top') %>
     <% end %>
   </div>
 


### PR DESCRIPTION
Description of problem:  
After executing an "Ansible command" job the details page shows two links "scroll bottom" and "scroll top" but none of them works.

How reproducible:
Always

Steps to Reproduce:

1. Execute a "Remote Ansible Command" job
2. Enter into the Job details page
3. Click "Scroll to bottom" Link

Actual behavior:
Nothing happens

Expected behavior:
The page scrolls down.