### PR TITLE
Fixes #38059 - job wizard limit starts at to future only

### DIFF
--- a/webpack/JobWizard/StartsErrorAlert.js
+++ b/webpack/JobWizard/StartsErrorAlert.js
@@ -7,10 +7,25 @@ export const StartsBeforeErrorAlert = () => (
     <Alert
       ouiaId="starts-before-error-alert"
       variant="danger"
-      title={__("'Starts before' date must in the future")}
+      title={__("'Starts before' date must be in the future")}
     >
       {__(
         'Please go back to "Schedule" - "Future execution" step to fix the error'
+      )}
+    </Alert>
+    <Divider component="div" />
+  </>
+);
+
+export const StartsAtErrorAlert = () => (
+  <>
+    <Alert
+      ouiaId="starts-at-error-alert"
+      variant="danger"
+      title={__("'Starts at' date must be in the future")}
+    >
+      {__(
+        'Please go back to "Schedule" - "Future execution" or "Recurring execution" step to fix the error'
       )}
     </Alert>
     <Divider component="div" />

--- a/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
+++ b/webpack/JobWizard/steps/AdvancedFields/__tests__/AdvancedFields.test.js
@@ -399,7 +399,7 @@ describe('AdvancedFields', () => {
         target: { value: 'some search' },
       });
 
-      jest.runAllTimers();
+      jest.advanceTimersByTime(10000);
     });
     expect(newStore.getActions()).toMatchSnapshot('resource search');
   });

--- a/webpack/JobWizard/steps/Schedule/ScheduleFuture.js
+++ b/webpack/JobWizard/steps/Schedule/ScheduleFuture.js
@@ -38,7 +38,7 @@ export const ScheduleFuture = ({
       setError(__("'Starts before' date must be after 'Starts at' date"));
     } else if (new Date().getTime() >= new Date(startsBefore).getTime()) {
       wrappedSetValid(false);
-      setError(__("'Starts before' date must in the future"));
+      setError(__("'Starts before' date must be in the future"));
     } else {
       wrappedSetValid(true);
       setError(null);

--- a/webpack/JobWizard/steps/Schedule/ScheduleRecurring.js
+++ b/webpack/JobWizard/steps/Schedule/ScheduleRecurring.js
@@ -51,7 +51,7 @@ export const ScheduleRecurring = ({
     if (isNeverEnds) setValidEnd(true);
     else if (!ends) setValidEnd(true);
     else if (
-      !startsAt.length &&
+      !startsAt?.length &&
       new Date().getTime() <= new Date(ends).getTime()
     )
       setValidEnd(true);
@@ -63,7 +63,7 @@ export const ScheduleRecurring = ({
 
     if (!validEnd || !repeatValid) {
       wrappedSetValid(false);
-    } else if (isFuture && startsAt.length) {
+    } else if (isFuture && startsAt?.length) {
       wrappedSetValid(true);
     } else if (!isFuture) {
       wrappedSetValid(true);
@@ -111,7 +111,9 @@ export const ScheduleRecurring = ({
                 onChange={() =>
                   setScheduleValue(current => ({
                     ...current,
-                    startsAt: new Date().toISOString(),
+                    startsAt: new Date(
+                      new Date().getTime() + 60000
+                    ).toISOString(), // 1 minute in the future
                     isFuture: true,
                   }))
                 }

--- a/webpack/JobWizard/steps/Schedule/ScheduleType.js
+++ b/webpack/JobWizard/steps/Schedule/ScheduleType.js
@@ -49,7 +49,7 @@ export const ScheduleType = ({
           onChange={() => {
             setScheduleValue(current => ({
               ...current,
-              startsAt: new Date().toISOString(),
+              startsAt: new Date(new Date().getTime() + 60000).toISOString(), // 1 minute in the future
               scheduleType: SCHEDULE_TYPES.FUTURE,
               repeatType: repeatTypes.noRepeat,
             }));

--- a/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
+++ b/webpack/JobWizard/steps/Schedule/__tests__/Schedule.test.js
@@ -168,7 +168,7 @@ describe('Schedule', () => {
     ).toHaveLength(1);
 
     expect(
-      screen.queryAllByText("'Starts before' date must in the future")
+      screen.queryAllByText("'Starts before' date must be in the future")
     ).toHaveLength(0);
     await act(async () => {
       await fireEvent.change(startsBeforeDateField(), {
@@ -182,7 +182,7 @@ describe('Schedule', () => {
 
     expect(startsBeforeDateField().value).toBe('2019/03/11');
     expect(
-      screen.getAllByText("'Starts before' date must in the future")
+      screen.getAllByText("'Starts before' date must be in the future")
     ).toHaveLength(2);
   });
 
@@ -329,7 +329,7 @@ describe('Schedule', () => {
       fireEvent.click(
         screen.getByRole('button', { name: 'Recurring execution' })
       );
-      jest.runAllTimers();
+      jest.advanceTimersByTime(1000);
     });
     expect(screen.queryAllByText('Recurring execution')).toHaveLength(3);
 

--- a/webpack/JobWizard/steps/form/DateTimePicker.js
+++ b/webpack/JobWizard/steps/form/DateTimePicker.js
@@ -22,6 +22,7 @@ export const DateTimePicker = ({
   ariaLabel,
   allowEmpty,
   includeSeconds,
+  isFutureOnly,
 }) => {
   const [validated, setValidated] = useState();
   const dateFormat = date =>
@@ -87,6 +88,15 @@ export const DateTimePicker = ({
       setValidated(ValidatedOptions.error);
     }
   };
+  const validateFuture = date => {
+    if (
+      isFutureOnly &&
+      date.setHours(1, 0, 0, 0) < new Date().setHours(0, 0, 0, 0)
+    ) {
+      return __('Date must be in the future');
+    }
+    return '';
+  };
   return (
     <>
       <DatePicker
@@ -105,6 +115,7 @@ export const DateTimePicker = ({
           validated === ValidatedOptions.error ? __('Invalid date') : ''
         }
         inputProps={{ validated }}
+        validators={[validateFuture]}
       />
       <TimePicker
         aria-label={`${ariaLabel} timepicker`}
@@ -132,6 +143,7 @@ DateTimePicker.propTypes = {
   ariaLabel: PropTypes.string,
   allowEmpty: PropTypes.bool,
   includeSeconds: PropTypes.bool,
+  isFutureOnly: PropTypes.bool,
 };
 DateTimePicker.defaultProps = {
   dateTime: null,
@@ -139,4 +151,5 @@ DateTimePicker.defaultProps = {
   ariaLabel: '',
   allowEmpty: true,
   includeSeconds: false,
+  isFutureOnly: true,
 };

--- a/webpack/JobWizard/steps/form/Formatter.js
+++ b/webpack/JobWizard/steps/form/Formatter.js
@@ -143,6 +143,7 @@ export const formatter = (input, values, setValue) => {
         isRequired={required}
       >
         <DateTimePicker
+          isFutureOnly={false}
           ariaLabel={name}
           className={hidden ? 'masked-input' : null}
           id={id}


### PR DESCRIPTION
Limited most of the date pickers to be only in the future (expect the user input one).
Added an error shown when the "starts at" is in the past.
Set the default value to starts at one minute on the future.
Updated the useEffect to set errors on "future" and "recurring" schedule, and to remove them otherwise.
Since I added a timer in the useEffect I added test fixes/ adjustments.