### PR TITLE
Fixes #37962 - Check template requirements before import

### DIFF
--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -64,6 +64,7 @@ class JobTemplate < ::Template
     # will overwrite (sync) an existing template if options[:update] is true.
     def import_raw(contents, options = {})
       metadata = Template.parse_metadata(contents)
+      return unless SeedHelper.test_template_requirements(metadata['name'], metadata['require'] || [])
       import_parsed(metadata['name'], contents, metadata, options)
     end
 


### PR DESCRIPTION
To prevent importing templates which don't have their requirements met.

Requires https://github.com/theforeman/foreman/pull/10361

TODO: 
- [x] bump required foreman version - we already require >= 3.13