### PR TITLE
Fixes #38527 - Fix job template clone endpoint for locked templates

### DIFF
--- a/app/controllers/api/v2/job_templates_controller.rb
+++ b/app/controllers/api/v2/job_templates_controller.rb
@@ -108,9 +108,7 @@ module Api
       param :id, :identifier, :required => true
       param_group :job_template_clone, :as => :create
       def clone
-        @job_template = @job_template.clone
-        load_vars_from_template
-        @job_template.name = job_template_params[:name]
+        @job_template = @job_template.deep_clone(job_template_params[:name])
         process_response @job_template.save
       end
 

--- a/app/models/job_template.rb
+++ b/app/models/job_template.rb
@@ -129,6 +129,17 @@ class JobTemplate < ::Template
     end
   end
 
+  # Deep clone template with proper handling of locked status and taxonomies
+  def deep_clone(new_name)
+    dup.tap do |template|
+      template.name = new_name
+      template.locked = false
+      # Copy taxonomies
+      template.organizations = self.organizations
+      template.locations = self.locations
+    end
+  end
+
   def provider
     RemoteExecutionProvider.provider_for(provider_type)
   end


### PR DESCRIPTION
### Description:

- Use dup() instead of clone() to prevent locked status inheritance. 
- Add `deep_clone` method to handle taxonomies properly.