### PR TITLE
Fixes #38785 - Align docs links with core's documentation versions

### DIFF
--- a/app/helpers/remote_execution_helper.rb
+++ b/app/helpers/remote_execution_helper.rb
@@ -54,7 +54,7 @@ module RemoteExecutionHelper
 
   def job_invocations_buttons
     [
-      documentation_button_rex('3.2ExecutingaJob'),
+      documentation_button('Managing_Hosts', type: 'docs', chapter: 'executing-a-remote-job_managing-hosts'),
       authorized_for(controller: :job_invocations, action: :create) ? link_to(_('Run Job'), hash_for_new_job_invocation_path, {:class => "btn btn-primary"}) : '',
     ]
   end
@@ -205,12 +205,6 @@ module RemoteExecutionHelper
       content_tag :span, (time > Time.now.utc ? _('in %s') : _('%s ago')) % time_ago_in_words(time),
         { :'data-original-title' => time.try(:in_time_zone), :rel => 'twipsy' }
     end
-  end
-
-  def documentation_button_rex(section = '')
-    url = 'http://theforeman.org/plugins/foreman_remote_execution/' +
-      "#{ForemanRemoteExecution::VERSION.split('.').take(2).join('.')}/index.html#"
-    documentation_button section, :root_url => url
   end
 
   def description_checkbox_f(f, job_template, disabled)

--- a/app/views/job_templates/index.html.erb
+++ b/app/views/job_templates/index.html.erb
@@ -2,7 +2,7 @@
 <%= javascript 'foreman_remote_execution/template_input' %>
 
 <% title _("Job Templates") %>
-<% title_actions(documentation_button_rex('3.1JobTemplates'),
+<% title_actions(documentation_button('Managing_Hosts', type: 'docs', chapter: 'creating-a-job-template_managing-hosts'),
                  link_to_function(_('Import'), 'show_import_job_template_modal();', :class => 'btn btn-default'),
                  new_link(_("New Job Template"))) %>
 


### PR DESCRIPTION
**Acceptance Criteria**

Links are adjusted to core docs.

- [ ] Monitor -> Jobs -> link (path: `/job_invocations`)
  - [ ] empty list: Learn more about this in the documentation link
  - [ ] non-empty list: Documentation button
- [ ] Hosts -> Templates -> Job Templates -> link (path: `/job_templates`)
  - [ ] non-empty list: Documentation button

Removes use of :root_url in favor of foreman's core docs params.

Fixes df6ffa2 (Fixes #14560 - Reuse foreman's core documentation helper. (#171))