### PR TITLE
Fixes #38327 - build job names with host names

### DIFF
--- a/webpack/JobWizard/steps/HostsAndInputs/buildHostQuery.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/buildHostQuery.js
@@ -1,12 +1,31 @@
 export const buildHostQuery = (selected, search) => {
+  const nameEscape = name => `"${name.replaceAll('"', '\\"')}"`;
   const { hosts, hostCollections, hostGroups } = selected;
-  const hostsSearch = `id ^ (${hosts.map(({ id }) => id).join(',')})`;
-  const hostCollectionsSearch = `host_collection_id ^ (${hostCollections
-    .map(({ id }) => id)
-    .join(',')})`;
-  const hostGroupsSearch = `hostgroup_id ^ (${hostGroups
-    .map(({ id }) => id)
-    .join(',')})`;
+  const MAX_NAME_ITEMS = 50;
+  let hostsSearch;
+  if (hosts.length < MAX_NAME_ITEMS)
+    hostsSearch = `name ^ (${hosts.map(({ name }) => name).join(',')})`;
+  else hostsSearch = `id ^ (${hosts.map(({ id }) => id).join(',')})`;
+
+  let hostCollectionsSearch;
+  if (hostCollections.length < MAX_NAME_ITEMS)
+    hostCollectionsSearch = `host_collection ^ (${hostCollections
+      .map(({ name }) => nameEscape(name))
+      .join(',')})`;
+  else
+    hostCollectionsSearch = `host_collection_id ^ (${hostCollections
+      .map(({ id }) => id)
+      .join(',')})`;
+
+  let hostGroupsSearch;
+  if (hostCollections.length < MAX_NAME_ITEMS)
+    hostGroupsSearch = `hostgroup_fullname ^ (${hostGroups
+      .map(({ name }) => nameEscape(name))
+      .join(',')})`;
+  else
+    hostGroupsSearch = `hostgroup_id ^ (${hostGroups
+      .map(({ id }) => id)
+      .join(',')})`;
   const queryParts = [
     hosts.length ? hostsSearch : false,
     hostCollections.length ? hostCollectionsSearch : false,


### PR DESCRIPTION
So its easier to see from the ui which hosts (/groups/collections) the job runs on