### PR TITLE
Fixes #39648 - Improve live job output updates

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationConstants.js
+++ b/webpack/JobInvocationDetail/JobInvocationConstants.js
@@ -14,16 +14,22 @@ export const GET_REPORT_TEMPLATES = 'GET_REPORT_TEMPLATES';
 export const GET_REPORT_TEMPLATE_INPUTS = 'GET_REPORT_TEMPLATE_INPUTS';
 export const JOB_INVOCATION_HOSTS = 'JOB_INVOCATION_HOSTS';
 export const GET_TEMPLATE_INVOCATION = 'GET_TEMPLATE_INVOCATION';
+export const GET_TEMPLATE_INVOCATION_OUTPUT = 'GET_TEMPLATE_INVOCATION_OUTPUT';
 export const DIRECT_OPEN_HOST_LIMIT = 3;
 export const AWAITING_STATUS_FILTER = '(job_invocation.result = N/A)';
 
 export const AUTO_REFRESH_INTERVAL_MS = 5000;
+export const OUTPUT_REFRESH_INTERVAL_MS = 1000;
+export const OUTPUT_MAX_REFRESH_INTERVAL_MS = 3000;
 export const DEFAULT_CHART_LEGEND_WIDTH = 270;
 export const CLIPBOARD_COPIED_EXIT_DELAY_MS = 1500;
 export const CLIPBOARD_DEFAULT_EXIT_DELAY_MS = 600;
 
 export const showTemplateInvocationUrl = (hostID, jobID) =>
   `/show_template_invocation_by_host/${hostID}/job_invocation/${jobID}`;
+
+export const templateInvocationOutputUrl = (hostID, jobID) =>
+  `/api/job_invocations/${jobID}/hosts/${hostID}`;
 
 export const templateInvocationPageUrl = (hostID, jobID) =>
   `/job_invocations_detail/${jobID}/host_invocation/${hostID}`;

--- a/webpack/JobInvocationDetail/TemplateInvocation.js
+++ b/webpack/JobInvocationDetail/TemplateInvocation.js
@@ -1,17 +1,13 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { ClipboardCopyButton, Alert, Skeleton } from '@patternfly/react-core';
-import { useDispatch, useSelector } from 'react-redux';
-import { APIActions } from 'foremanReact/redux/API';
+import { useSelector } from 'react-redux';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useForemanHostDetailsPageUrl } from 'foremanReact/Root/Context/ForemanContext';
 import { STATUS } from 'foremanReact/constants';
 import {
-  showTemplateInvocationUrl,
   templateInvocationPageUrl,
-  GET_TEMPLATE_INVOCATION,
-  AUTO_REFRESH_INTERVAL_MS,
   CLIPBOARD_COPIED_EXIT_DELAY_MS,
   CLIPBOARD_DEFAULT_EXIT_DELAY_MS,
 } from './JobInvocationConstants';
@@ -19,6 +15,7 @@ import {
   selectTemplateInvocationStatus,
   selectTemplateInvocation,
 } from './JobInvocationSelectors';
+import { useTemplateInvocationOutputPolling } from './useTemplateInvocationOutputPolling';
 import { OutputToggleGroup } from './TemplateInvocationComponents/OutputToggleGroup';
 import { PreviewTemplate } from './TemplateInvocationComponents/PreviewTemplate';
 import { OutputCodeBlock } from './TemplateInvocationComponents/OutputCodeBlock';
@@ -74,64 +71,16 @@ export const TemplateInvocation = ({
   showCommand,
   setShowCommand,
 }) => {
-  const timeoutRef = useRef(null);
-  const templateURL = showTemplateInvocationUrl(hostID, jobID);
   const hostDetailsPageUrl = useForemanHostDetailsPageUrl();
 
   const status = useSelector(selectTemplateInvocationStatus(hostID));
   const response = useSelector(selectTemplateInvocation(hostID));
-  const dispatch = useDispatch();
-
-  const responseRef = useRef(response);
-  useEffect(() => {
-    responseRef.current = response;
-  }, [response]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const schedulePoll = () => {
-      if (cancelled) return;
-      dispatch(
-        APIActions.get({
-          url: templateURL,
-          key: `${GET_TEMPLATE_INVOCATION}_${hostID}`,
-          handleSuccess: ({ data }) => {
-            if (cancelled) return;
-            const isFinished = data?.finished ?? true;
-            // eslint-disable-next-line camelcase
-            const autoRefresh = data?.auto_refresh || false;
-            if (!isFinished && autoRefresh) {
-              timeoutRef.current = setTimeout(
-                schedulePoll,
-                AUTO_REFRESH_INTERVAL_MS
-              );
-            } else {
-              timeoutRef.current = null;
-            }
-          },
-          handleError: () => {
-            if (cancelled) return;
-            timeoutRef.current = null;
-          },
-        })
-      );
-    };
-
-    clearTimeout(timeoutRef.current);
-    timeoutRef.current = null;
-
-    if (isExpanded) {
-      if (responseRef.current?.finished) return undefined;
-      schedulePoll();
-    }
-
-    return () => {
-      cancelled = true;
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    };
-  }, [isExpanded, dispatch, templateURL, hostID]);
+  const liveOutput = useTemplateInvocationOutputPolling({
+    hostID,
+    jobID,
+    isExpanded,
+    response,
+  });
 
   if (!response || (status === STATUS.PENDING && isEmpty(response))) {
     return <Skeleton data-testid="template-invocation-skeleton" />;
@@ -156,13 +105,7 @@ export const TemplateInvocation = ({
     );
   }
 
-  const {
-    preview,
-    output,
-    input_values: inputValues,
-    task,
-    permissions,
-  } = response;
+  const { preview, input_values: inputValues, task, permissions } = response;
   const { id: taskID, cancellable: taskCancellable } = task || {};
 
   return (
@@ -183,7 +126,7 @@ export const TemplateInvocation = ({
         isInTableView={isInTableView}
         copyToClipboard={
           <CopyToClipboard
-            fullOutput={output
+            fullOutput={liveOutput
               ?.filter(
                 ({ output_type: outputType }) => showOutputType[outputType]
               )
@@ -226,7 +169,7 @@ export const TemplateInvocation = ({
         </>
       )}
       <OutputCodeBlock
-        code={output || []}
+        code={liveOutput}
         showOutputType={showOutputType}
         scrollElement={
           isInTableView

--- a/webpack/JobInvocationDetail/TemplateInvocationComponents/OutputCodeBlock.js
+++ b/webpack/JobInvocationDetail/TemplateInvocationComponents/OutputCodeBlock.js
@@ -9,58 +9,87 @@ import { Button } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { MS_PER_SECOND } from 'foremanReact/constants';
 
+// eslint-disable-next-line no-control-regex
+const COLOR_PATTERN = /\x1b\[[\d;]*m/g;
+const CONSOLE_COLOR = {
+  '31': 'red',
+  '32': 'lightgreen',
+  '33': 'orange',
+  '34': 'deepskyblue',
+  '35': 'mediumpurple',
+  '36': 'cyan',
+  '37': 'grey',
+  '91': 'red',
+  '92': 'lightgreen',
+  '93': 'yellow',
+  '94': 'lightblue',
+  '95': 'violet',
+  '96': 'turquoise',
+  '0': 'default',
+  '39': 'default',
+};
+const parsedOutput = new WeakMap();
+
+const colorizeLine = line => {
+  line = line.replace(COLOR_PATTERN, seq => {
+    const codes = seq.match(/(\d+)/g) || [];
+    const lastColorCode =
+      [...codes].reverse().find(code_ => code_ in CONSOLE_COLOR) || '0';
+    return `{{{format color:${lastColorCode}}}}`;
+  });
+
+  let currentColor = 'default';
+  const parts = line.split(/({{{format.*?}}})/).filter(Boolean);
+  if (parts.length === 0) return <span>{'\n'}</span>;
+
+  // eslint-disable-next-line array-callback-return, consistent-return
+  return parts.map((consoleLine, index) => {
+    if (consoleLine.includes('{{{format')) {
+      const colorMatch = consoleLine.match(/color:(\d+)/);
+      if (colorMatch) {
+        const colorIndex = colorMatch[1];
+        currentColor = CONSOLE_COLOR[colorIndex] || 'default';
+      }
+    } else {
+      return (
+        <span key={index} style={{ color: currentColor }}>
+          {consoleLine.length ? consoleLine : '\n'}
+        </span>
+      );
+    }
+  });
+};
+
+const getLineOutputs = lineSet => {
+  if (parsedOutput.has(lineSet)) return parsedOutput.get(lineSet);
+
+  const lineOutputs =
+    lineSet.output === '\n'
+      ? []
+      : lineSet.output
+          .replace(/\r\n/g, '\n')
+          .replace(/\n$/, '')
+          .split('\n');
+  parsedOutput.set(lineSet, lineOutputs);
+  return lineOutputs;
+};
+
+const OutputLineSet = React.memo(({ lineSet, startLine }) =>
+  getLineOutputs(lineSet).map((lineOutput, index) => (
+    <div key={index} className={`line ${lineSet.output_type}`}>
+      <span
+        className="counter"
+        title={new Date(lineSet.timestamp * MS_PER_SECOND).toISOString()}
+      >
+        {(startLine + index).toString().padStart(4, '\u00A0')}:{' '}
+      </span>
+      <div className="content">{colorizeLine(lineOutput)}</div>
+    </div>
+  ))
+);
+
 export const OutputCodeBlock = ({ code, showOutputType, scrollElement }) => {
   let lineCounter = 0;
-  // eslint-disable-next-line no-control-regex
-  const COLOR_PATTERN = /\x1b\[[\d;]*m/g;
-  const CONSOLE_COLOR = {
-    '31': 'red',
-    '32': 'lightgreen',
-    '33': 'orange',
-    '34': 'deepskyblue',
-    '35': 'mediumpurple',
-    '36': 'cyan',
-    '37': 'grey',
-    '91': 'red',
-    '92': 'lightgreen',
-    '93': 'yellow',
-    '94': 'lightblue',
-    '95': 'violet',
-    '96': 'turquoise',
-    '0': 'default',
-    '39': 'default',
-  };
-
-  const colorizeLine = line => {
-    line = line.replace(COLOR_PATTERN, seq => {
-      const codes = seq.match(/(\d+)/g) || [];
-      const lastColorCode =
-        [...codes].reverse().find(code_ => code_ in CONSOLE_COLOR) || '0';
-      return `{{{format color:${lastColorCode}}}}`;
-    });
-
-    let currentColor = 'default';
-    const parts = line.split(/({{{format.*?}}})/).filter(Boolean);
-    if (parts.length === 0) {
-      return <span>{'\n'}</span>;
-    }
-    // eslint-disable-next-line array-callback-return, consistent-return
-    return parts.map((consoleLine, index) => {
-      if (consoleLine.includes('{{{format')) {
-        const colorMatch = consoleLine.match(/color:(\d+)/);
-        if (colorMatch) {
-          const colorIndex = colorMatch[1];
-          currentColor = CONSOLE_COLOR[colorIndex] || 'default';
-        }
-      } else {
-        return (
-          <span key={index} style={{ color: currentColor }}>
-            {consoleLine.length ? consoleLine : '\n'}
-          </span>
-        );
-      }
-    });
-  };
   const filteredCode = code.filter(
     ({ output_type: outputType }) => showOutputType[outputType]
   );
@@ -109,28 +138,16 @@ export const OutputCodeBlock = ({ code, showOutputType, scrollElement }) => {
   if (!filteredCode.length) {
     return <div>{__('No output for the selected filters')}</div>;
   }
-  const codeParse = filteredCode.map(line => {
-    if (line.output === '\n') {
-      return null;
-    }
-    const lineOutputs = line.output
-      .replace(/\r\n/g, '\n')
-      .replace(/\n$/, '')
-      .split('\n');
-    return lineOutputs.map((lineOutput, index) => {
-      lineCounter += 1;
-      return (
-        <div key={index} className={`line ${line.output_type}`}>
-          <span
-            className="counter"
-            title={new Date(line.timestamp * MS_PER_SECOND).toISOString()}
-          >
-            {lineCounter.toString().padStart(4, '\u00A0')}:{' '}
-          </span>
-          <div className="content">{colorizeLine(lineOutput)}</div>
-        </div>
-      );
-    });
+  const codeParse = filteredCode.map((lineSet, index) => {
+    const startLine = lineCounter + 1;
+    lineCounter += getLineOutputs(lineSet).length;
+    return (
+      <OutputLineSet
+        key={lineSet.id || `${lineSet.timestamp}-${index}`}
+        lineSet={lineSet}
+        startLine={startLine}
+      />
+    );
   });
 
   return (
@@ -166,4 +183,9 @@ OutputCodeBlock.propTypes = {
   code: PropTypes.array.isRequired,
   showOutputType: PropTypes.object.isRequired,
   scrollElement: PropTypes.string.isRequired,
+};
+
+OutputLineSet.propTypes = {
+  lineSet: PropTypes.object.isRequired,
+  startLine: PropTypes.number.isRequired,
 };

--- a/webpack/JobInvocationDetail/TemplateInvocationHelpers.js
+++ b/webpack/JobInvocationDetail/TemplateInvocationHelpers.js
@@ -1,0 +1,27 @@
+export const getLastOutputTimestamp = output =>
+  output.length ? output[output.length - 1].timestamp : null;
+
+export const mergeOutput = (currentOutput, newOutput) => {
+  if (!newOutput.length) return currentOutput;
+
+  const mergedOutput = [...currentOutput];
+  const appendedOutput = newOutput.map(lineSet => ({ ...lineSet }));
+  const previousLineSet = mergedOutput[mergedOutput.length - 1];
+  const firstNewLineSet = appendedOutput[0];
+
+  if (previousLineSet && !previousLineSet.output.endsWith('\n')) {
+    const firstCompleteLine = firstNewLineSet.output.match(/^.*\n/);
+    if (firstCompleteLine) {
+      mergedOutput[mergedOutput.length - 1] = {
+        ...previousLineSet,
+        output: previousLineSet.output + firstCompleteLine[0],
+      };
+      appendedOutput[0] = {
+        ...firstNewLineSet,
+        output: firstNewLineSet.output.slice(firstCompleteLine[0].length),
+      };
+    }
+  }
+
+  return [...mergedOutput, ...appendedOutput];
+};

--- a/webpack/JobInvocationDetail/__tests__/TemplateInvocationHelpers.test.js
+++ b/webpack/JobInvocationDetail/__tests__/TemplateInvocationHelpers.test.js
@@ -1,0 +1,52 @@
+import {
+  getLastOutputTimestamp,
+  mergeOutput,
+} from '../TemplateInvocationHelpers';
+
+describe('TemplateInvocationHelpers', () => {
+  describe('getLastOutputTimestamp', () => {
+    it('returns null for empty output', () => {
+      expect(getLastOutputTimestamp([])).toBeNull();
+    });
+
+    it('returns the timestamp of the last output chunk', () => {
+      expect(
+        getLastOutputTimestamp([
+          { timestamp: 1, output: 'first\n' },
+          { timestamp: 2, output: 'second\n' },
+        ])
+      ).toBe(2);
+    });
+  });
+
+  describe('mergeOutput', () => {
+    it('appends new chunks without changing existing objects', () => {
+      const existingChunk = { timestamp: 1, output: 'first\n' };
+      const newChunk = { timestamp: 2, output: 'second\n' };
+
+      const result = mergeOutput([existingChunk], [newChunk]);
+
+      expect(result).toEqual([existingChunk, newChunk]);
+      expect(result[0]).toBe(existingChunk);
+      expect(result[1]).not.toBe(newChunk);
+    });
+
+    it('joins a line split across two polling responses', () => {
+      const result = mergeOutput(
+        [{ timestamp: 1, output: 'partial ' }],
+        [{ timestamp: 2, output: 'line\nnext line\n' }]
+      );
+
+      expect(result).toEqual([
+        { timestamp: 1, output: 'partial line\n' },
+        { timestamp: 2, output: 'next line\n' },
+      ]);
+    });
+
+    it('returns the current output when there is nothing to append', () => {
+      const currentOutput = [{ timestamp: 1, output: 'first\n' }];
+
+      expect(mergeOutput(currentOutput, [])).toBe(currentOutput);
+    });
+  });
+});

--- a/webpack/JobInvocationDetail/__tests__/TemplateInvocationPolling.test.js
+++ b/webpack/JobInvocationDetail/__tests__/TemplateInvocationPolling.test.js
@@ -2,12 +2,19 @@ import React from 'react';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
-import { render, act } from '@testing-library/react';
+import { render, act, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import * as api from 'foremanReact/redux/API';
 import * as selectors from '../JobInvocationSelectors';
 import { TemplateInvocation } from '../TemplateInvocation';
-import { mockTemplateInvocationResponse } from './fixtures';
+import {
+  OUTPUT_MAX_REFRESH_INTERVAL_MS,
+  OUTPUT_REFRESH_INTERVAL_MS,
+} from '../JobInvocationConstants';
+import {
+  jobInvocationOutput,
+  mockTemplateInvocationResponse,
+} from './fixtures';
 
 jest.spyOn(api, 'get');
 jest.mock('../JobInvocationSelectors');
@@ -20,6 +27,8 @@ describe('TemplateInvocation polling', () => {
   const noop = () => {};
   const reducer = (state = {}) => state;
   const makeStore = () => createStore(reducer, applyMiddleware(thunk));
+  const outputURL = '/api/job_invocations/1/hosts/1';
+  const detailsURL = '/show_template_invocation_by_host/1/job_invocation/1';
 
   const pollingProps = {
     hostID: '1',
@@ -35,8 +44,28 @@ describe('TemplateInvocation polling', () => {
     showCommand: false,
     setShowCommand: noop,
   };
+  const renderInvocation = (props = {}) =>
+    render(
+      <Provider store={makeStore()}>
+        <TemplateInvocation {...pollingProps} {...props} />
+      </Provider>
+    );
 
   let apiGetSpy;
+
+  const respond = (request, overrides = {}) => {
+    const data =
+      request.url === outputURL
+        ? { output: [], refresh: true, ...overrides.output }
+        : {
+            ...mockTemplateInvocationResponse,
+            finished: false,
+            auto_refresh: true,
+            ...overrides.details,
+          };
+    if (request.handleSuccess) request.handleSuccess({ data });
+    return { type: 'MOCK_GET' };
+  };
 
   beforeEach(() => {
     jest.useFakeTimers({ legacyFakeTimers: true });
@@ -48,11 +77,7 @@ describe('TemplateInvocation polling', () => {
     );
     apiGetSpy = jest
       .spyOn(api.APIActions, 'get')
-      .mockImplementation(({ handleSuccess }) => {
-        handleSuccess &&
-          handleSuccess({ data: { finished: false, auto_refresh: true } });
-        return { type: 'MOCK_GET' };
-      });
+      .mockImplementation(request => respond(request));
   });
 
   afterEach(() => {
@@ -61,194 +86,239 @@ describe('TemplateInvocation polling', () => {
     apiGetSpy.mockRestore();
   });
 
-  it('fetches on mount when isExpanded is true', () => {
+  it('requests only output added since the latest displayed chunk', () => {
+    renderInvocation();
+
+    expect(apiGetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: outputURL,
+        params: {
+          since: jobInvocationOutput[jobInvocationOutput.length - 1].timestamp,
+        },
+      })
+    );
+  });
+
+  it('polls output once per output refresh interval', () => {
+    renderInvocation();
+    expect(apiGetSpy).toHaveBeenCalledTimes(1);
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+
+    expect(apiGetSpy).toHaveBeenCalledTimes(2);
+    expect(apiGetSpy.mock.calls[1][0].url).toBe(outputURL);
+  });
+
+  it('gradually backs off while the job produces no output', () => {
+    renderInvocation();
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+    expect(apiGetSpy).toHaveBeenCalledTimes(2);
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+    expect(apiGetSpy).toHaveBeenCalledTimes(2);
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+    expect(apiGetSpy).toHaveBeenCalledTimes(3);
+
+    act(() =>
+      jest.advanceTimersByTime(
+        OUTPUT_MAX_REFRESH_INTERVAL_MS - OUTPUT_REFRESH_INTERVAL_MS
+      )
+    );
+    expect(apiGetSpy).toHaveBeenCalledTimes(3);
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+    expect(apiGetSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns to fast polling when new output arrives', () => {
+    let outputRequests = 0;
+    apiGetSpy.mockImplementation(request => {
+      if (request.url !== outputURL) return respond(request);
+      outputRequests += 1;
+      return respond(request, {
+        output: {
+          output:
+            outputRequests === 3
+              ? [
+                  {
+                    output_type: 'stdout',
+                    output: 'New live output\n',
+                    timestamp: 1733931150.2044532,
+                  },
+                ]
+              : [],
+        },
+      });
+    });
+
+    renderInvocation();
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS * 2));
+    expect(apiGetSpy).toHaveBeenCalledTimes(3);
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+    expect(apiGetSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('appends new output without replacing the displayed output', () => {
+    apiGetSpy.mockImplementation(request =>
+      respond(request, {
+        output: {
+          output: [
+            {
+              output_type: 'stdout',
+              output: 'New live output\n',
+              timestamp: 1733931150.2044532,
+            },
+          ],
+        },
+      })
+    );
+
+    renderInvocation();
+
+    expect(screen.getByText('This is red text')).toBeInTheDocument();
+    expect(screen.getByText('New live output')).toBeInTheDocument();
+  });
+
+  it('refreshes the complete details once after host output finishes', () => {
+    apiGetSpy.mockImplementation(request =>
+      respond(request, {
+        output: { refresh: false },
+        details: { finished: false, auto_refresh: true },
+      })
+    );
+
+    renderInvocation();
+
+    expect(apiGetSpy).toHaveBeenCalledTimes(2);
+    expect(apiGetSpy.mock.calls[0][0].url).toBe(outputURL);
+    expect(apiGetSpy.mock.calls[1][0].url).toBe(detailsURL);
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS * 2));
+
+    expect(apiGetSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('loads complete details first when no cached response exists', () => {
+    selectors.selectTemplateInvocation.mockImplementation(() => () =>
+      undefined
+    );
+
+    renderInvocation();
+
+    expect(apiGetSpy).toHaveBeenCalledTimes(1);
+    expect(apiGetSpy.mock.calls[0][0].url).toBe(detailsURL);
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+
+    expect(apiGetSpy).toHaveBeenCalledTimes(2);
+    expect(apiGetSpy.mock.calls[1][0].url).toBe(outputURL);
+  });
+
+  it('does not poll output when complete details disable auto refresh', () => {
+    selectors.selectTemplateInvocation.mockImplementation(() => () =>
+      undefined
+    );
+    apiGetSpy.mockImplementation(request =>
+      respond(request, { details: { auto_refresh: false } })
+    );
+
+    renderInvocation();
+
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS * 2));
+
+    expect(apiGetSpy).toHaveBeenCalledTimes(1);
+    expect(apiGetSpy.mock.calls[0][0].url).toBe(detailsURL);
+  });
+
+  it('does not fetch while collapsed', () => {
+    renderInvocation({ isExpanded: false });
+
+    expect(apiGetSpy).not.toHaveBeenCalled();
+  });
+
+  it('pauses output requests while the document is hidden', () => {
+    const visibilityState = Object.getOwnPropertyDescriptor(
+      document,
+      'visibilityState'
+    );
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    });
+
+    try {
+      renderInvocation();
+      act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+      expect(apiGetSpy).not.toHaveBeenCalled();
+
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        value: 'visible',
+      });
+      act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
+      expect(apiGetSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      if (visibilityState) {
+        Object.defineProperty(document, 'visibilityState', visibilityState);
+      } else {
+        delete document.visibilityState;
+      }
+    }
+  });
+
+  it('does not fetch when the cached response is already finished', () => {
+    selectors.selectTemplateInvocation.mockImplementation(() => () => ({
+      ...mockTemplateInvocationResponse,
+      finished: true,
+    }));
+
+    renderInvocation();
+
+    expect(apiGetSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels a scheduled poll when collapsed', () => {
     const localStore = makeStore();
-    render(
+    const { rerender } = render(
       <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded />
+        <TemplateInvocation {...pollingProps} />
       </Provider>
     );
     expect(apiGetSpy).toHaveBeenCalledTimes(1);
-  });
 
-  it('does not fetch on mount when isExpanded is false', () => {
-    const localStore = makeStore();
-    render(
+    rerender(
       <Provider store={localStore}>
         <TemplateInvocation {...pollingProps} isExpanded={false} />
       </Provider>
     );
-    expect(apiGetSpy).not.toHaveBeenCalled();
-  });
+    act(() => jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS));
 
-  it('schedules next poll via setTimeout when auto_refresh is true and not finished', () => {
-    const localStore = makeStore();
-    render(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} />
-      </Provider>
-    );
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-
-    act(() => jest.advanceTimersByTime(5000));
-    expect(apiGetSpy).toHaveBeenCalledTimes(2);
-  });
-
-  it('does not schedule next poll when finished is true', () => {
-    apiGetSpy.mockImplementation(({ handleSuccess }) => {
-      handleSuccess &&
-        handleSuccess({ data: { finished: true, auto_refresh: true } });
-      return { type: 'MOCK_GET' };
-    });
-    const localStore = makeStore();
-    render(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} />
-      </Provider>
-    );
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-
-    act(() => jest.advanceTimersByTime(5000));
     expect(apiGetSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('does not schedule next poll when auto_refresh is false', () => {
-    apiGetSpy.mockImplementation(({ handleSuccess }) => {
-      handleSuccess &&
-        handleSuccess({ data: { finished: false, auto_refresh: false } });
-      return { type: 'MOCK_GET' };
-    });
-    const localStore = makeStore();
-    render(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} />
-      </Provider>
-    );
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-
-    act(() => jest.advanceTimersByTime(5000));
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('clears the polling timeout and sets cancelled on unmount', () => {
-    const localStore = makeStore();
-    const { unmount } = render(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} />
-      </Provider>
-    );
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-
-    unmount();
-    act(() => jest.advanceTimersByTime(5000));
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('cancels in-flight callback when unmounted before handleSuccess runs', () => {
+  it('ignores an in-flight response after unmount', () => {
     let capturedHandleSuccess;
     apiGetSpy.mockImplementation(({ handleSuccess }) => {
       capturedHandleSuccess = handleSuccess;
       return { type: 'MOCK_GET' };
     });
 
-    const localStore = makeStore();
     const { unmount } = render(
-      <Provider store={localStore}>
+      <Provider store={makeStore()}>
         <TemplateInvocation {...pollingProps} />
       </Provider>
     );
     expect(apiGetSpy).toHaveBeenCalledTimes(1);
 
     unmount();
-
     act(() => {
-      capturedHandleSuccess({ data: { finished: false, auto_refresh: true } });
-      jest.advanceTimersByTime(5000);
+      capturedHandleSuccess({ data: { output: [], refresh: true } });
+      jest.advanceTimersByTime(OUTPUT_REFRESH_INTERVAL_MS);
     });
 
     expect(apiGetSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('re-fetches when isExpanded changes from false to true', () => {
-    const localStore = makeStore();
-    const { rerender } = render(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded={false} />
-      </Provider>
-    );
-    expect(apiGetSpy).not.toHaveBeenCalled();
-
-    rerender(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded />
-      </Provider>
-    );
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not re-fetch on expand when response is already finished', () => {
-    selectors.selectTemplateInvocation.mockImplementation(() => () => ({
-      ...mockTemplateInvocationResponse,
-      finished: true,
-    }));
-    apiGetSpy.mockImplementation(({ handleSuccess }) => {
-      handleSuccess &&
-        handleSuccess({ data: { finished: true, auto_refresh: false } });
-      return { type: 'MOCK_GET' };
-    });
-
-    const localStore = makeStore();
-    const { rerender } = render(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded={false} />
-      </Provider>
-    );
-    expect(apiGetSpy).not.toHaveBeenCalled();
-
-    rerender(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded />
-      </Provider>
-    );
-    // Selector already returns finished=true → guard skips dispatchFetch
-    expect(apiGetSpy).not.toHaveBeenCalled();
-
-    rerender(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded={false} />
-      </Provider>
-    );
-    rerender(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded />
-      </Provider>
-    );
-    // Second expand: still finished → still no fetch
-    expect(apiGetSpy).not.toHaveBeenCalled();
-  });
-
-  it('cancels existing poll and starts fresh when isExpanded changes', () => {
-    const localStore = makeStore();
-    const { rerender } = render(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded />
-      </Provider>
-    );
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-
-    rerender(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded={false} />
-      </Provider>
-    );
-    act(() => jest.advanceTimersByTime(5000));
-    expect(apiGetSpy).toHaveBeenCalledTimes(1);
-
-    rerender(
-      <Provider store={localStore}>
-        <TemplateInvocation {...pollingProps} isExpanded />
-      </Provider>
-    );
-    expect(apiGetSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/webpack/JobInvocationDetail/useTemplateInvocationOutputPolling.js
+++ b/webpack/JobInvocationDetail/useTemplateInvocationOutputPolling.js
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { APIActions } from 'foremanReact/redux/API';
+import {
+  GET_TEMPLATE_INVOCATION,
+  GET_TEMPLATE_INVOCATION_OUTPUT,
+  OUTPUT_MAX_REFRESH_INTERVAL_MS,
+  OUTPUT_REFRESH_INTERVAL_MS,
+  showTemplateInvocationUrl,
+  templateInvocationOutputUrl,
+} from './JobInvocationConstants';
+import {
+  getLastOutputTimestamp,
+  mergeOutput,
+} from './TemplateInvocationHelpers';
+
+export const useTemplateInvocationOutputPolling = ({
+  hostID,
+  jobID,
+  isExpanded,
+  response,
+}) => {
+  const dispatch = useDispatch();
+  const responseOutput = response?.output;
+  const responseFinished = response?.finished || false;
+  const hostFinishedRef = useRef(response?.finished || false);
+  const [liveOutput, setLiveOutput] = useState(responseOutput || []);
+  const lastTimestampRef = useRef(getLastOutputTimestamp(responseOutput || []));
+  const hasCachedOutput = Array.isArray(responseOutput);
+
+  const replaceOutput = useCallback(output => {
+    const nextOutput = Array.isArray(output) ? output : [];
+    lastTimestampRef.current = getLastOutputTimestamp(nextOutput);
+    setLiveOutput(nextOutput);
+  }, []);
+
+  const appendOutput = useCallback(output => {
+    const nextOutput = Array.isArray(output) ? output : [];
+    const lastTimestamp = getLastOutputTimestamp(nextOutput);
+    if (lastTimestamp !== null && lastTimestamp !== undefined) {
+      lastTimestampRef.current = lastTimestamp;
+    }
+    setLiveOutput(currentOutput => mergeOutput(currentOutput, nextOutput));
+  }, []);
+
+  useEffect(() => {
+    if (Array.isArray(responseOutput)) replaceOutput(responseOutput);
+    if (responseFinished) hostFinishedRef.current = true;
+  }, [replaceOutput, responseFinished, responseOutput]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timeoutId = null;
+    let idlePolls = 0;
+    const detailsURL = showTemplateInvocationUrl(hostID, jobID);
+    const outputURL = templateInvocationOutputUrl(hostID, jobID);
+
+    const scheduleNextPoll = newOutput => {
+      idlePolls = newOutput.length ? 0 : idlePolls + 1;
+      const interval = Math.min(
+        OUTPUT_REFRESH_INTERVAL_MS * Math.max(idlePolls, 1),
+        OUTPUT_MAX_REFRESH_INTERVAL_MS
+      );
+      timeoutId = setTimeout(scheduleOutputPoll, interval);
+    };
+
+    function scheduleOutputPoll() {
+      if (cancelled) return;
+      const isDocumentVisible =
+        document.visibilityState === 'visible' ||
+        document.visibilityState === 'prerender';
+      if (!isDocumentVisible) {
+        timeoutId = setTimeout(scheduleOutputPoll, OUTPUT_REFRESH_INTERVAL_MS);
+        return;
+      }
+      dispatch(
+        APIActions.get({
+          url: outputURL,
+          key: `${GET_TEMPLATE_INVOCATION_OUTPUT}_${hostID}`,
+          params:
+            lastTimestampRef.current === null
+              ? {}
+              : { since: lastTimestampRef.current },
+          handleSuccess: ({ data }) => {
+            if (cancelled) return;
+            const newOutput = Array.isArray(data?.output) ? data.output : [];
+            appendOutput(newOutput);
+            if (data?.refresh) {
+              scheduleNextPoll(newOutput);
+            } else {
+              hostFinishedRef.current = true;
+              timeoutId = null;
+              fetchDetails(false);
+            }
+          },
+          handleError: () => {
+            if (cancelled) return;
+            timeoutId = null;
+          },
+        })
+      );
+    }
+
+    function fetchDetails(pollOutput = true) {
+      if (cancelled) return;
+      dispatch(
+        APIActions.get({
+          url: detailsURL,
+          key: `${GET_TEMPLATE_INVOCATION}_${hostID}`,
+          handleSuccess: ({ data }) => {
+            if (cancelled) return;
+            replaceOutput(data?.output || []);
+            const isFinished = data?.finished ?? true;
+            // eslint-disable-next-line camelcase
+            const autoRefresh = data?.auto_refresh || false;
+            if (pollOutput && !isFinished && autoRefresh) {
+              hostFinishedRef.current = false;
+              idlePolls = 0;
+              timeoutId = setTimeout(
+                scheduleOutputPoll,
+                OUTPUT_REFRESH_INTERVAL_MS
+              );
+            } else {
+              timeoutId = null;
+            }
+          },
+          handleError: () => {
+            if (cancelled) return;
+            timeoutId = null;
+          },
+        })
+      );
+    }
+
+    if (isExpanded) {
+      if (hostFinishedRef.current || responseFinished) return undefined;
+      if (hasCachedOutput) {
+        scheduleOutputPoll();
+      } else {
+        fetchDetails();
+      }
+    }
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeoutId);
+    };
+  }, [
+    appendOutput,
+    dispatch,
+    hasCachedOutput,
+    hostID,
+    isExpanded,
+    jobID,
+    replaceOutput,
+    responseFinished,
+  ]);
+
+  return liveOutput;
+};


### PR DESCRIPTION
The output for an expanded host is currently refreshed every five seconds by fetching the complete template invocation details. This repeatedly transfers the full accumulated output together with template, task, proxy, and permission data, then parses and renders the entire console again.

Use the existing per-host output API with the `since` parameter to request only chunks newer than the last displayed timestamp. Poll once per second while the output is open, append new chunks while preserving split lines, pause requests in hidden tabs, and refresh the complete invocation details once after the host finishes.

Keep existing output line sets stable and memoize their parsed ANSI output so long-running jobs only process newly appended content.

Tests:
- incremental requests use the latest displayed timestamp
- new output is appended and split lines are preserved
- polling stops after completion, collapse, or unmount
- hidden tabs pause output requests
- existing output rendering and ANSI colors remain unchanged

This pull request was assisted by Codex 5.6 Sol High.
