### PR TITLE
Fixes #37906 - move css import from vendor to foreman

### DIFF
--- a/webpack/react_app/components/TargetingHosts/TargetingHostsLabelsRow.scss
+++ b/webpack/react_app/components/TargetingHosts/TargetingHostsLabelsRow.scss
@@ -1,4 +1,4 @@
-@import '~@theforeman/vendor/scss/variables';
+@import 'foremanReact/common/variables';
 
 .tasks-labels-row {
   margin: 0;


### PR DESCRIPTION
css imports were moved in https://github.com/theforeman/foreman/pull/10345 already
and will break after https://github.com/theforeman/foreman/pull/10342 is merged.
This pr is only for the css import and can be merged now