### PR TITLE
Fixes #38632 - Update job search in rerun to use job ID directly

### DIFF
--- a/webpack/JobInvocationDetail/CheckboxesActions.js
+++ b/webpack/JobInvocationDetail/CheckboxesActions.js
@@ -28,7 +28,6 @@ import {
 } from './JobInvocationConstants';
 import {
   selectHasPermission,
-  selectItems,
   selectTaskCancelable,
 } from './JobInvocationSelectors';
 import OpenAllInvocationsModal, { PopupAlert } from './OpenAllInvocationsModal';
@@ -123,7 +122,7 @@ export const CheckboxesActions = ({
   const hasCancelPermission = useSelector(
     selectHasPermission('cancel_job_invocations')
   );
-  const jobSearchQuery = useSelector(selectItems)?.targeting?.search_query;
+  const jobSearchQuery = `job_invocation.id = ${jobID}`;
   const filterQuery =
     filter && filter !== 'all_statuses'
       ? ` and job_invocation.result = ${filter}`

--- a/webpack/JobInvocationDetail/__tests__/TableToolbarActions.test.js
+++ b/webpack/JobInvocationDetail/__tests__/TableToolbarActions.test.js
@@ -196,7 +196,7 @@ describe('TableToolbarActions', () => {
       const rerunLink = screen.getByRole('link', { name: /rerun/i });
       expect(rerunLink).toBeEnabled();
       const expectedHref = foremanUrl(
-        `/job_invocations/42/rerun?search=(name~*) AND ((id ^ (101, 102, 103)))`
+        `/job_invocations/42/rerun?search=(job_invocation.id = 42) AND ((id ^ (101, 102, 103)))`
       );
       expect(rerunLink).toHaveAttribute('href', expectedHref);
     });


### PR DESCRIPTION
in the job details table, when a user selects hosts and selects "rerun selected" the host query should include the job id to remove duplicate host entries in the job wizard.
Hopefully its a bug only in this one place 