### PR TITLE
Fixes #38041 - Use Rails 7.0 style for rendering JS partials

### DIFF
--- a/app/views/template_invocations/show.js.erb
+++ b/app/views/template_invocations/show.js.erb
@@ -9,7 +9,7 @@ var target = $("div.terminal div.printable");
   target.html(lines);
 <% end %>
 
-<%= render :partial => 'refresh.js' %>
+<%= render partial: 'refresh', formats: :js %>
 
 if (scrolledToBottom) {
   $("html, body").animate({ scrollTop: $(document).height() }, "slow");


### PR DESCRIPTION
The same change as in https://github.com/theforeman/foreman_remote_execution/commit/8b169c26abe218ff549b5185411221dbd28ef14c#diff-0ed4202665b4981a38809478b2881a9f24aaf1e2fa48572d0f73bab06286d7e5L58

Overlooks happen :/