### PR TITLE
Fixes #38636 - JobInvocationHostTable doesnt load the template with auto reload

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -23,7 +23,7 @@ import TableIndexPage from 'foremanReact/components/PF4/TableIndexPage/TableInde
 import { getControllerSearchProps } from 'foremanReact/constants';
 import { Icon } from 'patternfly-react';
 import PropTypes from 'prop-types';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useHistory } from 'react-router-dom';
 import URI from 'urijs';
@@ -45,6 +45,7 @@ const JobInvocationHostTable = ({
   id,
   initialFilter,
   onFilterUpdate,
+  statusLabel,
   targeting,
 }) => {
   const columns = Columns();
@@ -53,6 +54,7 @@ const JobInvocationHostTable = ({
   const history = useHistory();
   const [selectedFilter, setSelectedFilter] = useState(initialFilter);
   const [expandedHost, setExpandedHost] = useState([]);
+  const prevStatusLabel = useRef(statusLabel);
 
   useEffect(() => {
     if (initialFilter !== selectedFilter) {
@@ -137,6 +139,14 @@ const JobInvocationHostTable = ({
       setAllPagesResponse(allResponse.results);
     }
   }, [allResponse]);
+
+  useEffect(() => {
+    if (statusLabel !== prevStatusLabel.current) {
+      setAPIOptions(prevOptions => ({ ...prevOptions }));
+      prevStatusLabel.current = statusLabel;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusLabel]);
 
   const {
     updateSearchQuery: updateSearchQueryBulk,
@@ -408,6 +418,7 @@ const JobInvocationHostTable = ({
                       </div>
                     ) : (
                       <TemplateInvocation
+                        key={`${result.id}-${result.job_status}`}
                         hostID={result.id}
                         jobID={id}
                         isInTableView
@@ -430,11 +441,13 @@ JobInvocationHostTable.propTypes = {
   targeting: PropTypes.object.isRequired,
   failedCount: PropTypes.number.isRequired,
   initialFilter: PropTypes.string.isRequired,
+  statusLabel: PropTypes.string,
   onFilterUpdate: PropTypes.func,
 };
 
 JobInvocationHostTable.defaultProps = {
   onFilterUpdate: () => {},
+  statusLabel: undefined,
 };
 
 export default JobInvocationHostTable;

--- a/webpack/JobInvocationDetail/TemplateInvocationPage.js
+++ b/webpack/JobInvocationDetail/TemplateInvocationPage.js
@@ -36,6 +36,7 @@ const TemplateInvocationPage = ({
         hostID={hostID}
         jobID={jobID}
         isInTableView={false}
+        isExpanded
         hostName={hostName}
         hostProxy={hostProxy}
       />

--- a/webpack/JobInvocationDetail/__tests__/TemplateInvocation.test.js
+++ b/webpack/JobInvocationDetail/__tests__/TemplateInvocation.test.js
@@ -32,6 +32,7 @@ describe('TemplateInvocation', () => {
           hostID="1"
           jobID="1"
           isInTableView={false}
+          isExpanded
           hostName="example-host"
           hostProxy={{ name: 'example-proxy', href: '#' }}
         />
@@ -54,6 +55,7 @@ describe('TemplateInvocation', () => {
           hostID="1"
           jobID="1"
           isInTableView={false}
+          isExpanded
           hostName="example-host"
           hostProxy={{ name: 'example-proxy', href: '#' }}
         />
@@ -108,6 +110,7 @@ describe('TemplateInvocation', () => {
           hostID="1"
           jobID="1"
           isInTableView={false}
+          isExpanded
           hostName="example-host"
           hostProxy={{ name: 'example-proxy', href: '#' }}
         />
@@ -133,6 +136,7 @@ describe('TemplateInvocation', () => {
           hostID="1"
           jobID="1"
           isInTableView={false}
+          isExpanded
           hostName="example-host"
         />
       </Provider>

--- a/webpack/JobInvocationDetail/index.js
+++ b/webpack/JobInvocationDetail/index.js
@@ -183,9 +183,9 @@ const JobInvocationDetailPage = ({
             id={id}
             targeting={targeting}
             failedCount={failed}
-            finished={finished}
             autoRefresh={autoRefresh}
             initialFilter={selectedFilter}
+            statusLabel={statusLabel}
             onFilterUpdate={handleFilterChange}
           />
         </SkeletonLoader>


### PR DESCRIPTION
The index page now passes `finished` to the `JobInvocationHostTable`, and a `useEffect` is added to refetch the data when `finished` becomes true. I'm not sure if it's the best solution, even though it works as expected, so I'm open to new ideas.