### PR TITLE
Fixes #39247 - render colour formatting in job details output

### DIFF
--- a/webpack/JobInvocationDetail/TemplateInvocationComponents/OutputCodeBlock.js
+++ b/webpack/JobInvocationDetail/TemplateInvocationComponents/OutputCodeBlock.js
@@ -11,7 +11,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 export const OutputCodeBlock = ({ code, showOutputType, scrollElement }) => {
   let lineCounter = 0;
   // eslint-disable-next-line no-control-regex
-  const COLOR_PATTERN = /\x1b\[(\d+)m/g;
+  const COLOR_PATTERN = /\x1b\[[\d;]*m/g;
   const CONSOLE_COLOR = {
     '31': 'red',
     '32': 'lightgreen',
@@ -27,12 +27,15 @@ export const OutputCodeBlock = ({ code, showOutputType, scrollElement }) => {
     '95': 'violet',
     '96': 'turquoise',
     '0': 'default',
+    '39': 'default',
   };
 
   const colorizeLine = line => {
     line = line.replace(COLOR_PATTERN, seq => {
-      const color = seq.match(/(\d+)m/)[1];
-      return `{{{format color:${color}}}}`;
+      const codes = seq.match(/(\d+)/g) || [];
+      const lastColorCode =
+        [...codes].reverse().find(code_ => code_ in CONSOLE_COLOR) || '0';
+      return `{{{format color:${lastColorCode}}}}`;
     });
 
     let currentColor = 'default';

--- a/webpack/JobInvocationDetail/__tests__/OutputCodeBlock.test.js
+++ b/webpack/JobInvocationDetail/__tests__/OutputCodeBlock.test.js
@@ -31,6 +31,7 @@ describe('OutputCodeBlock', () => {
     expect(screen.getByText('This is green text')).toHaveStyle(
       'color: lightgreen'
     );
+    expect(screen.getByText('Compound red text')).toHaveStyle('color: red');
   });
 
   test('displays no output message when filtered', () => {

--- a/webpack/JobInvocationDetail/__tests__/fixtures.js
+++ b/webpack/JobInvocationDetail/__tests__/fixtures.js
@@ -197,6 +197,15 @@ export const jobInvocationOutput = [
   },
 
   {
+    id: 1960,
+    template_invocation_id: templateInvocationID,
+    timestamp: 1733931149.2044532,
+    meta: null,
+    external_id: '0',
+    output_type: 'stdout',
+    output: '\u001b[0;31mCompound red text\u001b[0m\n',
+  },
+  {
     id: 1907,
     template_invocation_id: templateInvocationID,
     timestamp: 1718719863.184878,


### PR DESCRIPTION
Issue: The Job invocation detail page fails to parse shell color codes in REX outputs. This is a regression from the legacy UI. Large logs become illegible.

Steps to Reproduce:

Execute a job using a bash script that outputs color codes (`echo -e "\033[0;31mError\033[0m"`).
View the job output in the new job invocation detail page.

AI assisted fix. 

Two changes:

Regex — changed from `/\x1b\[(\d+)m/g` to `/\x1b\[[\d;]*m/g` so it matches sequences with semicolons (e.g. `\x1b[0;31m`).

Color extraction — instead of grabbing a single (\d+), it now extracts all numeric codes from the sequence and picks the last one that maps to a known color. For 0;31, that's 31 (red). This matches the Ruby helper's behavior.