### PR TITLE
Fixes #38131 - Use #include? instead of Regexp substring match

### DIFF
--- a/app/controllers/ui_job_wizard_controller.rb
+++ b/app/controllers/ui_job_wizard_controller.rb
@@ -55,7 +55,7 @@ class UIJobWizardController < Api::V2::BaseController
 
   def resources
     resource_type = params[:resource]
-    resource_list = resource_type.constantize.authorized("view_#{resource_type.underscore.pluralize}").all.map { |r| {:name => r.to_s, :id => r.id } }.select { |v| v[:name] =~ /#{params[:name]}/ }
+    resource_list = resource_type.constantize.authorized("view_#{resource_type.underscore.pluralize}").all.map { |r| {:name => r.to_s, :id => r.id } }.select { |v| v[:name].include?(params[:name].to_s) }
     render :json => { :results =>
       resource_list.sort_by { |r| r[:name] }.take(100), :subtotal => resource_list.count}
   end


### PR DESCRIPTION
This PR only replaces `=~` with `include?` leaving the current behavior as is.

We could go extra mile with this in terms of optimizing:
```ruby
    attribute_name = resource_type.constantize.attribute_name
    resource_list = resource_type.constantize.authorized("view_#{resource_type.underscore.pluralize}")
                      .search_for("#{attribute_name} ~ \"#{params[:name]}\"")
                      .limit(100).pluck(attribute_name, :id).map { |name, id| { name: name, id: id } }
    render :json => { :results => resource_list.sort_by { |r| r[:name] }, :subtotal => resource_list.count }
```

This will take only 100 items from DB which match the param. There are some downsides though:

  1.  We lose the exact number of items matching the param to show (since we take max 100 items). To have this back, we'd need to make another call.
  2. Currently it takes items from DB at first and then calls `to_s` on each. Depending on exact implementation it always will return a string with at least something to compare with the param. This approach uses DB search, so we can compare only string column and if they are present at all. This can be workarounded, but will require more changes. Not sure if it's worth for some entities such as `Audit` or `TemplateInvocation`, where `Audit.any.to_s` produces basically unusable string and `TemplateInvocation.any.to_s` produces just a string with id of the object, which I don't find useful in context of template inputs. See screenshots:
  Before:
![Screenshot-1736418673663](https://github.com/user-attachments/assets/89696d03-3f50-479e-b0fa-b33b495361d7)
![Screenshot-1736426440694](https://github.com/user-attachments/assets/6a367241-0e00-48be-843f-dec8395014e6)
  After:
  
![Screenshot-1736426440694w](https://github.com/user-attachments/assets/068ea3e6-3475-4ec0-84e5-959fe2cdc8c6)

It'll fail internally with error, since it tries `~` operator on an integer column.
