### PR TITLE
Fixes #38461 - Replace SSHExecutionProvider with ScriptExecutionProvider

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -363,7 +363,6 @@ Style/ClassEqualityComparison:
   Exclude:
     - 'app/helpers/job_invocations_chart_helper.rb'
     - 'app/helpers/remote_execution_helper.rb'
-    - 'app/models/ssh_execution_provider.rb'
 
 # Offense count: 2
 # Cop supports --auto-correct.
@@ -405,7 +404,6 @@ Style/FormatString:
     - 'app/lib/actions/remote_execution/run_hosts_job.rb'
     - 'app/models/job_invocation_composer.rb'
     - 'app/models/remote_execution_provider.rb'
-    - 'app/models/ssh_execution_provider.rb'
     - 'extra/cockpit/foreman-cockpit-session'
 
 # Offense count: 61

--- a/app/controllers/cockpit_controller.rb
+++ b/app/controllers/cockpit_controller.rb
@@ -2,7 +2,7 @@ class CockpitController < ApplicationController
   before_action :find_resource, :only => [:host_ssh_params]
 
   def host_ssh_params
-    render :json => SSHExecutionProvider.ssh_params(@host)
+    render :json => ScriptExecutionProvider.ssh_params(@host)
   end
 
   def redirect
@@ -10,7 +10,7 @@ class CockpitController < ApplicationController
 
     redir_url = URI.parse(params[:redirect_uri])
 
-    cockpit_url = SSHExecutionProvider.cockpit_url_for_host('')
+    cockpit_url = ScriptExecutionProvider.cockpit_url_for_host('')
     redir_url.query = if redir_url.hostname == URI.join(Setting[:foreman_url], cockpit_url).hostname
                         "access_token=#{request.session_options[:id]}"
                       else

--- a/app/helpers/hosts_extensions_helper.rb
+++ b/app/helpers/hosts_extensions_helper.rb
@@ -44,7 +44,7 @@ module HostsExtensionsHelper
   def web_console_button(host, *_args)
     return if !authorized_for(permission: 'cockpit_hosts', auth_object: host) || !can_execute_on_infrastructure_host?(host)
 
-    url = SSHExecutionProvider.cockpit_url_for_host(host.name)
+    url = ScriptExecutionProvider.cockpit_url_for_host(host.name)
     url ? link_to(_('Web Console'), url, :class => 'btn btn-default', :id => :'web-console-button', :target => '_new') : nil
   end
 

--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -47,7 +47,7 @@ module ForemanRemoteExecution
     end
 
     def cockpit_url
-      SSHExecutionProvider.cockpit_url_for_host(self.name)
+      ScriptExecutionProvider.cockpit_url_for_host(self.name)
     end
 
     def execution_status(options = {})

--- a/app/models/script_execution_provider.rb
+++ b/app/models/script_execution_provider.rb
@@ -40,7 +40,7 @@ class ScriptExecutionProvider < RemoteExecutionProvider
       proxy = proxy_for_cockpit(host)
       {
         :hostname => find_ip_or_hostname(host),
-        :proxy => proxy.class == Symbol ? proxy : proxy.url,
+        :proxy => proxy.instance_of?(Symbol) ? proxy : proxy.url,
         :ssh_user => ssh_user(host),
         :ssh_port => ssh_port(host),
         :ssh_password => ssh_password(host),
@@ -50,7 +50,7 @@ class ScriptExecutionProvider < RemoteExecutionProvider
     end
 
     def cockpit_url_for_host(host)
-      Setting[:remote_execution_cockpit_url] % { :host => host } if Setting[:remote_execution_cockpit_url].present?
+      format(Setting[:remote_execution_cockpit_url], host: host) if Setting[:remote_execution_cockpit_url].present?
     end
 
     def proxy_feature
@@ -76,5 +76,3 @@ class ScriptExecutionProvider < RemoteExecutionProvider
     end
   end
 end
-
-SSHExecutionProvider = ScriptExecutionProvider

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,6 +1,5 @@
 Rails.autoloaders.each do |autoloader|
   autoloader.inflector.inflect(
-    'ssh_execution_provider' => 'SSHExecutionProvider',
     'remote_execution_ssh' => 'RemoteExecutionSSH'
   )
 end

--- a/lib/foreman_remote_execution/engine.rb
+++ b/lib/foreman_remote_execution/engine.rb
@@ -71,10 +71,10 @@ module ForemanRemoteExecution
                 full_name: N_('Effective User')
               setting 'remote_execution_effective_user_method',
                 type: :string,
-                description: N_('What command should be used to switch to the effective user. One of %s') % ::SSHExecutionProvider::EFFECTIVE_USER_METHODS.inspect,
+                description: N_('What command should be used to switch to the effective user. One of %s') % ::ScriptExecutionProvider::EFFECTIVE_USER_METHODS.inspect,
                 default: 'sudo',
                 full_name: N_('Effective User Method'),
-                collection: proc { Hash[::SSHExecutionProvider::EFFECTIVE_USER_METHODS.map { |method| [method, method] }] }
+                collection: proc { Hash[::ScriptExecutionProvider::EFFECTIVE_USER_METHODS.map { |method| [method, method] }] }
               setting 'remote_execution_effective_user_password',
                 type: :string,
                 description: N_('Effective user password'),
@@ -328,7 +328,7 @@ module ForemanRemoteExecution
       require_dependency 'foreman_tasks/task'
       ForemanTasks::Task.include ForemanRemoteExecution::ForemanTasksTaskExtensions
       ForemanTasks::Cleaner.include ForemanRemoteExecution::ForemanTasksCleanerExtensions
-      RemoteExecutionProvider.register(:SSH, ::SSHExecutionProvider)
+      RemoteExecutionProvider.register(:SSH, ::ScriptExecutionProvider)
       RemoteExecutionProvider.register(:script, ::ScriptExecutionProvider)
 
       ForemanRemoteExecution.register_rex_feature

--- a/test/unit/actions/run_host_job_test.rb
+++ b/test/unit/actions/run_host_job_test.rb
@@ -10,7 +10,7 @@ module ForemanRemoteExecution
       let(:job_invocation) { FactoryBot.create(:job_invocation, :with_task) }
       let(:host) { job_invocation.template_invocations.first.host }
       let(:provider) do
-        provider = ::SSHExecutionProvider
+        provider = ::ScriptExecutionProvider
         provider.expects(:ssh_password).with(host).returns('sshpass')
         provider.expects(:effective_user_password).with(host).returns('sudopass')
         provider.expects(:ssh_key_passphrase).with(host).returns('keypass')


### PR DESCRIPTION
I was working in Katello and found that `reload!` from the console is broken (not returning `true`) for a number of reasons. One of them led to this plugin in relation to some aliasing that was introduced in #704 

The error was:

```
TypeError: superclass mismatch for class ScriptExecutionProvider
from /home/vagrant/foreman/.vendor/ruby/3.0.0/gems/foreman_remote_execution-16.0.3/app/models/ssh_execution_provider.rb:1:in `<main>'
```

This PR removes the `SSHExecutionProvider` constant while still providing 'ssh' as a provider by using `ScriptExecutionProvider` directly