### PR TITLE
Fixes #37590 - Trigger ready batches on planning finished

### DIFF
--- a/app/lib/actions/remote_execution/run_hosts_job.rb
+++ b/app/lib/actions/remote_execution/run_hosts_job.rb
@@ -75,6 +75,7 @@ module Actions
       end
 
       def on_planning_finished
+        trigger_remote_batch
         plan_event(Actions::TriggerProxyBatch::TriggerLastBatch, nil, step_id: input[:trigger_run_step_id])
         super
       end


### PR DESCRIPTION
Previously we sent the last batch event followed by a regular TriggerNextBatch event with correct number of batches. The proxy batch triggering action received the TriggerLastBatch event, set an internal flag, triggered a single batch and exited, the other event got discarded. This commit changes the ordering so that the TriggerNextBatch event is sent out first when planning is done.