### PR TITLE
Fixes #39533 - "View task" disabled when job is running

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationActions.js
+++ b/webpack/JobInvocationDetail/JobInvocationActions.js
@@ -19,7 +19,7 @@ export const getJobInvocation = url => dispatch => {
   const fetchData = withInterval(
     get({
       key: JOB_INVOCATION_KEY,
-      params: { include_permissions: true, include_hosts: false },
+      params: { include_hosts: false },
       url,
       handleError: () => {
         dispatch(stopInterval(JOB_INVOCATION_KEY));

--- a/webpack/JobInvocationDetail/JobInvocationOverview.js
+++ b/webpack/JobInvocationDetail/JobInvocationOverview.js
@@ -8,6 +8,7 @@ import {
   DescriptionListDescription,
 } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { usePermissions } from 'foremanReact/common/hooks/Permissions/permissionHooks';
 import DefaultLoaderEmptyState from 'foremanReact/components/HostDetails/DetailsCard/DefaultLoaderEmptyState';
 
 const JobInvocationOverview = ({
@@ -20,11 +21,8 @@ const JobInvocationOverview = ({
     template_id: templateId,
     template_name: templateName,
     effective_user: effectiveUser,
-    permissions,
   } = data;
-  const canEditJobTemplates = permissions
-    ? permissions.edit_job_templates
-    : false;
+  const canEditJobTemplates = usePermissions(['edit_job_templates']);
 
   return (
     <DescriptionList

--- a/webpack/JobInvocationDetail/JobInvocationToolbarButtons.js
+++ b/webpack/JobInvocationDetail/JobInvocationToolbarButtons.js
@@ -28,15 +28,11 @@ import {
 import { selectTaskCancelable } from './JobInvocationSelectors';
 
 const JobInvocationToolbarButtons = ({ jobId, data }) => {
-  const { succeeded, failed, task, recurrence, permissions } = data;
+  const { succeeded, failed, task, recurrence } = data;
   const recurringEnabled = recurrence?.state === 'active';
-  const canViewForemanTasks = permissions
-    ? permissions.view_foreman_tasks
-    : false;
-  const canEditRecurringLogic = permissions
-    ? permissions.edit_recurring_logics
-    : false;
   const isTaskCancelable = useSelector(selectTaskCancelable);
+  const canViewForemanTasks = usePermissions(['view_foreman_tasks']);
+  const canEditRecurringLogic = usePermissions(['edit_recurring_logics']);
   const canCreateJobInvocations = usePermissions(['create_job_invocations']);
   const canCancelJobInvocations = usePermissions(['cancel_job_invocations']);
   const canGenerateReportTemplates = usePermissions([

--- a/webpack/JobInvocationDetail/TemplateInvocation.js
+++ b/webpack/JobInvocationDetail/TemplateInvocation.js
@@ -144,13 +144,7 @@ export const TemplateInvocation = ({
     );
   }
 
-  const {
-    preview,
-    output,
-    input_values: inputValues,
-    task,
-    permissions,
-  } = response;
+  const { preview, output, input_values: inputValues, task } = response;
   const { id: taskID, cancellable: taskCancellable } = task || {};
 
   return (
@@ -183,7 +177,6 @@ export const TemplateInvocation = ({
         jobID={jobID}
         hostID={hostID}
         taskCancellable={taskCancellable}
-        permissions={permissions}
       />
       {!isInTableView && (
         <>

--- a/webpack/JobInvocationDetail/TemplateInvocationComponents/OutputToggleGroup.js
+++ b/webpack/JobInvocationDetail/TemplateInvocationComponents/OutputToggleGroup.js
@@ -25,7 +25,6 @@ export const OutputToggleGroup = ({
   jobID,
   hostID,
   taskCancellable,
-  permissions,
 }) => {
   const handleSTDERRClick = useCallback(
     _isSelected => {
@@ -127,7 +126,6 @@ export const OutputToggleGroup = ({
           jobID={jobID}
           hostID={hostID}
           taskCancellable={taskCancellable}
-          permissions={permissions}
         />
       )}
       <FlexItem>{copyToClipboard}</FlexItem>

--- a/webpack/JobInvocationDetail/TemplateInvocationComponents/TemplateActionButtons.js
+++ b/webpack/JobInvocationDetail/TemplateInvocationComponents/TemplateActionButtons.js
@@ -6,6 +6,7 @@ import { ActionsColumn } from '@patternfly/react-table';
 import { APIActions } from 'foremanReact/redux/API';
 import { addToast } from 'foremanReact/components/ToastsList';
 import { translate as __ } from 'foremanReact/common/I18n';
+import { usePermissions } from 'foremanReact/common/hooks/Permissions/permissionHooks';
 import { selectTemplateInvocationList } from '../JobInvocationSelectors';
 import './index.scss';
 
@@ -14,7 +15,9 @@ const actions = ({
   jobID,
   hostID,
   taskCancellable,
-  permissions,
+  canExecuteJobs,
+  canViewForemanTasks,
+  canCancelJobInvocations,
   dispatch,
 }) => ({
   rerun: {
@@ -22,19 +25,19 @@ const actions = ({
     href: `/job_invocations/${jobID}/rerun?host_ids[]=${hostID}`,
     component: 'a',
     text: __('Rerun'),
-    permission: permissions.execute_jobs,
+    permission: canExecuteJobs,
   },
   details: {
     name: 'template-invocation-task-details',
     href: `/foreman_tasks/tasks/${taskID}`,
     component: 'a',
     text: __('Task Details'),
-    permission: permissions.view_foreman_tasks,
+    permission: canViewForemanTasks,
   },
   cancel: {
     name: 'template-invocation-cancel-job',
     text: __('Cancel Task'),
-    permission: permissions.cancel_job_invocations,
+    permission: canCancelJobInvocations,
     onClick: () => {
       dispatch(
         addToast({
@@ -58,7 +61,7 @@ const actions = ({
   abort: {
     name: 'template-invocation-abort-job',
     text: __('Abort task'),
-    permission: permissions.cancel_job_invocations,
+    permission: canCancelJobInvocations,
     onClick: () => {
       dispatch(
         addToast({
@@ -83,16 +86,21 @@ const actions = ({
 
 export const RowActions = ({ hostID, jobID }) => {
   const dispatch = useDispatch();
+  const canExecuteJobs = usePermissions(['execute_jobs']);
+  const canViewForemanTasks = usePermissions(['view_foreman_tasks']);
+  const canCancelJobInvocations = usePermissions(['cancel_job_invocations']);
   const response = useSelector(selectTemplateInvocationList)?.[hostID];
-  if (!response?.permissions) return null;
-  const { task, permissions } = response;
+  if (!response) return null;
+  const { task } = response;
   const { id: taskID, cancellable: taskCancellable } = task || {};
   const getActions = actions({
     taskID,
     jobID,
     hostID,
     taskCancellable,
-    permissions,
+    canExecuteJobs,
+    canViewForemanTasks,
+    canCancelJobInvocations,
     dispatch,
   });
 
@@ -117,15 +125,19 @@ export const TemplateActionButtons = ({
   jobID,
   hostID,
   taskCancellable,
-  permissions,
 }) => {
   const dispatch = useDispatch();
+  const canExecuteJobs = usePermissions(['execute_jobs']);
+  const canViewForemanTasks = usePermissions(['view_foreman_tasks']);
+  const canCancelJobInvocations = usePermissions(['cancel_job_invocations']);
   const { rerun, details, cancel, abort } = actions({
     taskID,
     jobID,
     hostID,
     taskCancellable,
-    permissions,
+    canExecuteJobs,
+    canViewForemanTasks,
+    canCancelJobInvocations,
     dispatch,
   });
   return (
@@ -196,21 +208,11 @@ TemplateActionButtons.propTypes = {
   jobID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   hostID: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   taskCancellable: PropTypes.bool,
-  permissions: PropTypes.shape({
-    view_foreman_tasks: PropTypes.bool,
-    cancel_job_invocations: PropTypes.bool,
-    execute_jobs: PropTypes.bool,
-  }),
 };
 
 TemplateActionButtons.defaultProps = {
   taskID: null,
   taskCancellable: false,
-  permissions: {
-    view_foreman_tasks: false,
-    cancel_job_invocations: false,
-    execute_jobs: false,
-  },
 };
 
 RowActions.propTypes = {

--- a/webpack/JobInvocationDetail/__tests__/TemplateInvocation.test.js
+++ b/webpack/JobInvocationDetail/__tests__/TemplateInvocation.test.js
@@ -195,11 +195,6 @@ describe('TemplateInvocation', () => {
     const responseWithCancellableTask = {
       ...mockTemplateInvocationResponse,
       task: { id: 'task-123', cancellable: true },
-      permissions: {
-        view_foreman_tasks: true,
-        cancel_job_invocations: true,
-        execute_jobs: true,
-      },
     };
 
     beforeEach(() => {

--- a/webpack/JobInvocationDetail/__tests__/fixtures.js
+++ b/webpack/JobInvocationDetail/__tests__/fixtures.js
@@ -132,12 +132,6 @@ export const jobInvocationDataRecurring = {
   targeting,
 };
 
-export const mockPermissionsData = {
-  edit_job_templates: true,
-  view_foreman_tasks: true,
-  edit_recurring_logics: true,
-};
-
 export const mockReportTemplatesResponse = {
   results: [{ id: '12', name: 'Job - Invocation Report' }],
 };


### PR DESCRIPTION
`include_permissions` wasnt present in every api call when job is running, causing the view task button to be disabled as it didnt have permissions data.
Also just removed the usage of `include_permissions` api requests for permissions, as all permissions are loaded to the foreman metadata.