### PR TITLE
Fixes #39636 - Restrict job template revision endpoint to JobTemplate audits

### DIFF
--- a/app/controllers/api/v2/job_templates_controller.rb
+++ b/app/controllers/api/v2/job_templates_controller.rb
@@ -88,7 +88,7 @@ module Api
       api :GET, '/job_templates/revision'
       param :version, String, :desc => N_('Template version')
       def revision
-        audit = Audit.authorized(:view_audit_logs).find(params[:version])
+        audit = Audit.authorized(:view_audit_logs).where(:auditable_type => 'JobTemplate', :id => params[:version]).first!
         render :json => audit.revision.template
       end
 

--- a/test/functional/api/v2/job_templates_controller_test.rb
+++ b/test/functional/api/v2/job_templates_controller_test.rb
@@ -133,6 +133,27 @@ module Api
         assert_response :success
         assert JobTemplate.unscoped.find_by(name: new_name)
       end
+
+      context '#revision' do
+        test 'should return revision for a job template audit' do
+          @template.update!(template: 'updated template content')
+          audit = @template.audits.last
+          get :revision, params: { :version => audit.id }
+          assert_response :success
+          assert_equal 'updated template content', ActiveSupport::JSON.decode(@response.body)
+        end
+
+        test 'should not return revision for a non-job-template audit' do
+          other_audit = Audited::Audit.create!(
+            :auditable_type => 'Host',
+            :auditable_id => 1,
+            :action => 'update',
+            :version => 1
+          )
+          get :revision, params: { :version => other_audit.id }
+          assert_response :not_found
+        end
+      end
     end
 
   end


### PR DESCRIPTION
## Summary

The `revision` endpoint is specifically for JobTemplate revision history, but the original `find(params[:version])` didn't constrain the audit's `auditable_type`. This meant a valid audit ID for a different model type (e.g. Host) would resolve successfully even though the endpoint should only serve JobTemplate audits.

This change makes that invariant explicit:

```ruby
# before
audit = Audit.authorized(:view_audit_logs).find(params[:version])

# after
audit = Audit.authorized(:view_audit_logs)
             .where(:auditable_type => 'JobTemplate', :id => params[:version])
             .first!
```

The existing `Audit.authorized(:view_audit_logs)` scope remains responsible for access control. This is a correctness fix, not a security issue.

## Changes

- `app/controllers/api/v2/job_templates_controller.rb` — scope revision lookup to `auditable_type: 'JobTemplate'`
- `test/functional/api/v2/job_templates_controller_test.rb` — add tests for the `#revision` action:
  - Positive case: authorized JobTemplate audit resolves correctly
  - Negative case: authorized audit for a different `auditable_type` returns 404