### PR TITLE
Fixes #39673 - Use SeedHelper.format_errors in seeds

### DIFF
--- a/db/seeds.d/60-ssh_proxy_feature.rb
+++ b/db/seeds.d/60-ssh_proxy_feature.rb
@@ -1,5 +1,5 @@
 f = Feature.where(:name => 'SSH').first_or_create
-raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
+raise "Unable to create proxy feature: #{SeedHelper.format_errors(f)}" if f.nil? || f.errors.any?
 
 f = Feature.where(:name => 'Script').first_or_create
-raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
+raise "Unable to create proxy feature: #{SeedHelper.format_errors(f)}" if f.nil? || f.errors.any?

--- a/db/seeds.d/90-bookmarks.rb
+++ b/db/seeds.d/90-bookmarks.rb
@@ -15,6 +15,6 @@ Bookmark.without_auditing do
     b = Bookmark.where(:name => input[:name], :controller => input[:controller]).first || Bookmark.new
     b.attributes = attributes
     b.save
-    raise "Unable to create bookmark: #{format_errors b}" if b.errors.any?
+    raise "Unable to create bookmark: #{SeedHelper.format_errors(b)}" if b.errors.any?
   end
 end

--- a/db/seeds.d/95-mail_notifications.rb
+++ b/db/seeds.d/95-mail_notifications.rb
@@ -18,7 +18,7 @@ notifications.each do |notification|
     created_notification = RexMailNotification.create(notification)
     if created_notification.nil? || created_notification.errors.any?
       raise ::Foreman::Exception.new(N_("Unable to create mail notification: %s"),
-        format_errors(created_notification))
+        SeedHelper.format_errors(created_notification))
     end
   end
 end


### PR DESCRIPTION
Refs #39673

The top-level `format_errors` seed helper in Foreman core is deprecated (since 3.4) and is being removed as part of Foreman #39667 (theforeman/foreman#11193). This switches the plugin seed scripts to call `SeedHelper.format_errors` directly.

`SeedHelper.format_errors` has been available since the helper was deprecated, so this change is backward compatible with all supported Foreman versions and can be merged independently of the core removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)