### PR TITLE
Fixes #38379 - add transient package install support

### DIFF
--- a/app/views/templates/script/package_action.erb
+++ b/app/views/templates/script/package_action.erb
@@ -105,7 +105,11 @@ handle_zypp_res_codes () {
 
 # Action
 <% if package_manager == 'yum' -%>
-  yum -y <%= input("options") %> <%= action %> <%= input("package") %>
+  <% if @host.respond_to?(:yum_or_yum_transient) -%>
+    <%= @host.yum_or_yum_transient %> -y <%= input("options") %> <%= action %> <%= input("package") %>
+  <% else -%>
+    yum -y <%= input("options") %> <%= action %> <%= input("package") %>
+  <% end -%>
 <% elsif package_manager == 'apt' -%>
   <%-
     action = 'install' if action == 'group install'


### PR DESCRIPTION
Allows the package action template to generate something like:

```
#!/bin/bash

# Helper function that exits with a particular message and code.
#
# Usage:
#   exit_with_message "Could not do a thing" 2
#
exit_with_message () {
  echo "${1}, exiting..."
  exit $2
}




# Action
      yum --transient -y  install walrus
  RETVAL=$?
[ $RETVAL -eq 0 ] || exit_with_message "Package action failed" $RETVAL
```

If the host responds to the `yum_or_yum_transient` method being proposed by https://github.com/Katello/katello/pull/11374, Katello will detect if the host is a bootc host or not and apply the `--transient` flag appropriately.

Questions:
- Is the whitespace caused by the indentation in the nested if-statement an issue?
- Are there any other changes that could potentially be relevant in this repository?

I'm marking this as a draft until the Katello PR is merged. Feedback is welcome and could help shape the Katello PR.