### PR TITLE
Refs #39253 - perf 4/4 - Fetch permissions only on initial load

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationActions.js
+++ b/webpack/JobInvocationDetail/JobInvocationActions.js
@@ -26,13 +26,20 @@ const createPollState = cancel => ({ timeoutId: null, cancel });
 
 export const getJobInvocation = (url, pollTimeoutRef) => dispatch => {
   let cancelled = false;
+  let isFirstCall = true;
 
   const poll = () => {
     if (cancelled) return;
+    const params = { include_hosts: false };
+    if (isFirstCall) {
+      params.include_permissions = true;
+      isFirstCall = false;
+    }
+
     dispatch(
       APIActions.get({
         key: JOB_INVOCATION_KEY,
-        params: { include_permissions: true, include_hosts: false },
+        params,
         url,
         handleSuccess: ({ data }) => {
           if (cancelled) return;

--- a/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
+++ b/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
@@ -311,6 +311,39 @@ describe('JobInvocationHostTable polling', () => {
     expect(hostsCalls.length).toBeGreaterThan(callsAfterFilterChange);
   });
 
+  it('sends include_permissions only on the first request', () => {
+    renderTable();
+
+    expect(hostsCalls).toHaveLength(1);
+    expect(hostsCalls[0].params.include_permissions).toBe(true);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls).toHaveLength(2);
+    expect(hostsCalls[1].params.include_permissions).toBeUndefined();
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls).toHaveLength(3);
+    expect(hostsCalls[2].params.include_permissions).toBeUndefined();
+  });
+
   it('stops polling on API error', () => {
     apiGetSpy.mockRestore();
     setupErrorMock();

--- a/webpack/JobInvocationDetail/__tests__/JobInvocationPolling.test.js
+++ b/webpack/JobInvocationDetail/__tests__/JobInvocationPolling.test.js
@@ -70,7 +70,7 @@ describe('job invocation polling', () => {
     expect(apiGetSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('includes include_permissions=true in every poll call', () => {
+  it('does not include include_permissions on subsequent poll calls', () => {
     setupGetMock(runningData);
     const store = makeStore();
 
@@ -80,8 +80,10 @@ describe('job invocation polling', () => {
     expect(apiGetSpy).toHaveBeenCalledTimes(2);
     expect(apiGetSpy.mock.calls[1][0].params).toMatchObject({
       include_hosts: false,
-      include_permissions: true,
     });
+    expect(apiGetSpy.mock.calls[1][0].params).not.toHaveProperty(
+      'include_permissions'
+    );
   });
 
   it('stops polling when job succeeds', () => {

--- a/webpack/JobInvocationDetail/index.js
+++ b/webpack/JobInvocationDetail/index.js
@@ -54,6 +54,11 @@ const JobInvocationDetailPage = ({
   } = items;
   const finished = isJobFinished(statusLabel);
   const pollTimeoutRef = useRef({ timeoutId: null, cancel: () => {} });
+  const permissionsRef = useRef(null);
+  if (items.permissions && !permissionsRef.current) {
+    permissionsRef.current = items.permissions;
+  }
+  const permissions = items.permissions || permissionsRef.current;
   const jobInvocationApiStatus = useSelector(state =>
     selectAPIStatus(state, JOB_INVOCATION_KEY)
   );
@@ -86,6 +91,11 @@ const JobInvocationDetailPage = ({
       stopJobInvocationPolling(pollTimeoutRef);
     };
   }, [dispatch, id]);
+
+  const dataWithPermissions = useMemo(() => ({ ...items, permissions }), [
+    items,
+    permissions,
+  ]);
 
   const apiFailed = jobInvocationApiStatus === API_STATUS.ERROR;
 
@@ -143,7 +153,10 @@ const JobInvocationDetailPage = ({
         breadcrumbOptions={breadcrumbOptions}
         toolbarButtons={
           items.id !== undefined && (
-            <JobInvocationToolbarButtons jobId={id} data={items} />
+            <JobInvocationToolbarButtons
+              jobId={id}
+              data={dataWithPermissions}
+            />
           )
         }
         searchable={false}


### PR DESCRIPTION
Follows https://github.com/theforeman/foreman_remote_execution/pull/1049

TODOs:
- [x] make the permission checks task-specific