### PR TITLE
Fixes #38202 - allow host search in job feature run

### DIFF
--- a/app/controllers/job_invocations_controller.rb
+++ b/app/controllers/job_invocations_controller.rb
@@ -171,7 +171,7 @@ class JobInvocationsController < ApplicationController
       inputs = params[:inputs].permit!.to_hash if params.include?(:inputs)
       JobInvocationComposer.for_feature(
         params[:feature],
-        params[:host_ids],
+        params[:search].presence || params[:host_ids],
         inputs
       )
     else


### PR DESCRIPTION
For new hosts index page, use the search from the url when its used like: /job_invocations?feature=ansible_run_host&search=id%20^%20(63,50)
for example for the "run all ansible jobs" button when selecting hosts.
Without this the button doesnt run anything.
I didnt change the ui url calls to api since then we dont have the information on when to redirect to the job form or just run it.