### PR TITLE
Fixes #38263 - Assign correct taxonomies on template import

### DIFF
--- a/app/controllers/api/v2/job_templates_controller.rb
+++ b/app/controllers/api/v2/job_templates_controller.rb
@@ -23,10 +23,13 @@ module Api
       end
 
       api :POST, '/job_templates/import', N_('Import a job template from ERB')
+      param_group :template_import_options, ::Api::V2::BaseController
       param :template, String, :required => true, :desc => N_('Template ERB')
       param :overwrite, :bool, :required => false, :desc => N_('Overwrite template if it already exists')
       def import
         options = params[:overwrite] ? { :update => true } : { :build_new => true }
+        # the Template superclass expects hash indexed by symbols
+        options = options.merge(params.permit(:options => {}).try(:[], :options).try(:to_h) || {}).with_indifferent_access
 
         @job_template = JobTemplate.import_raw(params[:template], options)
         @job_template ||= JobTemplate.new


### PR DESCRIPTION
Currently, when importing a job template, taxonomies of the request are honored instead of taxonomies of the template itself. For an example see the Redmine issue.

The superclass [Template](https://github.com/theforeman/foreman/blob/develop/app/models/template.rb) of the class `JobTemplate` only extracts taxonomies from metadata on import if the option `:associate` is present, but this option is never accepted by the endpoint or assigned during the processing of the import request. I have added this option as a part of the `template_import_options` param group to stay consistent with imports of other template types.

The new behavior allows user to choose if the taxonomies of the request or the taxonomies in the template metadata should be honored based on the `options[associate]` param