### PR TITLE
Refs #39253 - Add explicit polling to host table

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -41,7 +41,6 @@ import Columns, {
   JOB_INVOCATION_HOSTS,
   LIST_TEMPLATE_INVOCATIONS,
   STATUS_UPPERCASE,
-  ALL_JOB_HOSTS,
   AWAITING_STATUS_FILTER,
 } from './JobInvocationConstants';
 import { TemplateInvocation } from './TemplateInvocation';
@@ -51,8 +50,8 @@ import { PopupAlert } from './OpenAllInvocationsModal';
 const JobInvocationHostTable = ({
   id,
   initialFilter,
+  jobFinished,
   onFilterUpdate,
-  statusLabel,
   targeting,
 }) => {
   const columns = Columns();
@@ -69,7 +68,16 @@ const JobInvocationHostTable = ({
 
   // Expansive items
   const [expandedHost, setExpandedHost] = useState(new Set());
-  const prevStatusLabel = useRef(statusLabel);
+  const prevJobFinished = useRef(jobFinished);
+  const prevFilter = useRef('');
+  const prevId = useRef(id);
+  const pollTimeoutId = useRef(null);
+  const currentPollParams = useRef({});
+  const mountedRef = useRef(true);
+  const jobFinishedRef = useRef(jobFinished);
+  useEffect(() => {
+    jobFinishedRef.current = jobFinished;
+  }, [jobFinished]);
 
   const [hostInvocationStates, setHostInvocationStates] = useState({});
 
@@ -153,33 +161,45 @@ const JobInvocationHostTable = ({
     [initialFilter, urlSearchQuery]
   );
 
-  const handleResponse = useCallback((data, key) => {
-    if (key === JOB_INVOCATION_HOSTS) {
-      const ids = data.data.results.map(i => i.id);
-
-      setApiResponse(data.data);
-      setAllHostsIds(ids);
-    }
-
+  const updateHostsState = useCallback(data => {
+    const ids = data.data.results.map(i => i.id);
+    setApiResponse(data.data);
+    setAllHostsIds(ids);
     setStatus(STATUS_UPPERCASE.RESOLVED);
   }, []);
 
   // Call hosts data with params
   const makeApiCall = useCallback(
-    (requestParams, callParams = {}) => {
+    requestParams => {
       dispatch(
         APIActions.get({
-          key: callParams.key ?? ALL_JOB_HOSTS,
-          url: callParams.url ?? `/api/job_invocations/${id}/hosts`,
+          key: JOB_INVOCATION_HOSTS,
+          url: `/api/job_invocations/${id}/hosts`,
           params: requestParams,
-          handleSuccess: data => handleResponse(data, callParams.key),
-          handleError: () => setStatus(STATUS_UPPERCASE.ERROR),
+          handleSuccess: data => {
+            if (!mountedRef.current) return;
+            updateHostsState(data);
+            if (!jobFinishedRef.current) {
+              pollTimeoutId.current = setTimeout(
+                () => makeApiCall(currentPollParams.current),
+                5000
+              );
+            } else {
+              pollTimeoutId.current = null;
+            }
+          },
+          handleError: () => {
+            pollTimeoutId.current = null;
+            setStatus(STATUS_UPPERCASE.ERROR);
+          },
           errorToast: ({ response }) =>
-            response?.data?.error?.full_messages?.[0] || response,
+            response?.data?.error?.full_messages?.[0] ||
+            response?.data?.error?.message ||
+            __('Failed to load host invocation data'),
         })
       );
     },
-    [dispatch, id, handleResponse]
+    [dispatch, id, updateHostsState]
   );
 
   const filterApiCall = useCallback(
@@ -202,7 +222,11 @@ const JobInvocationHostTable = ({
         finalParams.search = filterSearch;
       }
 
-      makeApiCall(finalParams, { key: JOB_INVOCATION_HOSTS });
+      currentPollParams.current = finalParams;
+      clearTimeout(pollTimeoutId.current);
+      pollTimeoutId.current = null;
+
+      makeApiCall(finalParams);
 
       const urlSearchParams = new URLSearchParams(window.location.search);
 
@@ -222,26 +246,17 @@ const JobInvocationHostTable = ({
     ]
   );
 
-  // Filter change
-  const handleFilterChange = useCallback(
-    newFilter => {
-      onFilterUpdate(newFilter);
-    },
-    [onFilterUpdate]
-  );
-
   // Effects
   // run after mount
   const initializedRef = useRef(false);
   useEffect(() => {
     if (!initializedRef.current) {
-      // Job Invo template load
-      makeApiCall(
-        {},
-        {
-          url: `/job_invocations/${id}/hosts`,
+      dispatch(
+        APIActions.get({
           key: LIST_TEMPLATE_INVOCATIONS,
-        }
+          url: `/job_invocations/${id}/hosts`,
+          params: {},
+        })
       );
 
       if (initialFilter === '') {
@@ -249,16 +264,28 @@ const JobInvocationHostTable = ({
       }
       initializedRef.current = true;
     }
-  }, [makeApiCall, id, initialFilter, onFilterUpdate]);
+  }, [dispatch, id, initialFilter, onFilterUpdate]);
 
   useEffect(() => {
-    if (initialFilter !== '') filterApiCall();
+    const filterChanged = initialFilter !== prevFilter.current;
+    const statusChanged = jobFinished !== prevJobFinished.current;
+    const idChanged = id !== prevId.current;
 
-    if (statusLabel !== prevStatusLabel.current) {
-      prevStatusLabel.current = statusLabel;
+    if ((filterChanged || statusChanged || idChanged) && initialFilter !== '') {
+      prevFilter.current = initialFilter;
+      prevJobFinished.current = jobFinished;
+      prevId.current = id;
       filterApiCall();
     }
-  }, [initialFilter, statusLabel, id, filterApiCall]);
+  }, [initialFilter, jobFinished, id, filterApiCall]);
+
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+      clearTimeout(pollTimeoutId.current);
+    },
+    []
+  );
 
   const {
     updateSearchQuery: updateSearchQueryBulk,
@@ -403,7 +430,7 @@ const JobInvocationHostTable = ({
           <DropdownFilter
             key="dropdown-filter"
             dropdownFilter={initialFilter}
-            setDropdownFilter={handleFilterChange}
+            setDropdownFilter={onFilterUpdate}
           />,
           <CheckboxesActions
             bulkParams={selectedCount > 0 ? fetchBulkParams() : null}
@@ -541,13 +568,13 @@ JobInvocationHostTable.propTypes = {
   id: PropTypes.string.isRequired,
   targeting: PropTypes.object.isRequired,
   initialFilter: PropTypes.string.isRequired,
-  statusLabel: PropTypes.string,
+  jobFinished: PropTypes.bool,
   onFilterUpdate: PropTypes.func,
 };
 
 JobInvocationHostTable.defaultProps = {
   onFilterUpdate: () => {},
-  statusLabel: undefined,
+  jobFinished: false,
 };
 
 export default JobInvocationHostTable;

--- a/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
+++ b/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
@@ -1,0 +1,336 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { APIActions } from 'foremanReact/redux/API';
+import { createForemanContextWrapper } from './foremanTestHelpers';
+import JobInvocationHostTable from '../JobInvocationHostTable';
+import { JOB_INVOCATION_HOSTS } from '../JobInvocationConstants';
+
+jest.useFakeTimers();
+
+jest.mock('foremanReact/redux/API/APISelectors', () =>
+  jest.requireActual('foremanReact/redux/API/APISelectors')
+);
+
+jest.mock('foremanReact/common/hooks/Permissions/permissionHooks', () => ({
+  usePermissions: jest.fn(() => true),
+}));
+
+jest.mock('../TemplateInvocation', () => ({
+  TemplateInvocation: () => <div data-testid="template-invocation" />,
+}));
+
+jest.mock('../TemplateInvocationComponents/TemplateActionButtons', () => ({
+  RowActions: () => <div data-testid="row-actions" />,
+}));
+
+const mockStore = configureMockStore([thunk]);
+
+const hostsResponse = {
+  total: 1,
+  subtotal: 1,
+  page: 1,
+  per_page: 20,
+  results: [
+    {
+      id: 1,
+      name: 'host1.example.com',
+      operatingsystem_id: 1,
+      operatingsystem_name: 'RHEL 9',
+      hostgroup_id: 1,
+      hostgroup_name: 'default',
+      job_status: 'success',
+      smart_proxy_id: 1,
+      smart_proxy_name: 'proxy1',
+    },
+  ],
+};
+
+let apiGetSpy;
+let hostsCalls;
+let pendingCallbacks;
+
+const createStore = () =>
+  mockStore({
+    API: {},
+  });
+
+const flushPendingCallbacks = () => {
+  const batch = [...pendingCallbacks];
+  pendingCallbacks = [];
+  batch.forEach(cb => cb());
+};
+
+const renderTable = (props = {}) => {
+  const store = createStore();
+  const history = createMemoryHistory();
+  const Wrapper = createForemanContextWrapper();
+
+  const defaultProps = {
+    id: '42',
+    targeting: { targeting_type: 'static_query', search_query: '' },
+    initialFilter: 'all_statuses',
+    jobFinished: false,
+    onFilterUpdate: jest.fn(),
+    ...props,
+  };
+
+  const result = render(
+    <Provider store={store}>
+      <Router history={history}>
+        <Wrapper>
+          <JobInvocationHostTable {...defaultProps} />
+        </Wrapper>
+      </Router>
+    </Provider>
+  );
+
+  return { ...result, store, history };
+};
+
+const setupSuccessMock = () => {
+  apiGetSpy = jest
+    .spyOn(APIActions, 'get')
+    .mockImplementation(opts => dispatch => {
+      if (opts.key === JOB_INVOCATION_HOSTS) {
+        hostsCalls.push(opts);
+        if (opts.handleSuccess) {
+          pendingCallbacks.push(() =>
+            opts.handleSuccess({ data: hostsResponse })
+          );
+        }
+      }
+    });
+};
+
+const setupErrorMock = () => {
+  apiGetSpy = jest
+    .spyOn(APIActions, 'get')
+    .mockImplementation(opts => dispatch => {
+      if (opts.key === JOB_INVOCATION_HOSTS) {
+        hostsCalls.push(opts);
+        if (opts.handleError) {
+          pendingCallbacks.push(() => opts.handleError());
+        }
+      }
+    });
+};
+
+describe('JobInvocationHostTable polling', () => {
+  beforeEach(() => {
+    hostsCalls = [];
+    pendingCallbacks = [];
+    setupSuccessMock();
+  });
+
+  afterEach(() => {
+    apiGetSpy.mockRestore();
+    jest.clearAllTimers();
+  });
+
+  it('schedules a poll after the initial fetch succeeds', () => {
+    renderTable();
+
+    expect(hostsCalls.length).toBe(1);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(1);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(2);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(3);
+  });
+
+  it('does not schedule a poll when jobFinished is true', () => {
+    renderTable({ jobFinished: true });
+
+    expect(hostsCalls.length).toBe(1);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(1);
+  });
+
+  it('stops polling when jobFinished transitions to true', () => {
+    const { rerender } = renderTable();
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(1);
+
+    const store = createStore();
+    const history = createMemoryHistory();
+    const Wrapper = createForemanContextWrapper();
+
+    act(() => {
+      rerender(
+        <Provider store={store}>
+          <Router history={history}>
+            <Wrapper>
+              <JobInvocationHostTable
+                id="42"
+                targeting={{
+                  targeting_type: 'static_query',
+                  search_query: '',
+                }}
+                initialFilter="all_statuses"
+                jobFinished
+                onFilterUpdate={jest.fn()}
+              />
+            </Wrapper>
+          </Router>
+        </Provider>
+      );
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    const callsAtTransition = hostsCalls.length;
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(callsAtTransition);
+  });
+
+  it('cleans up the poll timer on unmount', () => {
+    const { unmount } = renderTable();
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    const callsBeforeUnmount = hostsCalls.length;
+
+    unmount();
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(callsBeforeUnmount);
+  });
+
+  it('restarts polling when filter changes', () => {
+    const { rerender } = renderTable({ initialFilter: 'all_statuses' });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    const callsBeforeFilterChange = hostsCalls.length;
+
+    const store = createStore();
+    const history = createMemoryHistory();
+    const Wrapper = createForemanContextWrapper();
+
+    act(() => {
+      rerender(
+        <Provider store={store}>
+          <Router history={history}>
+            <Wrapper>
+              <JobInvocationHostTable
+                id="42"
+                targeting={{
+                  targeting_type: 'static_query',
+                  search_query: '',
+                }}
+                initialFilter="success"
+                jobFinished={false}
+                onFilterUpdate={jest.fn()}
+              />
+            </Wrapper>
+          </Router>
+        </Provider>
+      );
+    });
+
+    expect(hostsCalls.length).toBeGreaterThan(callsBeforeFilterChange);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    const callsAfterFilterChange = hostsCalls.length;
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBeGreaterThan(callsAfterFilterChange);
+  });
+
+  it('stops polling on API error', () => {
+    apiGetSpy.mockRestore();
+    setupErrorMock();
+
+    renderTable();
+
+    expect(hostsCalls.length).toBe(1);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls.length).toBe(1);
+  });
+});

--- a/webpack/JobInvocationDetail/index.js
+++ b/webpack/JobInvocationDetail/index.js
@@ -216,10 +216,8 @@ const JobInvocationDetailPage = ({
           <JobInvocationHostTable
             id={id}
             targeting={targeting}
-            finished={finished}
-            autoRefresh={autoRefresh}
             initialFilter={selectedFilter}
-            statusLabel={statusLabel}
+            jobFinished={finished}
             onFilterUpdate={handleFilterChange}
           />
         </SkeletonLoader>


### PR DESCRIPTION
The host table previously relied on an accidental refresh cascade: parent polling updated Redux state, which changed callback identities, which triggered useEffect, which re-fetched hosts. This adds an explicit setTimeout-based polling chain (5s interval) that stops when the job finishes or on API error, and restarts when filters change.