### PR TITLE
Fixes #38773 - Add breadcrumb navigation to job invocation page

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -197,7 +197,7 @@ const JobInvocationHostTable = ({
       filterApiCall();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialFilter, statusLabel]);
+  }, [initialFilter, statusLabel, id]);
 
   const {
     updateSearchQuery: updateSearchQueryBulk,

--- a/webpack/JobInvocationDetail/__tests__/MainInformation.test.js
+++ b/webpack/JobInvocationDetail/__tests__/MainInformation.test.js
@@ -83,6 +83,7 @@ jest.mock('../JobInvocationHostTable.js', () => () => (
 const reportTemplateJobId = mockReportTemplatesResponse.results[0].id;
 
 const mockStore = configureMockStore([thunk]);
+const props = { history: { push: jest.fn() } };
 
 describe('JobInvocationDetailPage', () => {
   it('renders main information', async () => {
@@ -91,7 +92,10 @@ describe('JobInvocationDetailPage', () => {
 
     const { container } = render(
       <Provider store={store}>
-        <JobInvocationDetailPage match={{ params: { id: `${jobId}` } }} />
+        <JobInvocationDetailPage
+          match={{ params: { id: `${jobId}` } }}
+          {...props}
+        />
       </Provider>
     );
 
@@ -185,6 +189,7 @@ describe('JobInvocationDetailPage', () => {
       <Provider store={store}>
         <JobInvocationDetailPage
           match={{ params: { id: `${jobInvocationDataScheduled.id}` } }}
+          {...props}
         />
       </Provider>
     );
@@ -201,7 +206,10 @@ describe('JobInvocationDetailPage', () => {
     const store = mockStore(jobInvocationDataRecurring);
     render(
       <Provider store={store}>
-        <JobInvocationDetailPage match={{ params: { id: `${jobId}` } }} />
+        <JobInvocationDetailPage
+          match={{ params: { id: `${jobId}` } }}
+          {...props}
+        />
       </Provider>
     );
 

--- a/webpack/JobInvocationDetail/index.js
+++ b/webpack/JobInvocationDetail/index.js
@@ -35,6 +35,7 @@ const JobInvocationDetailPage = ({
   match: {
     params: { id },
   },
+  history,
 }) => {
   const dispatch = useDispatch();
   const items = useSelector(selectItems);
@@ -94,6 +95,16 @@ const JobInvocationDetailPage = ({
       : STATUS_UPPERCASE.RESOLVED;
 
   const breadcrumbOptions = {
+    isSwitchable: true,
+    onSwitcherItemClick: (e, href) => {
+      e.preventDefault();
+      history.push(href);
+    },
+    resource: {
+      nameField: 'description',
+      resourceUrl: '/api/v2/job_invocations',
+      switcherItemUrl: '/job_invocations/:id',
+    },
     breadcrumbItems: [
       { caption: __('Jobs'), url: `/job_invocations` },
       {
@@ -199,6 +210,7 @@ JobInvocationDetailPage.propTypes = {
       id: PropTypes.string.isRequired,
     }),
   }).isRequired,
+  history: PropTypes.object.isRequired,
 };
 
 export default JobInvocationDetailPage;


### PR DESCRIPTION
Enables users to switch between adjacent jobs while maintaining context. Updates job details, data table, and charts dynamically when navigating.

Fixes: ac66cfb (Fixes #38599 - Sort out the loading of the new job invocation page)