### PR TITLE
Fixes #39251 - Load job wizard host previews via POST

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
   get 'ui_job_wizard/template/:id', to: 'ui_job_wizard#template'
   get 'ui_job_wizard/resources', to: 'ui_job_wizard#resources'
   get 'ui_job_wizard/job_invocation', to: 'ui_job_wizard#job_invocation'
+  post 'ui_job_wizard/hosts', to: 'api/v2/hosts#index', :defaults => {:format => 'json'}
 
   namespace :api, :defaults => {:format => 'json'} do
     scope '(:apiv)', :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do

--- a/test/integration/job_wizard_hosts_routing_test.rb
+++ b/test/integration/job_wizard_hosts_routing_test.rb
@@ -1,0 +1,11 @@
+require File.expand_path('../test_plugin_helper', __dir__)
+require 'integration_test_helper'
+
+class JobWizardHostsRoutingTest < ActionDispatch::IntegrationTest
+  test 'routes host preview searches to the hosts API via POST' do
+    assert_recognizes(
+      {:controller => 'api/v2/hosts', :action => 'index', :format => 'json'},
+      {:path => '/ui_job_wizard/hosts', :method => :post}
+    )
+  end
+end

--- a/webpack/JobWizard/steps/HostsAndInputs/index.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/index.js
@@ -15,7 +15,6 @@ import {
 import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 import { FilterIcon } from '@patternfly/react-icons';
-import { get } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
   selectTemplateInputs,
@@ -35,14 +34,13 @@ import {
   HOST_COLLECTIONS,
   HOST_GROUPS,
   hostMethods,
-  HOSTS_API,
-  HOSTS_TO_PREVIEW_AMOUNT,
   DEBOUNCE_API,
 } from '../../JobWizardConstants';
 import { WizardTitle } from '../form/WizardTitle';
 import { SelectAPI } from './SelectAPI';
 import { SelectGQL } from './SelectGQL';
 import { buildHostQuery } from './buildHostQuery';
+import { loadHosts } from './loadHosts';
 
 const HostsAndInputs = ({
   templateValues,
@@ -86,16 +84,7 @@ const HostsAndInputs = ({
   ]);
   useEffect(() => {
     debounce(() => {
-      dispatch(
-        get({
-          key: HOSTS_API,
-          url: '/api/hosts',
-          params: {
-            search: buildHostQuery(selected, hostsSearchQuery),
-            per_page: HOSTS_TO_PREVIEW_AMOUNT,
-          },
-        })
-      );
+      dispatch(loadHosts(buildHostQuery(selected, hostsSearchQuery)));
     }, DEBOUNCE_API)();
   }, [
     dispatch,

--- a/webpack/JobWizard/steps/HostsAndInputs/loadHosts.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/loadHosts.js
@@ -1,0 +1,12 @@
+import { post } from 'foremanReact/redux/API';
+import { HOSTS_API, HOSTS_TO_PREVIEW_AMOUNT } from '../../JobWizardConstants';
+
+export const loadHosts = search =>
+  post({
+    key: HOSTS_API,
+    url: '/ui_job_wizard/hosts',
+    params: {
+      search,
+      per_page: HOSTS_TO_PREVIEW_AMOUNT,
+    },
+  });

--- a/webpack/JobWizard/steps/HostsAndInputs/loadHosts.test.js
+++ b/webpack/JobWizard/steps/HostsAndInputs/loadHosts.test.js
@@ -1,0 +1,25 @@
+import { post } from 'foremanReact/redux/API';
+import { HOSTS_API, HOSTS_TO_PREVIEW_AMOUNT } from '../../JobWizardConstants';
+import { loadHosts } from './loadHosts';
+
+jest.mock('foremanReact/redux/API');
+
+describe('loadHosts', () => {
+  it('sends long searches in a POST request body', () => {
+    const hosts = Array(1000)
+      .fill('host.example.com')
+      .join(',');
+    const search = `name ^ (${hosts})`;
+
+    loadHosts(search);
+
+    expect(post).toHaveBeenCalledWith({
+      key: HOSTS_API,
+      url: '/ui_job_wizard/hosts',
+      params: {
+        search,
+        per_page: HOSTS_TO_PREVIEW_AMOUNT,
+      },
+    });
+  });
+});

--- a/webpack/JobWizard/steps/ReviewDetails/index.js
+++ b/webpack/JobWizard/steps/ReviewDetails/index.js
@@ -10,7 +10,6 @@ import {
 import { WizardContextConsumer } from '@patternfly/react-core/deprecated';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { get } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import {
   selectJobTemplates,
@@ -19,13 +18,9 @@ import {
   selectTemplateInputs,
   selectAdvancedTemplateInputs,
 } from '../../JobWizardSelectors';
-import {
-  HOSTS_API,
-  HOSTS_TO_PREVIEW_AMOUNT,
-  WIZARD_TITLES,
-  SCHEDULE_TYPES,
-} from '../../JobWizardConstants';
+import { WIZARD_TITLES, SCHEDULE_TYPES } from '../../JobWizardConstants';
 import { buildHostQuery } from '../HostsAndInputs/buildHostQuery';
+import { loadHosts } from '../HostsAndInputs/loadHosts';
 import { WizardTitle } from '../form/WizardTitle';
 import { parseEnd, parseRepeat } from './helpers';
 import { HostPreviewModal } from '../HostsAndInputs/HostPreviewModal';
@@ -58,16 +53,7 @@ const ReviewDetails = ({
   );
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(
-      get({
-        key: HOSTS_API,
-        url: '/api/hosts',
-        params: {
-          search: buildHostQuery(selectedTargets, hostsSearchQuery),
-          per_page: HOSTS_TO_PREVIEW_AMOUNT,
-        },
-      })
-    );
+    dispatch(loadHosts(buildHostQuery(selectedTargets, hostsSearchQuery)));
   }, [dispatch, hostsSearchQuery, selectedTargets]);
   const jobTemplates = useSelector(selectJobTemplates);
   const templateInputs = useSelector(selectTemplateInputs);


### PR DESCRIPTION
When rerunning jobs with many target hosts, the generated search query can exceed the maximum URI length. Both the target selection and review steps loaded host previews through `GET /api/hosts`, causing HTTP 414 before Foreman could process the request.

Send host preview searches through a POST endpoint backed by the existing hosts index. This keeps the current authorization, pagination, and response format while carrying the search query in the request body.

The final job submission already uses POST and is unchanged.

Tests:
- long host searches are sent in the POST body
- the host preview route accepts POST and targets the existing hosts index

This pull request was assisted by Codex 5.6 Sol High.
