### PR TITLE
Fixes #37630 - Display basic list of hosts on the new job_invocations page

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -18,9 +18,9 @@ module RemoteExecutionHelper
   end
 
   def template_invocation_status(task, parent_task)
-    return(parent_task.result == 'cancelled' ? _('cancelled') : _('Awaiting start')) if task.nil?
+    return(parent_task.result == 'cancelled' ? 'cancelled' : 'N/A') if task.nil?
     return task.state if task.state == 'running' || task.state == 'planned'
-    return _('error') if task.result == 'warning'
+    return 'error' if task.result == 'warning'
 
     task.result
   end

--- a/app/views/api/v2/job_invocations/hosts.json.rabl
+++ b/app/views/api/v2/job_invocations/hosts.json.rabl
@@ -1,0 +1,15 @@
+collection @hosts
+
+attribute :name, :operatingsystem_id, :operatingsystem_name, :hostgroup_id, :hostgroup_name
+
+node :job_status do |host|
+  @host_statuses[host.id]
+end
+
+node :smart_proxy_id do |host|
+  @smart_proxy_id[host.id]
+end
+
+node :smart_proxy_name do |host|
+  @smart_proxy_name[host.id]
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
           get '/raw', :to => 'job_invocations#raw_output'
         end
         member do
+          get 'hosts'
           post 'cancel'
           post 'rerun'
           get  'template_invocations', :to => 'template_invocations#template_invocations'

--- a/webpack/JobInvocationDetail/JobInvocationActions.js
+++ b/webpack/JobInvocationDetail/JobInvocationActions.js
@@ -15,7 +15,7 @@ import {
   UPDATE_JOB,
 } from './JobInvocationConstants';
 
-export const getData = url => dispatch => {
+export const getJobInvocation = url => dispatch => {
   const fetchData = withInterval(
     get({
       key: JOB_INVOCATION_KEY,

--- a/webpack/JobInvocationDetail/JobInvocationConstants.js
+++ b/webpack/JobInvocationDetail/JobInvocationConstants.js
@@ -1,14 +1,21 @@
+/* eslint-disable camelcase */
+import React from 'react';
 import { foremanUrl } from 'foremanReact/common/helpers';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { useForemanHostDetailsPageUrl } from 'foremanReact/Root/Context/ForemanContext';
+import JobStatusIcon from '../react_app/components/RecentJobsCard/JobStatusIcon';
 
 export const JOB_INVOCATION_KEY = 'JOB_INVOCATION_KEY';
 export const CURRENT_PERMISSIONS = 'CURRENT_PERMISSIONS';
 export const UPDATE_JOB = 'UPDATE_JOB';
 export const CANCEL_JOB = 'CANCEL_JOB';
 export const GET_TASK = 'GET_TASK';
+export const GET_TEMPLATE_INVOCATIONS = 'GET_TEMPLATE_INVOCATIONS';
 export const CHANGE_ENABLED_RECURRING_LOGIC = 'CHANGE_ENABLED_RECURRING_LOGIC';
 export const CANCEL_RECURRING_LOGIC = 'CANCEL_RECURRING_LOGIC';
 export const GET_REPORT_TEMPLATES = 'GET_REPORT_TEMPLATES';
 export const GET_REPORT_TEMPLATE_INPUTS = 'GET_REPORT_TEMPLATE_INPUTS';
+export const JOB_INVOCATION_HOSTS = 'JOB_INVOCATION_HOSTS';
 export const currentPermissionsUrl = foremanUrl(
   '/api/v2/permissions/current_permissions'
 );
@@ -20,6 +27,12 @@ export const STATUS = {
   CANCELLED: 'cancelled',
 };
 
+export const STATUS_UPPERCASE = {
+  RESOLVED: 'RESOLVED',
+  ERROR: 'ERROR',
+  PENDING: 'PENDING',
+};
+
 export const DATE_OPTIONS = {
   day: 'numeric',
   month: 'short',
@@ -29,3 +42,74 @@ export const DATE_OPTIONS = {
   hour12: false,
   timeZoneName: 'short',
 };
+
+const Columns = () => {
+  const getColumnsStatus = ({ hostJobStatus }) => {
+    switch (hostJobStatus) {
+      case 'success':
+        return { title: __('Succeeded'), status: 0 };
+      case 'error':
+        return { title: __('Failed'), status: 1 };
+      case 'planned':
+        return { title: __('Scheduled'), status: 2 };
+      case 'running':
+        return { title: __('Pending'), status: 3 };
+      case 'cancelled':
+        return { title: __('Cancelled'), status: 4 };
+      case 'N/A':
+        return { title: __('Awaiting start'), status: 5 };
+      default:
+        return { title: hostJobStatus, status: 6 };
+    }
+  };
+  const hostDetailsPageUrl = useForemanHostDetailsPageUrl();
+
+  return {
+    name: {
+      title: __('Name'),
+      wrapper: ({ name }) => (
+        <a href={`${hostDetailsPageUrl}${name}`}>{name}</a>
+      ),
+      weight: 1,
+    },
+    groups: {
+      title: __('Host group'),
+      wrapper: ({ hostgroup_id, hostgroup_name }) => (
+        <a href={`/hostgroups/${hostgroup_id}/edit`}>{hostgroup_name}</a>
+      ),
+      weight: 2,
+    },
+    os: {
+      title: __('OS'),
+      wrapper: ({ operatingsystem_id, operatingsystem_name }) => (
+        <a href={`/operatingsystems/${operatingsystem_id}/edit`}>
+          {operatingsystem_name}
+        </a>
+      ),
+      weight: 3,
+    },
+    smart_proxy: {
+      title: __('Smart proxy'),
+      wrapper: ({ smart_proxy_name, smart_proxy_id }) => (
+        <a href={`/smart_proxies/${smart_proxy_id}`}>{smart_proxy_name}</a>
+      ),
+      weight: 4,
+    },
+    status: {
+      title: __('Status'),
+      wrapper: ({ job_status }) => {
+        const { title, status } = getColumnsStatus({
+          hostJobStatus: job_status,
+        });
+        return (
+          <JobStatusIcon status={status}>
+            {title || __('Unknown')}
+          </JobStatusIcon>
+        );
+      },
+      weight: 5,
+    },
+  };
+};
+
+export default Columns;

--- a/webpack/JobInvocationDetail/JobInvocationDetail.scss
+++ b/webpack/JobInvocationDetail/JobInvocationDetail.scss
@@ -38,4 +38,3 @@
     height: $chart_size;
   }
 }
-  

--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -1,0 +1,210 @@
+/* eslint-disable camelcase */
+import PropTypes from 'prop-types';
+import React, { useMemo, useEffect } from 'react';
+import { Icon } from 'patternfly-react';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { FormattedMessage } from 'react-intl';
+import { Tr, Td } from '@patternfly/react-table';
+import {
+  Title,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import { foremanUrl } from 'foremanReact/common/helpers';
+import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
+import { Table } from 'foremanReact/components/PF4/TableIndexPage/Table/Table';
+import TableIndexPage from 'foremanReact/components/PF4/TableIndexPage/TableIndexPage';
+import { useSetParamsAndApiAndSearch } from 'foremanReact/components/PF4/TableIndexPage/Table/TableIndexHooks';
+import {
+  useBulkSelect,
+  useUrlParams,
+} from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
+import Pagination from 'foremanReact/components/Pagination';
+import { getControllerSearchProps } from 'foremanReact/constants';
+import Columns, {
+  JOB_INVOCATION_HOSTS,
+  STATUS_UPPERCASE,
+} from './JobInvocationConstants';
+
+const JobInvocationHostTable = ({ id, targeting, finished, autoRefresh }) => {
+  const columns = Columns();
+  const columnNamesKeys = Object.keys(columns);
+  const apiOptions = { key: JOB_INVOCATION_HOSTS };
+  const {
+    searchParam: urlSearchQuery = '',
+    page: urlPage,
+    per_page: urlPerPage,
+  } = useUrlParams();
+  const defaultParams = { search: urlSearchQuery };
+  if (urlPage) defaultParams.page = Number(urlPage);
+  if (urlPerPage) defaultParams.per_page = Number(urlPerPage);
+  const { response, status, setAPIOptions } = useAPI(
+    'get',
+    `/api/job_invocations/${id}/hosts`,
+    {
+      params: { ...defaultParams, key: JOB_INVOCATION_HOSTS },
+    }
+  );
+
+  const combinedResponse = {
+    response: {
+      search: urlSearchQuery,
+      can_create: false,
+      results: response?.results || [],
+      total: response?.total || 0,
+      per_page: response?.perPage,
+      page: response?.page,
+      subtotal: response?.subtotal || 0,
+      message: response?.message || 'error',
+    },
+    status,
+    setAPIOptions,
+  };
+
+  const { setParamsAndAPI, params } = useSetParamsAndApiAndSearch({
+    defaultParams,
+    apiOptions,
+    setAPIOptions: combinedResponse.setAPIOptions,
+  });
+
+  const { updateSearchQuery } = useBulkSelect({
+    initialSearchQuery: urlSearchQuery,
+  });
+
+  const controller = 'hosts';
+  const memoDefaultSearchProps = useMemo(
+    () => getControllerSearchProps(controller),
+    [controller]
+  );
+  memoDefaultSearchProps.autocomplete.url = foremanUrl(
+    `/${controller}/auto_complete_search`
+  );
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      if (!finished || autoRefresh) {
+        setAPIOptions(prevOptions => ({
+          ...prevOptions,
+          params: {
+            ...prevOptions.params,
+          },
+        }));
+      }
+    }, 5000);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [finished, autoRefresh, setAPIOptions]);
+
+  const onPagination = newPagination => {
+    setParamsAndAPI({
+      ...params,
+      ...newPagination,
+      search: urlSearchQuery,
+    });
+  };
+
+  const bottomPagination = (
+    <Pagination
+      ouiaId="table-hosts-bottom-pagination"
+      key="table-bottom-pagination"
+      page={params.page}
+      perPage={params.perPage}
+      itemCount={response?.subtotal}
+      onChange={onPagination}
+    />
+  );
+
+  const customEmptyState = (
+    <Tr ouiaId="table-empty">
+      <Td colSpan={100}>
+        <EmptyState variant={EmptyStateVariant.xl}>
+          <span className="empty-state-icon">
+            <Icon name="add-circle-o" type="pf" size="2x" />
+          </span>
+          <Title ouiaId="empty-state-header" headingLevel="h5" size="4xl">
+            {__('No Results')}
+          </Title>
+          <EmptyStateBody>
+            <div className="empty-state-description">
+              {targeting?.targeting_type === 'dynamic_query' ? (
+                <FormattedMessage
+                  id="view-dynamic-hosts"
+                  defaultMessage={__(
+                    'The dynamic query is still being processed. You can {viewTheHosts} targeted by the query.'
+                  )}
+                  values={{
+                    viewTheHosts: (
+                      <a href={`/new/hosts?search=${targeting?.search_query}`}>
+                        {__('view the hosts')}
+                      </a>
+                    ),
+                  }}
+                />
+              ) : (
+                __('No hosts found')
+              )}
+            </div>
+          </EmptyStateBody>
+        </EmptyState>
+      </Td>
+    </Tr>
+  );
+
+  return (
+    <TableIndexPage
+      apiUrl=""
+      apiOptions={apiOptions}
+      customSearchProps={memoDefaultSearchProps}
+      controller="hosts"
+      creatable={false}
+      replacementResponse={combinedResponse}
+      updateSearchQuery={updateSearchQuery}
+    >
+      <Table
+        ouiaId="job-invocation-hosts-table"
+        columns={columns}
+        customEmptyState={
+          status === STATUS_UPPERCASE.RESOLVED && !response?.results?.length
+            ? customEmptyState
+            : null
+        }
+        params={params}
+        setParams={setParamsAndAPI}
+        itemCount={response?.subtotal}
+        results={response?.results}
+        url=""
+        refreshData={() => {}}
+        errorMessage={
+          status === STATUS_UPPERCASE.ERROR && response?.message
+            ? response.message
+            : null
+        }
+        isPending={status === STATUS_UPPERCASE.PENDING}
+        isDeleteable={false}
+        bottomPagination={bottomPagination}
+      >
+        {response?.results?.map((result, rowIndex) => (
+          <Tr key={rowIndex} ouiaId={`table-row-${rowIndex}`}>
+            {columnNamesKeys.map(k => (
+              <Td key={k}>{columns[k].wrapper(result)}</Td>
+            ))}
+          </Tr>
+        ))}
+      </Table>
+    </TableIndexPage>
+  );
+};
+
+JobInvocationHostTable.propTypes = {
+  id: PropTypes.string.isRequired,
+  targeting: PropTypes.object.isRequired,
+  finished: PropTypes.bool.isRequired,
+  autoRefresh: PropTypes.bool.isRequired,
+};
+
+JobInvocationHostTable.defaultProps = {};
+
+export default JobInvocationHostTable;

--- a/webpack/JobInvocationDetail/JobInvocationSelectors.js
+++ b/webpack/JobInvocationDetail/JobInvocationSelectors.js
@@ -1,10 +1,10 @@
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
-import { JOB_INVOCATION_KEY } from './JobInvocationConstants';
+import { JOB_INVOCATION_KEY, GET_TASK } from './JobInvocationConstants';
 
 export const selectItems = state =>
   selectAPIResponse(state, JOB_INVOCATION_KEY);
 
-export const selectTask = state => selectAPIResponse(state, 'GET_TASK');
+export const selectTask = state => selectAPIResponse(state, GET_TASK);
 
 export const selectTaskCancelable = state =>
   selectTask(state).available_actions?.cancellable || false;

--- a/webpack/JobInvocationDetail/__tests__/MainInformation.test.js
+++ b/webpack/JobInvocationDetail/__tests__/MainInformation.test.js
@@ -76,6 +76,10 @@ api.get.mockImplementation(({ handleSuccess, ...action }) => {
   return { type: 'get', ...action };
 });
 
+jest.mock('../JobInvocationHostTable.js', () => () => (
+  <div data-testid="mock-table">Mock Table</div>
+));
+
 const reportTemplateJobId = mockReportTemplatesResponse.results[0].id;
 
 const mockStore = configureMockStore([thunk]);
@@ -207,7 +211,7 @@ describe('JobInvocationDetailPage', () => {
       { key: GET_REPORT_TEMPLATES, url: '/api/report_templates' },
       {
         key: JOB_INVOCATION_KEY,
-        url: `/api/job_invocations/${jobId}`,
+        url: `/api/job_invocations/${jobId}?host_status=true`,
       },
       {
         key: GET_REPORT_TEMPLATE_INPUTS,

--- a/webpack/JobInvocationDetail/__tests__/fixtures.js
+++ b/webpack/JobInvocationDetail/__tests__/fixtures.js
@@ -1,4 +1,7 @@
 export const jobInvocationData = {
+  search: '',
+  per_page: 20,
+  page: 1,
   id: 123,
   description: 'Description',
   job_category: 'Commands',
@@ -40,6 +43,9 @@ export const jobInvocationData = {
 };
 
 export const jobInvocationDataScheduled = {
+  search: '',
+  per_page: 20,
+  page: 1,
   id: 456,
   description: 'Description',
   job_category: 'Commands',
@@ -62,6 +68,9 @@ export const jobInvocationDataScheduled = {
 };
 
 export const jobInvocationDataRecurring = {
+  search: '',
+  per_page: 20,
+  page: 1,
   id: 789,
   description: 'Description',
   job_category: 'Commands',

--- a/webpack/JobInvocationDetail/index.js
+++ b/webpack/JobInvocationDetail/index.js
@@ -1,12 +1,17 @@
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Divider, Flex } from '@patternfly/react-core';
+import {
+  Divider,
+  Flex,
+  PageSection,
+  PageSectionVariants,
+} from '@patternfly/react-core';
 import { translate as __, documentLocale } from 'foremanReact/common/I18n';
 import PageLayout from 'foremanReact/routes/common/PageLayout/PageLayout';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 import { stopInterval } from 'foremanReact/redux/middlewares/IntervalMiddleware';
-import { getData, getTask } from './JobInvocationActions';
+import { getJobInvocation, getTask } from './JobInvocationActions';
 import {
   CURRENT_PERMISSIONS,
   DATE_OPTIONS,
@@ -19,6 +24,7 @@ import JobInvocationOverview from './JobInvocationOverview';
 import { selectItems } from './JobInvocationSelectors';
 import JobInvocationSystemStatusChart from './JobInvocationSystemStatusChart';
 import JobInvocationToolbarButtons from './JobInvocationToolbarButtons';
+import JobInvocationHostTable from './JobInvocationHostTable';
 
 const JobInvocationDetailPage = ({
   match: {
@@ -32,6 +38,7 @@ const JobInvocationDetailPage = ({
     status_label: statusLabel,
     task,
     start_at: startAt,
+    targeting,
   } = items;
   const finished =
     statusLabel === STATUS.FAILED ||
@@ -57,7 +64,7 @@ const JobInvocationDetailPage = ({
   }
 
   useEffect(() => {
-    dispatch(getData(`/api/job_invocations/${id}`));
+    dispatch(getJobInvocation(`/api/job_invocations/${id}?host_status=true`));
     if (finished && !autoRefresh) {
       dispatch(stopInterval(JOB_INVOCATION_KEY));
     }
@@ -82,45 +89,60 @@ const JobInvocationDetailPage = ({
   };
 
   return (
-    <PageLayout
-      header={description}
-      breadcrumbOptions={breadcrumbOptions}
-      toolbarButtons={
-        <JobInvocationToolbarButtons
-          jobId={id}
-          data={items}
-          currentPermissions={response.results}
-          permissionsStatus={status}
-        />
-      }
-      searchable={false}
-    >
-      <Flex
-        className="job-invocation-detail-flex"
-        alignItems={{ default: 'alignItemsFlexStart' }}
+    <>
+      <PageLayout
+        header={description}
+        breadcrumbOptions={breadcrumbOptions}
+        toolbarButtons={
+          <JobInvocationToolbarButtons
+            jobId={id}
+            data={items}
+            currentPermissions={response.results}
+            permissionsStatus={status}
+          />
+        }
+        searchable={false}
       >
-        <JobInvocationSystemStatusChart
-          data={items}
-          isAlreadyStarted={isAlreadyStarted}
-          formattedStartDate={formattedStartDate}
-        />
-        <Divider
-          orientation={{
-            default: 'vertical',
-          }}
-        />
         <Flex
-          className="job-overview"
-          alignItems={{ default: 'alignItemsCenter' }}
+          className="job-invocation-detail-flex"
+          alignItems={{ default: 'alignItemsFlexStart' }}
         >
-          <JobInvocationOverview
+          <JobInvocationSystemStatusChart
             data={items}
             isAlreadyStarted={isAlreadyStarted}
             formattedStartDate={formattedStartDate}
           />
+          <Divider
+            orientation={{
+              default: 'vertical',
+            }}
+          />
+          <Flex
+            className="job-overview"
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <JobInvocationOverview
+              data={items}
+              isAlreadyStarted={isAlreadyStarted}
+              formattedStartDate={formattedStartDate}
+            />
+          </Flex>
         </Flex>
-      </Flex>
-    </PageLayout>
+      </PageLayout>
+      <PageSection
+        variant={PageSectionVariants.light}
+        className="table-section"
+      >
+        {items.id !== undefined && (
+          <JobInvocationHostTable
+            id={id}
+            targeting={targeting}
+            finished={finished}
+            autoRefresh={autoRefresh}
+          />
+        )}
+      </PageSection>
+    </>
   );
 };
 

--- a/webpack/__mocks__/foremanReact/components/HostDetails/DetailsCard/DefaultLoaderEmptyState.js
+++ b/webpack/__mocks__/foremanReact/components/HostDetails/DetailsCard/DefaultLoaderEmptyState.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { translate as __ } from '../../../common/I18n';
 
 const DefaultLoaderEmptyState = () => (
-  <span className="disabled-text">{__('Not available')}</span>
+  <span className="disabled-text">Not available</span>
 );
 
 export default DefaultLoaderEmptyState;

--- a/webpack/react_app/components/RecentJobsCard/JobStatusIcon.js
+++ b/webpack/react_app/components/RecentJobsCard/JobStatusIcon.js
@@ -3,29 +3,60 @@ import PropTypes from 'prop-types';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
+  BuildIcon,
+  RunningIcon,
+  ExclamationTriangleIcon,
   QuestionCircleIcon,
 } from '@patternfly/react-icons';
-import { JOB_SUCCESS_STATUS, JOB_ERROR_STATUS } from './constants';
+import {
+  JOB_SUCCESS_STATUS,
+  JOB_ERROR_STATUS,
+  JOB_PLANNED_STATUS,
+  JOB_RUNNING_STATUS,
+  JOB_CANCELLED_STATUS,
+  JOB_AWAITING_STATUS,
+} from './constants';
 import './styles.scss';
 
 const JobStatusIcon = ({ status, children, ...props }) => {
   switch (status) {
     case JOB_SUCCESS_STATUS:
       return (
-        <span className="job-success">
-          <CheckCircleIcon {...props} /> {children}
+        <span>
+          <CheckCircleIcon className="job-success" {...props} /> {children}
         </span>
       );
     case JOB_ERROR_STATUS:
       return (
-        <span className="job-error">
-          <ExclamationCircleIcon {...props} /> {children}
+        <span>
+          <ExclamationCircleIcon className="job-error" {...props} /> {children}
         </span>
       );
+    case JOB_PLANNED_STATUS:
+      return (
+        <span>
+          <BuildIcon className="job-planned" {...props} /> {children}
+        </span>
+      );
+    case JOB_RUNNING_STATUS:
+      return (
+        <span>
+          <RunningIcon className="job-running" {...props} /> {children}
+        </span>
+      );
+    case JOB_CANCELLED_STATUS:
+      return (
+        <span>
+          <ExclamationTriangleIcon className="job-cancelled" {...props} />{' '}
+          {children}
+        </span>
+      );
+    case JOB_AWAITING_STATUS:
+      return <span className="job-awaiting_start">{children}</span>;
     default:
       return (
-        <span className="job-info">
-          <QuestionCircleIcon {...props} /> {children}
+        <span>
+          <QuestionCircleIcon className="job-unknown" {...props} /> {children}
         </span>
       );
   }

--- a/webpack/react_app/components/RecentJobsCard/constants.js
+++ b/webpack/react_app/components/RecentJobsCard/constants.js
@@ -5,6 +5,10 @@ export const SCHEDULED_TAB = 2;
 
 export const JOB_SUCCESS_STATUS = 0;
 export const JOB_ERROR_STATUS = 1;
+export const JOB_PLANNED_STATUS = 2;
+export const JOB_RUNNING_STATUS = 3;
+export const JOB_CANCELLED_STATUS = 4;
+export const JOB_AWAITING_STATUS = 5;
 
 export const JOB_BASE_URL = '/job_invocations?search=targeted_host_id+%3D+';
 export const JOB_API_URL =

--- a/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/HostStatus.test.js.snap
+++ b/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/HostStatus.test.js.snap
@@ -7,6 +7,6 @@ exports[`HostStatus renders 1`] = `
     type="pf"
   />
    
-  success
+  Succeeded
 </div>
 `;

--- a/webpack/react_app/components/TargetingHosts/components/HostStatus.js
+++ b/webpack/react_app/components/TargetingHosts/components/HostStatus.js
@@ -8,38 +8,38 @@ const HostStatus = ({ status }) => {
     case 'cancelled':
       return (
         <div>
-          <Icon type="pf" name="warning-triangle-o" /> {status}
+          <Icon type="pf" name="warning-triangle-o" /> {__('Cancelled')}
         </div>
       );
     case 'N/A':
       return (
         <div>
-          <Icon type="fa" name="question" /> {status}
+          <Icon type="fa" name="question" /> {__('Awaiting start')}
         </div>
       );
     case 'running':
       return (
         <div>
-          <Icon type="pf" name="running" /> {status}
+          <Icon type="pf" name="running" /> {__('Pending')}
         </div>
       );
     case 'planned':
       return (
         <div>
-          <Icon type="pf" name="build" /> {status}
+          <Icon type="pf" name="build" /> {__('Scheduled')}
         </div>
       );
     case 'warning':
     case 'error':
       return (
         <div>
-          <Icon type="pf" name="error-circle-o" /> {__('failed')}
+          <Icon type="pf" name="error-circle-o" /> {__('Failed')}
         </div>
       );
     case 'success':
       return (
         <div>
-          <Icon type="pf" name="ok" /> {status}
+          <Icon type="pf" name="ok" /> {__('Succeeded')}
         </div>
       );
     default:


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/28b77662-626d-436d-99fa-4d69c9c22226)


Dependent on [this PR](https://github.com/theforeman/foreman_remote_execution/pull/899/commits/7c3c9edc42325faee3bd59f5a9a3a8660b80930e).

The next PR will add sorting, filtering by status, and permission handling.
The changes in the `JobStatusIcon` also affect the recent jobs card on the host detail page.