### PR TITLE
Fixes #39651 - Fix host table not updating during job execution

### DIFF
--- a/app/controllers/api/v2/job_invocations_controller.rb
+++ b/app/controllers/api/v2/job_invocations_controller.rb
@@ -118,6 +118,11 @@ module Api
       add_scoped_search_description_for(JobInvocation)
       param :id, :identifier, :required => true
       param :include_permissions, :bool, :required => false, :desc => N_('Include per-host task and permission data in the response')
+      description <<-DOC
+        Returns standard index metadata with an additional auto_refresh field.
+        The auto_refresh field indicates whether the job is still running and
+        the client should continue polling for updates.
+      DOC
       def hosts
         set_hosts_and_template_invocations
         @total = @hosts.size
@@ -128,7 +133,8 @@ module Api
         if params[:awaiting]
           @hosts = @hosts.select { |host| @host_statuses[host.id] == 'N/A' }
         end
-        render :hosts, :layout => 'api/v2/layouts/index_layout'
+        @auto_refresh = @job_invocation.task.try(:pending?) || false
+        render :hosts, :layout => 'api/v2/layouts/index_with_auto_refresh'
       end
 
       api :GET, '/job_invocations/:id/hosts/:host_id/raw', N_('Get raw output for a host')

--- a/app/views/api/v2/layouts/index_with_auto_refresh.json.erb
+++ b/app/views/api/v2/layouts/index_with_auto_refresh.json.erb
@@ -1,0 +1,6 @@
+<%
+# Extends api/v2/layouts/index_layout.json.erb with auto_refresh field
+base_json = JSON.parse(render(template: 'api/v2/layouts/index_layout', layout: false))
+base_json['auto_refresh'] = @auto_refresh
+base_json.to_json.html_safe
+%>

--- a/webpack/JobInvocationDetail/JobInvocationConstants.js
+++ b/webpack/JobInvocationDetail/JobInvocationConstants.js
@@ -76,7 +76,8 @@ const Columns = () => {
         return { title: __('Failed'), status: 1 };
       case 'planned':
         return { title: __('Scheduled'), status: 2 };
-      case 'running' || 'pending':
+      case 'running':
+      case 'pending':
         return { title: __('Pending'), status: 3 };
       case 'cancelled':
         return { title: __('Cancelled'), status: 4 };

--- a/webpack/JobInvocationDetail/JobInvocationHostTable.js
+++ b/webpack/JobInvocationDetail/JobInvocationHostTable.js
@@ -75,10 +75,6 @@ const JobInvocationHostTable = ({
   const currentPollParams = useRef({});
   const mountedRef = useRef(true);
   const requestIdRef = useRef(0);
-  const jobFinishedRef = useRef(jobFinished);
-  useEffect(() => {
-    jobFinishedRef.current = jobFinished;
-  }, [jobFinished]);
 
   const [hostInvocationStates, setHostInvocationStates] = useState({});
 
@@ -196,7 +192,7 @@ const JobInvocationHostTable = ({
             if (thisRequest !== requestIdRef.current) return;
             if (!mountedRef.current) return;
             updateHostsState(data);
-            if (!jobFinishedRef.current) {
+            if (data.data.auto_refresh) {
               pollTimeoutId.current = setTimeout(
                 () => makeApiCall(currentPollParams.current),
                 AUTO_REFRESH_INTERVAL_MS

--- a/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
+++ b/webpack/JobInvocationDetail/__tests__/JobInvocationHostTablePolling.test.js
@@ -36,6 +36,7 @@ const hostsResponse = {
   subtotal: 1,
   page: 1,
   per_page: 20,
+  auto_refresh: true,
   results: [
     {
       id: 1,
@@ -49,6 +50,11 @@ const hostsResponse = {
       smart_proxy_name: 'proxy1',
     },
   ],
+};
+
+const finishedHostsResponse = {
+  ...hostsResponse,
+  auto_refresh: false,
 };
 
 let apiGetSpy;
@@ -75,7 +81,6 @@ const renderTable = (props = {}) => {
     id: '42',
     targeting: { targeting_type: 'static_query', search_query: '' },
     initialFilter: 'all_statuses',
-    jobFinished: false,
     onFilterUpdate: jest.fn(),
     ...props,
   };
@@ -93,7 +98,10 @@ const renderTable = (props = {}) => {
   return { ...result, store, history };
 };
 
-const setupSuccessMock = () => {
+let mockResponse;
+
+const setupSuccessMock = (response = hostsResponse) => {
+  mockResponse = response;
   apiGetSpy = jest
     .spyOn(APIActions, 'get')
     .mockImplementation(opts => dispatch => {
@@ -101,7 +109,7 @@ const setupSuccessMock = () => {
         hostsCalls.push(opts);
         if (opts.handleSuccess) {
           pendingCallbacks.push(() =>
-            opts.handleSuccess({ data: hostsResponse })
+            opts.handleSuccess({ data: mockResponse })
           );
         }
       }
@@ -125,6 +133,7 @@ describe('JobInvocationHostTable polling', () => {
   beforeEach(() => {
     hostsCalls = [];
     pendingCallbacks = [];
+    mockResponse = hostsResponse;
     setupSuccessMock();
   });
 
@@ -165,8 +174,9 @@ describe('JobInvocationHostTable polling', () => {
     expect(hostsCalls).toHaveLength(3);
   });
 
-  it('does not schedule a poll when jobFinished is true', () => {
-    renderTable({ jobFinished: true });
+  it('does not schedule a poll when auto_refresh is false', () => {
+    setupSuccessMock(finishedHostsResponse);
+    renderTable();
 
     expect(hostsCalls).toHaveLength(1);
 
@@ -185,8 +195,8 @@ describe('JobInvocationHostTable polling', () => {
     expect(hostsCalls).toHaveLength(1);
   });
 
-  it('stops polling when jobFinished transitions to true', () => {
-    const { rerender } = renderTable();
+  it('stops polling when auto_refresh transitions to false', () => {
+    renderTable();
 
     act(() => {
       flushPendingCallbacks();
@@ -194,36 +204,19 @@ describe('JobInvocationHostTable polling', () => {
 
     expect(hostsCalls).toHaveLength(1);
 
-    const store = createStore();
-    const history = createMemoryHistory();
-    const Wrapper = createForemanContextWrapper();
+    mockResponse = finishedHostsResponse;
 
     act(() => {
-      rerender(
-        <Provider store={store}>
-          <Router history={history}>
-            <Wrapper>
-              <JobInvocationHostTable
-                id="42"
-                targeting={{
-                  targeting_type: 'static_query',
-                  search_query: '',
-                }}
-                initialFilter="all_statuses"
-                jobFinished
-                onFilterUpdate={jest.fn()}
-              />
-            </Wrapper>
-          </Router>
-        </Provider>
-      );
+      jest.advanceTimersByTime(5000);
     });
 
     act(() => {
       flushPendingCallbacks();
     });
 
-    const callsAtTransition = hostsCalls.length;
+    expect(hostsCalls).toHaveLength(2);
+
+    const callsAfterFinished = hostsCalls.length;
 
     act(() => {
       jest.advanceTimersByTime(10000);
@@ -233,7 +226,7 @@ describe('JobInvocationHostTable polling', () => {
       flushPendingCallbacks();
     });
 
-    expect(hostsCalls).toHaveLength(callsAtTransition);
+    expect(hostsCalls).toHaveLength(callsAfterFinished);
   });
 
   it('cleans up the poll timer on unmount', () => {


### PR DESCRIPTION
The host table on the job Invocation detail page didn't update while a job was running - it stayed frozen, showing "pending" even after the hosts finished.
The server now includes "auto_refresh": true/false in the API response. The client checks this field and stops polling when it becomes false.