### PR TITLE
Fixes #38101 - Align search bar with hosts list on job details page

### DIFF
--- a/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsPage.js
@@ -25,7 +25,7 @@ const TargetingHostsPage = ({
 }) => (
   <div id="targeting_hosts">
     <Grid.Row>
-      <Grid.Col md={6} className="title_filter">
+      <Grid.Col md={6}>
         <SearchBar
           onSearch={query => handleSearch(query, statusFilter)}
           data={{

--- a/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
+++ b/webpack/react_app/components/TargetingHosts/__tests__/__snapshots__/TargetingHostsPage.test.js.snap
@@ -10,7 +10,6 @@ exports[`TargetingHostsPage renders 1`] = `
   >
     <Col
       bsClass="col"
-      className="title_filter"
       componentClass="div"
       md={6}
     >


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/0a235ce7-a74c-4ba0-a807-93a62b1a6ecb)

After:
![image](https://github.com/user-attachments/assets/a6db6593-d386-4ced-9eae-55ab1f40f16d)
