### PR TITLE
Refs #39640 - Support remote_execution_remote_working_dir in push mode

### DIFF
--- a/app/models/remote_execution_provider.rb
+++ b/app/models/remote_execution_provider.rb
@@ -76,6 +76,17 @@ class RemoteExecutionProvider
       [true, 'true', 'True', 'TRUE', '1'].include?(setting)
     end
 
+    def remote_working_dir(host)
+      dir = host_setting(host, :remote_execution_remote_working_dir).to_s.strip
+      unless Pathname.new(dir).absolute?
+        raise ::Foreman::Exception.new(
+          N_('Remote working directory "%{current_value}" is not an absolute path'),
+          current_value: dir
+        )
+      end
+      dir
+    end
+
     def effective_user_password(host)
       host_setting(host, :remote_execution_effective_user_password)
     end

--- a/app/models/script_execution_provider.rb
+++ b/app/models/script_execution_provider.rb
@@ -1,11 +1,14 @@
 class ScriptExecutionProvider < RemoteExecutionProvider
   class << self
     def proxy_command_options(template_invocation, host)
-      super.merge(:ssh_user => ssh_user(host, template_invocation.job_invocation),
-        :effective_user => effective_user(template_invocation),
-        :effective_user_method => effective_user_method(host),
-        :cleanup_working_dirs => cleanup_working_dirs?(host),
-        :ssh_port => ssh_port(host))
+      super.merge(
+        ssh_user: ssh_user(host, template_invocation.job_invocation),
+        effective_user: effective_user(template_invocation),
+        effective_user_method: effective_user_method(host),
+        cleanup_working_dirs: cleanup_working_dirs?(host),
+        remote_working_dir: remote_working_dir(host),
+        ssh_port: ssh_port(host)
+      )
     end
 
     def humanized_name

--- a/lib/foreman_remote_execution/plugin.rb
+++ b/lib/foreman_remote_execution/plugin.rb
@@ -86,6 +86,15 @@ Foreman::Plugin.register :foreman_remote_execution do
         description: N_('When enabled, working directories will be removed after task completion. You may override this per host by setting a parameter called remote_execution_cleanup_working_dirs.'),
         default: true,
         full_name: N_('Cleanup working directories')
+      setting 'remote_execution_remote_working_dir',
+        type: :string,
+        description: N_('Directory on the host where remote execution jobs in push mode place and run their scripts. '\
+                        'You can override this setting per host with the `remote_execution_remote_working_dir` host parameter.'),
+        default: '/var/tmp',
+        full_name: N_('Remote working directory')
+      validates 'remote_execution_remote_working_dir',
+        ->(value) { Pathname.new(value.to_s.strip).absolute? },
+        message: N_('must be an absolute path')
       setting 'remote_execution_cockpit_url',
         type: :string,
         description: N_('Where to find the Cockpit instance for the Web Console button.  By default, no button is shown.'),

--- a/test/unit/remote_execution_provider_test.rb
+++ b/test/unit/remote_execution_provider_test.rb
@@ -202,6 +202,62 @@ class RemoteExecutionProviderTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'remote working directory' do
+      it 'defaults to the value of the global setting' do
+        assert_equal '/var/tmp', proxy_options[:remote_working_dir]
+      end
+
+      it 'updates the value via settings' do
+        Setting[:remote_execution_remote_working_dir] = '/opt/rex'
+        assert_equal '/opt/rex', proxy_options[:remote_working_dir]
+      end
+
+      it 'takes the value from host parameters over the global setting' do
+        Setting[:remote_execution_remote_working_dir] = '/opt/rex'
+        host.host_parameters << FactoryBot.build(:host_parameter, name: 'remote_execution_remote_working_dir', value: '/opt/host')
+        host.clear_host_parameters_cache!
+        assert_equal '/opt/host', proxy_options[:remote_working_dir]
+      end
+
+      it 'takes the value inherited from the host group over the global setting' do
+        Setting[:remote_execution_remote_working_dir] = '/opt/rex'
+        hostgroup = FactoryBot.create(:hostgroup)
+        hostgroup.group_parameters << FactoryBot.build(:hostgroup_parameter, name: 'remote_execution_remote_working_dir', value: '/opt/hostgroup')
+        host.update!(hostgroup: hostgroup)
+        host.clear_host_parameters_cache!
+        assert_equal '/opt/hostgroup', proxy_options[:remote_working_dir]
+      end
+
+      it 'strips surrounding whitespace' do
+        Setting[:remote_execution_remote_working_dir] = ' /opt/rex '
+        assert_equal '/opt/rex', proxy_options[:remote_working_dir]
+      end
+
+      it 'rejects a setting value that is not an absolute path' do
+        assert_raises(ActiveRecord::RecordInvalid) do
+          Setting[:remote_execution_remote_working_dir] = 'opt/rex'
+        end
+      end
+
+      it 'rejects an empty setting value' do
+        assert_raises(ActiveRecord::RecordInvalid) do
+          Setting[:remote_execution_remote_working_dir] = ''
+        end
+      end
+
+      it 'raises when the host parameter is not an absolute path' do
+        host.host_parameters << FactoryBot.build(:host_parameter, name: 'remote_execution_remote_working_dir', value: 'opt/host')
+        host.clear_host_parameters_cache!
+        assert_raises(::Foreman::Exception) { proxy_options }
+      end
+
+      it 'raises when the host parameter is empty' do
+        host.host_parameters << FactoryBot.build(:host_parameter, name: 'remote_execution_remote_working_dir', value: '')
+        host.clear_host_parameters_cache!
+        assert_raises(::Foreman::Exception) { proxy_options }
+      end
+    end
+
     describe '#find_ip_or_hostname' do
       let(:host) do
         FactoryBot.create(:host) do |host|


### PR DESCRIPTION
Adds remote_execution_remote_working_dir setting, defaulting to /var/tmp.