### PR TITLE
Stop serializing all hosts and template invocations in job invocation

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -19,14 +19,10 @@ module Api
 
       api :GET, '/job_invocations/:id', N_('Show job invocation')
       param :id, :identifier, :required => true
-      param :host_status, :bool, required: false, desc: N_('Show Job status for the hosts')
       def show
-        set_hosts_and_template_invocations
+        @pattern_template_invocations = @job_invocation.pattern_template_invocations.includes(:input_values)
         @job_organization = Taxonomy.find_by(id: @job_invocation.task.input[:current_organization_id])
         @job_location = Taxonomy.find_by(id: @job_invocation.task.input[:current_location_id])
-        if params[:host_status] == 'true'
-          set_statuses_and_smart_proxies
-        end
       end
 
       def_param_group :job_invocation do

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -8,6 +8,7 @@ module Api
       before_action :find_optional_nested_object, :only => %w{output raw_output}
       before_action :find_host, :only => %w{output raw_output}
       before_action :find_resource, :only => %w{show update destroy clone cancel rerun outputs hosts}
+      before_action :find_pattern_template_invocations, :only => %w{show hosts}
 
       wrap_parameters JobInvocation, :include => (JobInvocation.attribute_names + [:ssh])
 
@@ -20,7 +21,6 @@ module Api
       api :GET, '/job_invocations/:id', N_('Show job invocation')
       param :id, :identifier, :required => true
       def show
-        @pattern_template_invocations = @job_invocation.pattern_template_invocations.includes(:input_values)
         @job_organization = Taxonomy.find_by(id: @job_invocation.task.input[:current_organization_id])
         @job_location = Taxonomy.find_by(id: @job_invocation.task.input[:current_location_id])
       end
@@ -86,7 +86,6 @@ module Api
         )
         composer.trigger!
         @job_invocation = composer.job_invocation
-        @hosts = @job_invocation.targeting.hosts
         process_response @job_invocation
       rescue JobInvocationComposer::JobTemplateNotFound, JobInvocationComposer::FeatureNotFound => e
         not_found(error: { message: e.message })
@@ -293,8 +292,11 @@ module Api
         resource_class.where(nil)
       end
 
-      def set_hosts_and_template_invocations
+      def find_pattern_template_invocations
         @pattern_template_invocations = @job_invocation.pattern_template_invocations.includes(:input_values)
+      end
+
+      def set_hosts_and_template_invocations
         @hosts = @job_invocation.targeting.hosts.authorized(:view_hosts, Host)
 
         if params[:search].present?

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -19,7 +19,7 @@ module Api
 
       api :GET, '/job_invocations/:id', N_('Show job invocation')
       param :id, :identifier, :required => true
-      param :include_hosts, :bool, :required => false, :default_value => true, :desc => N_('Include hosts and template invocations in the response. Defaults to true for backwards compatibility, pass false to skip serializing all hosts.')
+      param :include_hosts, :bool, :required => false, :default_value => true, :desc => N_('Include hosts and template invocations in the response. Defaults to true for backwards compatibility. Pass false to skip serializing all hosts.')
       param :host_status, :bool, :required => false, :default_value => false, :desc => N_('Show job status for each host, only applicable when include_hosts is true')
       def show
         @pattern_template_invocations = @job_invocation.pattern_template_invocations.includes(:input_values)
@@ -87,7 +87,7 @@ module Api
 
       api :POST, '/job_invocations/', N_('Create a job invocation')
       param_group :job_invocation, :as => :create
-      param :include_hosts, :bool, :required => false, :default_value => true, :desc => N_('Include hosts and template invocations in the response. Defaults to true for backwards compatibility, pass false to skip serializing all hosts.')
+      param :include_hosts, :bool, :required => false, :default_value => true, :desc => N_('Include hosts and template invocations in the response. Defaults to true for backwards compatibility. Pass false to skip serializing all hosts.')
       def create
         composer = JobInvocationComposer.from_api_params(
           job_invocation_params

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -26,7 +26,7 @@ module Api
         @job_organization = Taxonomy.find_by(id: @job_invocation.task.input[:current_organization_id])
         @job_location = Taxonomy.find_by(id: @job_invocation.task.input[:current_location_id])
 
-        if params[:include_hosts].nil? || Foreman::Cast.to_bool(params[:include_hosts])
+        if include_hosts?
           set_hosts_and_template_invocations
           set_statuses_and_smart_proxies if Foreman::Cast.to_bool(params[:host_status])
         end
@@ -94,7 +94,7 @@ module Api
         )
         composer.trigger!
         @job_invocation = composer.job_invocation
-        set_hosts_and_template_invocations if params[:include_hosts].nil? || Foreman::Cast.to_bool(params[:include_hosts])
+        set_hosts_and_template_invocations if include_hosts?
         process_response @job_invocation
       rescue JobInvocationComposer::JobTemplateNotFound, JobInvocationComposer::FeatureNotFound => e
         not_found(error: { message: e.message })
@@ -311,6 +311,10 @@ module Api
         @template_invocations = @job_invocation.template_invocations
                                                .where(host: @hosts)
                                                .includes(:input_values)
+      end
+
+      def include_hosts?
+        params[:include_hosts].nil? || Foreman::Cast.to_bool(params[:include_hosts])
       end
 
       def set_statuses_and_smart_proxies

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -8,7 +8,6 @@ module Api
       before_action :find_optional_nested_object, :only => %w{output raw_output}
       before_action :find_host, :only => %w{output raw_output}
       before_action :find_resource, :only => %w{show update destroy clone cancel rerun outputs hosts}
-      before_action :find_pattern_template_invocations, :only => %w{show hosts}
 
       wrap_parameters JobInvocation, :include => (JobInvocation.attribute_names + [:ssh])
 
@@ -21,6 +20,7 @@ module Api
       api :GET, '/job_invocations/:id', N_('Show job invocation')
       param :id, :identifier, :required => true
       def show
+        @pattern_template_invocations = @job_invocation.pattern_template_invocations.includes(:input_values)
         @job_organization = Taxonomy.find_by(id: @job_invocation.task.input[:current_organization_id])
         @job_location = Taxonomy.find_by(id: @job_invocation.task.input[:current_location_id])
       end
@@ -290,10 +290,6 @@ module Api
       # Do not try to scope JobInvocations by taxonomies
       def parent_scope
         resource_class.where(nil)
-      end
-
-      def find_pattern_template_invocations
-        @pattern_template_invocations = @job_invocation.pattern_template_invocations.includes(:input_values)
       end
 
       def set_hosts_and_template_invocations

--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -19,10 +19,17 @@ module Api
 
       api :GET, '/job_invocations/:id', N_('Show job invocation')
       param :id, :identifier, :required => true
+      param :include_hosts, :bool, :required => false, :default_value => true, :desc => N_('Include hosts and template invocations in the response. Defaults to true for backwards compatibility, pass false to skip serializing all hosts.')
+      param :host_status, :bool, :required => false, :default_value => false, :desc => N_('Show job status for each host, only applicable when include_hosts is true')
       def show
         @pattern_template_invocations = @job_invocation.pattern_template_invocations.includes(:input_values)
         @job_organization = Taxonomy.find_by(id: @job_invocation.task.input[:current_organization_id])
         @job_location = Taxonomy.find_by(id: @job_invocation.task.input[:current_location_id])
+
+        if params[:include_hosts].nil? || Foreman::Cast.to_bool(params[:include_hosts])
+          set_hosts_and_template_invocations
+          set_statuses_and_smart_proxies if Foreman::Cast.to_bool(params[:host_status])
+        end
       end
 
       def_param_group :job_invocation do
@@ -80,12 +87,14 @@ module Api
 
       api :POST, '/job_invocations/', N_('Create a job invocation')
       param_group :job_invocation, :as => :create
+      param :include_hosts, :bool, :required => false, :default_value => true, :desc => N_('Include hosts and template invocations in the response. Defaults to true for backwards compatibility, pass false to skip serializing all hosts.')
       def create
         composer = JobInvocationComposer.from_api_params(
           job_invocation_params
         )
         composer.trigger!
         @job_invocation = composer.job_invocation
+        set_hosts_and_template_invocations if params[:include_hosts].nil? || Foreman::Cast.to_bool(params[:include_hosts])
         process_response @job_invocation
       rescue JobInvocationComposer::JobTemplateNotFound, JobInvocationComposer::FeatureNotFound => e
         not_found(error: { message: e.message })

--- a/app/views/api/v2/job_invocations/main.json.rabl
+++ b/app/views/api/v2/job_invocations/main.json.rabl
@@ -18,28 +18,8 @@ end
 child :targeting do
   attributes :bookmark_id, :bookmark_name, :search_query, :targeting_type, :user_id, :status, :status_label,
     :randomized_ordering
-
-  child @hosts => :hosts do
-    extends 'api/v2/hosts/base'
-
-    if params[:host_status] == 'true'
-      node :job_status do |host|
-        @host_statuses[host.id]
-      end
-    end
-  end
 end
 
 child :task do
   attributes :id, :state, :started_at
-end
-
-child @template_invocations do
-  attributes :template_id, :template_name, :host_id
-  child :input_values do
-    attributes :template_input_name, :template_input_id
-    node :value do |iv|
-      iv.template_input.respond_to?(:hidden_value) && iv.template_input.hidden_value? ? '*' * 5 : iv.value
-    end
-  end
 end

--- a/app/views/api/v2/job_invocations/main.json.rabl
+++ b/app/views/api/v2/job_invocations/main.json.rabl
@@ -18,8 +18,32 @@ end
 child :targeting do
   attributes :bookmark_id, :bookmark_name, :search_query, :targeting_type, :user_id, :status, :status_label,
     :randomized_ordering
+
+  if @hosts
+    child @hosts => :hosts do
+      extends 'api/v2/hosts/base'
+
+      if @host_statuses
+        node :job_status do |host|
+          @host_statuses[host.id]
+        end
+      end
+    end
+  end
 end
 
 child :task do
   attributes :id, :state, :started_at
+end
+
+if @template_invocations
+  child @template_invocations => :template_invocations do
+    attributes :template_id, :template_name, :host_id
+    child :input_values do
+      attributes :template_input_name, :template_input_id
+      node :value do |iv|
+        iv.template_input.respond_to?(:hidden_value) && iv.template_input.hidden_value? ? '*' * 5 : iv.value
+      end
+    end
+  end
 end

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -27,25 +27,13 @@ module Api
           template = ActiveSupport::JSON.decode(@response.body)
           assert_not_empty template
           assert_equal template['job_category'], @invocation.job_category
-          assert_not_empty template['targeting']['hosts']
+          assert_not_nil template['targeting']
         end
 
         test 'should get invocation detail when taxonomies are set' do
           taxonomy_params = %w(organization location).reduce({}) { |acc, cur| acc.merge("#{cur}_id" => FactoryBot.create(cur)) }
           get :show, params: taxonomy_params.merge(:id => @invocation.id)
           assert_response :success
-        end
-
-        test 'should see only permitted hosts' do
-          @user = FactoryBot.create(:user, admin: false)
-          @invocation.task.update(user: @user)
-          setup_user('view', 'job_invocations', nil, @user)
-          setup_user('view', 'hosts', 'name ~ nope.example.com', @user)
-
-          get :show, params: { :id => @invocation.id }, session: prepare_user(@user)
-          assert_response :success
-          response = ActiveSupport::JSON.decode(@response.body)
-          assert_equal response['targeting']['hosts'], []
         end
       end
 

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -36,6 +36,22 @@ module Api
           get :show, params: taxonomy_params.merge(:id => @invocation.id)
           assert_response :success
         end
+
+        test 'should include hosts by default' do
+          get :show, params: { :id => @invocation.id }
+          assert_response :success
+          result = ActiveSupport::JSON.decode(@response.body)
+          assert_not_nil result['targeting']['hosts']
+          assert_not_nil result['template_invocations']
+        end
+
+        test 'should exclude hosts when include_hosts=false' do
+          get :show, params: { :id => @invocation.id, :include_hosts => false }
+          assert_response :success
+          result = ActiveSupport::JSON.decode(@response.body)
+          assert_nil result['targeting']['hosts']
+          assert_nil result['template_invocations']
+        end
       end
 
       context 'creation' do
@@ -52,6 +68,20 @@ module Api
 
           invocation = ActiveSupport::JSON.decode(@response.body)
           assert_equal @attrs[:job_category], invocation['job_category']
+          assert_response :success
+        end
+
+        test 'should include hosts in create response by default' do
+          post :create, params: { job_invocation: @attrs }
+          invocation = ActiveSupport::JSON.decode(@response.body)
+          assert_not_nil invocation['targeting']['hosts']
+          assert_response :success
+        end
+
+        test 'should exclude hosts from create response when include_hosts=false' do
+          post :create, params: { job_invocation: @attrs, include_hosts: false }
+          invocation = ActiveSupport::JSON.decode(@response.body)
+          assert_nil invocation['targeting']['hosts']
           assert_response :success
         end
 

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -29,6 +29,8 @@ module Api
           assert_equal template['job_category'], @invocation.job_category
           assert_not_nil template['targeting']
           assert_not_empty template['pattern_template_invocations']
+          assert_not_nil template['targeting']['hosts']
+          assert_not_nil template['template_invocations']
         end
 
         test 'should get invocation detail when taxonomies are set' do
@@ -37,20 +39,47 @@ module Api
           assert_response :success
         end
 
-        test 'should include hosts by default' do
-          get :show, params: { :id => @invocation.id }
-          assert_response :success
-          result = ActiveSupport::JSON.decode(@response.body)
-          assert_not_nil result['targeting']['hosts']
-          assert_not_nil result['template_invocations']
-        end
-
         test 'should exclude hosts when include_hosts=false' do
           get :show, params: { :id => @invocation.id, :include_hosts => false }
           assert_response :success
           result = ActiveSupport::JSON.decode(@response.body)
           assert_nil result['targeting']['hosts']
           assert_nil result['template_invocations']
+        end
+
+        test 'should see only permitted hosts' do
+          @user = FactoryBot.create(:user, :admin => false)
+          @invocation.task.update(:user => @user)
+          setup_user('view', 'job_invocations', nil, @user)
+          setup_user('view', 'hosts', 'name ~ nope.example.com', @user)
+
+          get :show, params: { :id => @invocation.id }, session: prepare_user(@user)
+          assert_response :success
+          response = ActiveSupport::JSON.decode(@response.body)
+          assert_equal response['targeting']['hosts'], []
+        end
+
+        test 'should ignore host_status when include_hosts=false' do
+          get :show, params: { :id => @invocation.id, :include_hosts => false, :host_status => true }
+          assert_response :success
+          result = ActiveSupport::JSON.decode(@response.body)
+          assert_nil result['targeting']['hosts']
+          assert_nil result['template_invocations']
+        end
+
+        test 'should include job_status per host when host_status=true' do
+          invocation = FactoryBot.create(:job_invocation, :with_template, :with_task)
+          invocation.template_invocations << FactoryBot.create(:template_invocation, :with_task, :with_host, :job_invocation => invocation)
+          invocation.job_category = invocation.pattern_template_invocations.first.template.job_category
+          invocation.targeting.hosts = invocation.template_invocations.map(&:host)
+          invocation.save!
+
+          get :show, params: { :id => invocation.id, :include_hosts => true, :host_status => true }
+          assert_response :success
+          result = ActiveSupport::JSON.decode(@response.body)
+          hosts = result['targeting']['hosts']
+          assert_not_empty hosts
+          assert hosts.all? { |h| h.key?('job_status') }, 'Expected job_status to be present on each host'
         end
       end
 

--- a/test/functional/api/v2/job_invocations_controller_test.rb
+++ b/test/functional/api/v2/job_invocations_controller_test.rb
@@ -28,6 +28,7 @@ module Api
           assert_not_empty template
           assert_equal template['job_category'], @invocation.job_category
           assert_not_nil template['targeting']
+          assert_not_empty template['pattern_template_invocations']
         end
 
         test 'should get invocation detail when taxonomies are set' do

--- a/webpack/JobInvocationDetail/JobInvocationActions.js
+++ b/webpack/JobInvocationDetail/JobInvocationActions.js
@@ -19,7 +19,7 @@ export const getJobInvocation = url => dispatch => {
   const fetchData = withInterval(
     get({
       key: JOB_INVOCATION_KEY,
-      params: { include_permissions: true },
+      params: { include_permissions: true, include_hosts: false },
       url,
       handleError: () => {
         dispatch(stopInterval(JOB_INVOCATION_KEY));
@@ -44,6 +44,7 @@ export const updateJob = jobId => dispatch => {
     APIActions.get({
       url,
       key: UPDATE_JOB,
+      params: { include_hosts: false },
     })
   );
 };


### PR DESCRIPTION
> The show endpoint serialized every host (via hosts/base) and every template invocation on each request, including the 1-second polling requests from the detail page. None of this data is used by the frontend — hosts are fetched separately by the host table, and per-host template invocations are fetched on row expand.

The biggest problem with this is that removing it changes a public api. To offer some alternatives, we could:
- add a parameter that would just disable the parts that I'm proposing to remove
- add a new endpoint, deprecate the old one and eventually remove it, but then we'd eventually end up with an oddly shaped api
