### PR TITLE
Fixes #38468 - Reset HostProxyInvocations when rebuilding a host

### DIFF
--- a/app/models/concerns/foreman_remote_execution/host_extensions.rb
+++ b/app/models/concerns/foreman_remote_execution/host_extensions.rb
@@ -28,6 +28,8 @@ module ForemanRemoteExecution
           end
         }
 
+        after_build :reset_host_proxy_invocations
+
         def search_by_job_invocation(key, operator, value)
           if key == 'job_invocation.result'
             operator = operator == '=' ? 'IN' : 'NOT IN'
@@ -44,6 +46,10 @@ module ForemanRemoteExecution
           }
         end
       end
+    end
+
+    def reset_host_proxy_invocations
+      HostProxyInvocation.where(host_id: self.id).delete_all
     end
 
     def cockpit_url


### PR DESCRIPTION
Rebuilding a provisioned host in-place generates new host ssh keys, but does not reset the host-proxy mapping in the host_proxy_invocations table. As a result, the ssh keys are not pruned from the known hosts proxy file, and REX jobs won't succeed on the host because of the offending keys. Resetting host-proxy mapping solves this issue.