### PR TITLE
Fixes #39606 - Stop hosts table polling when all page hosts are terminal

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationConstants.js
+++ b/webpack/JobInvocationDetail/JobInvocationConstants.js
@@ -57,6 +57,16 @@ export const STATUS_TITLES = {
   NOT_STARTED: { id: 'N/A', title: __('Scheduled') },
 };
 
+export const TERMINAL_HOST_STATUSES = new Set([
+  'success',
+  'error',
+  'cancelled',
+]);
+
+export const areAllHostsTerminal = results =>
+  results?.length > 0 &&
+  results.every(host => TERMINAL_HOST_STATUSES.has(host.job_status));
+
 export const DATE_OPTIONS = {
   day: 'numeric',
   month: 'short',

--- a/webpack/JobInvocationDetail/JobInvocationConstants.js
+++ b/webpack/JobInvocationDetail/JobInvocationConstants.js
@@ -55,6 +55,16 @@ export const STATUS_TITLES = {
   NOT_STARTED: { id: 'N/A', title: __('Scheduled') },
 };
 
+export const TERMINAL_HOST_STATUSES = new Set([
+  'success',
+  'error',
+  'cancelled',
+]);
+
+export const areAllHostsTerminal = results =>
+  results?.length > 0 &&
+  results.every(host => TERMINAL_HOST_STATUSES.has(host.job_status));
+
 export const DATE_OPTIONS = {
   day: 'numeric',
   month: 'short',

--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -197,7 +197,12 @@ const JobInvocationHostTable = ({
             if (thisRequest !== requestIdRef.current) return;
             if (!mountedRef.current) return;
             updateHostsState(data);
-            const pageAllTerminal = areAllHostsTerminal(data.data?.results);
+            const hasActiveFilter = !!(
+              currentPollParams.current.search ||
+              currentPollParams.current.awaiting
+            );
+            const pageAllTerminal =
+              !hasActiveFilter && areAllHostsTerminal(data.data?.results);
             if (!jobFinishedRef.current && !pageAllTerminal) {
               pollTimeoutId.current = setTimeout(
                 () => makeApiCall(currentPollParams.current),

--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -42,6 +42,7 @@ import Columns, {
   STATUS_UPPERCASE,
   AWAITING_STATUS_FILTER,
   AUTO_REFRESH_INTERVAL_MS,
+  areAllHostsTerminal,
 } from './JobInvocationConstants';
 import { TemplateInvocation } from './TemplateInvocation';
 import { RowActions } from './TemplateInvocationComponents/TemplateActionButtons';
@@ -196,7 +197,8 @@ const JobInvocationHostTable = ({
             if (thisRequest !== requestIdRef.current) return;
             if (!mountedRef.current) return;
             updateHostsState(data);
-            if (!jobFinishedRef.current) {
+            const pageAllTerminal = areAllHostsTerminal(data.data?.results);
+            if (!jobFinishedRef.current && !pageAllTerminal) {
               pollTimeoutId.current = setTimeout(
                 () => makeApiCall(currentPollParams.current),
                 AUTO_REFRESH_INTERVAL_MS

--- a/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
+++ b/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import React from 'react';
 import { render, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
@@ -44,10 +45,25 @@ const hostsResponse = {
       operatingsystem_name: 'RHEL 9',
       hostgroup_id: 1,
       hostgroup_name: 'default',
-      job_status: 'success',
+      job_status: 'running',
       smart_proxy_id: 1,
       smart_proxy_name: 'proxy1',
     },
+  ],
+};
+
+const terminalHostsResponse = {
+  ...hostsResponse,
+  results: [{ ...hostsResponse.results[0], job_status: 'success' }],
+};
+
+const mixedHostsResponse = {
+  ...hostsResponse,
+  total: 2,
+  subtotal: 2,
+  results: [
+    { ...hostsResponse.results[0], id: 1, job_status: 'success' },
+    { ...hostsResponse.results[0], id: 2, job_status: 'running' },
   ],
 };
 
@@ -93,16 +109,14 @@ const renderTable = (props = {}) => {
   return { ...result, store, history };
 };
 
-const setupSuccessMock = () => {
+const setupSuccessMock = (response = hostsResponse) => {
   apiGetSpy = jest
     .spyOn(APIActions, 'get')
     .mockImplementation(opts => dispatch => {
       if (opts.key === JOB_INVOCATION_HOSTS) {
         hostsCalls.push(opts);
         if (opts.handleSuccess) {
-          pendingCallbacks.push(() =>
-            opts.handleSuccess({ data: hostsResponse })
-          );
+          pendingCallbacks.push(() => opts.handleSuccess({ data: response }));
         }
       }
     });
@@ -309,6 +323,52 @@ describe('JobInvocationHostTable polling', () => {
     });
 
     expect(hostsCalls.length).toBeGreaterThan(callsAfterFilterChange);
+  });
+
+  it('stops polling when all hosts on the page are terminal', () => {
+    apiGetSpy.mockRestore();
+    setupSuccessMock(terminalHostsResponse);
+
+    renderTable();
+
+    expect(hostsCalls).toHaveLength(1);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls).toHaveLength(1);
+  });
+
+  it('continues polling when at least one host on the page is non-terminal', () => {
+    apiGetSpy.mockRestore();
+    setupSuccessMock(mixedHostsResponse);
+
+    renderTable();
+
+    expect(hostsCalls).toHaveLength(1);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls).toHaveLength(2);
   });
 
   it('sends include_permissions only on the first request', () => {

--- a/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
+++ b/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
@@ -82,9 +82,9 @@ const flushPendingCallbacks = () => {
   batch.forEach(cb => cb());
 };
 
-const renderTable = (props = {}) => {
+const renderTable = (props = {}, historyEntries = ['/']) => {
   const store = createStore();
-  const history = createMemoryHistory();
+  const history = createMemoryHistory({ initialEntries: historyEntries });
   const Wrapper = createForemanContextWrapper();
 
   const defaultProps = {
@@ -353,6 +353,52 @@ describe('JobInvocationHostTable polling', () => {
     setupSuccessMock(mixedHostsResponse);
 
     renderTable();
+
+    expect(hostsCalls).toHaveLength(1);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls).toHaveLength(2);
+  });
+
+  it('continues polling when all hosts on the page are terminal but a status filter is active', () => {
+    apiGetSpy.mockRestore();
+    setupSuccessMock(terminalHostsResponse);
+
+    renderTable({ initialFilter: 'success' });
+
+    expect(hostsCalls).toHaveLength(1);
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      flushPendingCallbacks();
+    });
+
+    expect(hostsCalls).toHaveLength(2);
+  });
+
+  it('continues polling when all hosts on the page are terminal but a search query is active', () => {
+    apiGetSpy.mockRestore();
+    setupSuccessMock(terminalHostsResponse);
+
+    renderTable({}, ['/?search=host1']);
 
     expect(hostsCalls).toHaveLength(1);
 

--- a/webpack/JobInvocationDetail/__tests__/areAllHostsTerminal.test.js
+++ b/webpack/JobInvocationDetail/__tests__/areAllHostsTerminal.test.js
@@ -1,0 +1,40 @@
+import { areAllHostsTerminal } from '../JobInvocationConstants';
+
+describe('areAllHostsTerminal', () => {
+  it('returns false for an empty results array', () => {
+    expect(areAllHostsTerminal([])).toBe(false);
+  });
+
+  it('returns false for undefined results', () => {
+    expect(areAllHostsTerminal(undefined)).toBe(false);
+  });
+
+  it('returns true when every host is in a terminal state', () => {
+    expect(
+      areAllHostsTerminal([
+        { id: 1, job_status: 'success' },
+        { id: 2, job_status: 'error' },
+        { id: 3, job_status: 'cancelled' },
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when at least one host is non-terminal', () => {
+    expect(
+      areAllHostsTerminal([
+        { id: 1, job_status: 'success' },
+        { id: 2, job_status: 'running' },
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false when every host is non-terminal', () => {
+    expect(
+      areAllHostsTerminal([
+        { id: 1, job_status: 'running' },
+        { id: 2, job_status: 'planned' },
+        { id: 3, job_status: 'N/A' },
+      ])
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
The job invocation detail page now stops polling the /hosts endpoint
when all hosts on the current page are in a terminal state (success,
error, or cancelled), even if the overall job hasn't finished yet.

This reduces unnecessary API calls, especially when users filter by
terminal statuses like "Succeeded" or view pages where all hosts
completed before the overall job did.

The existing job-level polling and per-host template invocation
polling remain unaffected and continue independently.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
