### PR TITLE
Fixes #39609 - Add missing ouiaId to MenuToggle components

### DIFF
--- a/webpack/JobInvocationDetail/CheckboxesActions.js
+++ b/webpack/JobInvocationDetail/CheckboxesActions.js
@@ -86,6 +86,7 @@ const ActionsKebab = ({
           id="toggle-kebab"
           isExpanded={isDropdownOpen}
           onClick={() => setIsDropdownOpen(prev => !prev)}
+          ouiaId="actions-kebab-toggle"
           ref={toggleRef}
           variant="plain"
         >

--- a/webpack/JobInvocationDetail/DropdownFilter.js
+++ b/webpack/JobInvocationDetail/DropdownFilter.js
@@ -22,6 +22,7 @@ const DropdownFilter = ({ dropdownFilter, setDropdownFilter }) => {
       ref={toggleRef}
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
+      ouiaId="host-status-select-toggle"
       style={{
         width: '200px',
       }}


### PR DESCRIPTION
Strict checking of ouia ids on PF5 components was introduced with [#39562](https://projects.theforeman.org/issues/39562) / theforeman/foreman#11117.
