### PR TITLE
Fixes #38709 - Fix hosts job status stuck in "Pending"

### DIFF
--- a/webpack/JobInvocationDetail/index.js
+++ b/webpack/JobInvocationDetail/index.js
@@ -50,7 +50,7 @@ const JobInvocationDetailPage = ({
     statusLabel === STATUS.FAILED ||
     statusLabel === STATUS.SUCCEEDED ||
     statusLabel === STATUS.CANCELLED;
-  const autoRefresh = task?.state === STATUS.PENDING || false;
+  const autoRefresh = task?.state === 'running' || false;
   useAPI('get', currentPermissionsUrl, {
     key: CURRENT_PERMISSIONS,
   });
@@ -184,8 +184,13 @@ const JobInvocationDetailPage = ({
             targeting={targeting}
             failedCount={failed}
             autoRefresh={autoRefresh}
-            initialFilter={selectedFilter}
             statusLabel={statusLabel}
+            hostStatus={{
+              succeeded: items.succeeded,
+              failed: items.failed,
+              pending: items.pending,
+            }}
+            initialFilter={selectedFilter}
             onFilterUpdate={handleFilterChange}
           />
         </SkeletonLoader>


### PR DESCRIPTION
Fix hosts job status remaining "Pending" after completion

Testing steps:

1. Navigate to Monitor -> Jobs
2. Click on "Run Job" button
3. Job category -> Katello
4. Job template -> Install errata by search query - Katello Script Default
5. Filter the hosts and enter search query
6. Submit
7. Once the job completes successfully, the status should be updated accordingly (e.g., to "Success" or "Completed") for all associated hosts mentioned in the table.