### PR TITLE
Fixes #39344 - No error toast is shown when API call fails

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationActions.js
+++ b/webpack/JobInvocationDetail/JobInvocationActions.js
@@ -24,6 +24,13 @@ export const getJobInvocation = url => dispatch => {
       handleError: () => {
         dispatch(stopInterval(JOB_INVOCATION_KEY));
       },
+      errorToast: ({ response }) =>
+        // eslint-disable-next-line camelcase
+        response?.data?.error?.full_messages?.[0] ||
+        // eslint-disable-next-line camelcase
+        response?.data?.error?.full_messages ||
+        response?.data?.error?.message ||
+        'Error',
     }),
     1000
   );


### PR DESCRIPTION
When server returns err 500 not toast is shown and skeleton loading continues.