### PR TITLE
Fixes #39543 - Add alert to locked Job template form

### DIFF
--- a/app/views/job_templates/_alerts.html.erb
+++ b/app/views/job_templates/_alerts.html.erb
@@ -1,0 +1,4 @@
+<% if @template.locked? -%>
+  <%= locked_warning(::Template.find(params[:id])) %>
+<% end -%>
+


### PR DESCRIPTION
Adds _alert.html.erb view to Job templates, bringing it on par with other Template resources. This shows a warning alert when trying to edit locked resource (same as the other templates).