### PR TITLE
Use sentence case for abort button task

### DIFF
--- a/webpack/JobInvocationDetail/TemplateInvocationComponents/TemplateActionButtons.js
+++ b/webpack/JobInvocationDetail/TemplateInvocationComponents/TemplateActionButtons.js
@@ -56,7 +56,7 @@ const actions = ({
   },
   abort: {
     name: 'template-invocation-abort-job',
-    text: __('Abort Task'),
+    text: __('Abort task'),
     permission: permissions.cancel_job_invocations,
     onClick: () => {
       dispatch(


### PR DESCRIPTION
The patternfly style guide prefers Sentence case instead of Title Case.

Link: https://www.patternfly.org/ux-writing/capitalization
Fixes: 35cd0649f681 ("Fixes #38187 - Fix kebab items in job invocation (#947)")