### PR TITLE
Fixes #38811 - Fix position of the overview on the job invocation page

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationDetail.scss
+++ b/webpack/JobInvocationDetail/JobInvocationDetail.scss
@@ -2,6 +2,8 @@
   $chart_size: 105px;
   padding-top: 0px;
   padding-left: 10px;
+  display: flex;
+  align-items: center;
 
   .chart-donut {
     height: $chart_size;
@@ -47,10 +49,10 @@
   .pf-v5-c-divider {
     max-height: $chart_size;
   }
+}
 
-  .job-overview {
-    height: $chart_size;
-  }
+.job-invocation-detail-flex .job-overview-description-list {
+  margin: 0;
 }
 
 .job-additional-info {

--- a/webpack/JobInvocationDetail/JobInvocationOverview.js
+++ b/webpack/JobInvocationDetail/JobInvocationOverview.js
@@ -28,6 +28,7 @@ const JobInvocationOverview = ({
 
   return (
     <DescriptionList
+      className="job-overview-description-list"
       columnModifier={{
         default: '2Col',
       }}

--- a/webpack/JobInvocationDetail/index.js
+++ b/webpack/JobInvocationDetail/index.js
@@ -127,10 +127,7 @@ const JobInvocationDetailPage = ({
         toolbarButtons={<JobInvocationToolbarButtons jobId={id} data={items} />}
         searchable={false}
       >
-        <Flex
-          className="job-invocation-detail-flex"
-          alignItems={{ default: 'alignItemsFlexStart' }}
-        >
+        <Flex className="job-invocation-detail-flex">
           <SkeletonLoader
             status={pageStatus}
             skeletonProps={{
@@ -150,24 +147,19 @@ const JobInvocationDetailPage = ({
               default: 'vertical',
             }}
           />
-          <Flex
-            className="job-overview"
-            alignItems={{ default: 'alignItemsCenter' }}
+          <SkeletonLoader
+            status={pageStatus}
+            skeletonProps={{
+              height: 105,
+              width: 270,
+            }}
           >
-            <SkeletonLoader
-              status={pageStatus}
-              skeletonProps={{
-                height: 105,
-                width: 270,
-              }}
-            >
-              <JobInvocationOverview
-                data={items}
-                isAlreadyStarted={isAlreadyStarted}
-                formattedStartDate={formattedStartDate}
-              />
-            </SkeletonLoader>
-          </Flex>
+            <JobInvocationOverview
+              data={items}
+              isAlreadyStarted={isAlreadyStarted}
+              formattedStartDate={formattedStartDate}
+            />
+          </SkeletonLoader>
         </Flex>
         <PageSection
           variant={PageSectionVariants.light}


### PR DESCRIPTION
Before:
<img width="895" height="162" alt="image" src="https://github.com/user-attachments/assets/9099fbdf-c4e8-4800-a920-d8ad8de64c03" />

After:
<img width="739" height="119" alt="image" src="https://github.com/user-attachments/assets/bc3479c4-acac-4dfe-bd67-a2af848ce187" />
