### PR TITLE
Fixes #38428 - don't add extra column header for table row expansion

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationConstants.js
+++ b/webpack/JobInvocationDetail/JobInvocationConstants.js
@@ -82,11 +82,6 @@ const Columns = () => {
   const hostDetailsPageUrl = useForemanHostDetailsPageUrl();
 
   return {
-    expand: {
-      title: '',
-      weight: 0,
-      wrapper: () => null,
-    },
     name: {
       title: __('Name'),
       wrapper: ({ name }) => (

--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -262,7 +262,7 @@ const JobInvocationHostTable = ({
                     expandId: 'host-expandable',
                   }}
                 />
-                {columnNamesKeys.slice(1).map(k => (
+                {columnNamesKeys.map(k => (
                   <Td key={k}>{columns[k].wrapper(result)}</Td>
                 ))}
                 <Td isActionCell>
@@ -275,7 +275,7 @@ const JobInvocationHostTable = ({
               >
                 <Td
                   dataLabel={`${result.id}-expandable-content`}
-                  colSpan={columnNamesKeys.length + 1}
+                  colSpan={columnNamesKeys.length}
                 >
                   <ExpandableRowContent>
                     {result.job_status === 'cancelled' ||


### PR DESCRIPTION
After https://github.com/theforeman/foreman/pull/10523 we no longer need to pass an extra column for the table row expansion.
