### PR TITLE
Fixes #39711 - Disable Skip to review on the job wizard review step

### DIFF
--- a/webpack/JobWizard/Footer.js
+++ b/webpack/JobWizard/Footer.js
@@ -22,6 +22,19 @@ export const Footer = ({ canSubmit, onSave }) => {
             activeStep && activeStep.enableNext !== undefined
               ? activeStep.enableNext
               : true;
+          const isReviewStep = activeStep.name === WIZARD_TITLES.review;
+          const canSkipToReview = canSubmit && !isReviewStep;
+          const skipToReviewTooltip = () => {
+            if (canSkipToReview) {
+              return __('Skip to review step');
+            }
+            if (isReviewStep) {
+              return __('Already on the review step');
+            }
+            return __(
+              'Fill all required fields in all the steps to start the job'
+            );
+          };
 
           return (
             <>
@@ -32,9 +45,7 @@ export const Footer = ({ canSubmit, onSave }) => {
                 onClick={onNext}
                 isDisabled={!isValid || isSubmitting}
               >
-                {activeStep.name === WIZARD_TITLES.review
-                  ? __('Submit')
-                  : __('Next')}
+                {isReviewStep ? __('Submit') : __('Next')}
               </Button>
               <Button
                 ouiaId="back-footer"
@@ -68,22 +79,14 @@ export const Footer = ({ canSubmit, onSave }) => {
                 </Button>
               </Tooltip>
               <Tooltip
-                content={
-                  <div>
-                    {canSubmit
-                      ? __('Skip to review step')
-                      : __(
-                          'Fill all required fields in all the steps to start the job'
-                        )}
-                  </div>
-                }
+                content={<div>{skipToReviewTooltip()}</div>}
                 triggerRef={tooltipSkipTo}
               >
                 <Button
                   ouiaId="skip-to-review-footer"
                   variant="tertiary"
                   onClick={() => goToStepByName(WIZARD_TITLES.review)}
-                  isAriaDisabled={!canSubmit}
+                  isAriaDisabled={!canSkipToReview}
                   isDisabled={isSubmitting}
                   ref={tooltipSkipTo}
                 >

--- a/webpack/JobWizard/__tests__/Footer.test.js
+++ b/webpack/JobWizard/__tests__/Footer.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Wizard } from '@patternfly/react-core/deprecated';
+import configureMockStore from 'redux-mock-store';
+import { Footer } from '../Footer';
+import { WIZARD_TITLES } from '../JobWizardConstants';
+
+const store = configureMockStore([])({ API: {} });
+
+const renderFooterWizard = ({ canSubmit = true, startAtStep = 1 } = {}) =>
+  render(
+    <Provider store={store}>
+      <Wizard
+        steps={[
+          {
+            name: WIZARD_TITLES.categoryAndTemplate,
+            component: <div>category step</div>,
+          },
+          {
+            name: WIZARD_TITLES.review,
+            component: <div>review step</div>,
+          },
+        ]}
+        startAtStep={startAtStep}
+        footer={<Footer canSubmit={canSubmit} onSave={jest.fn()} />}
+      />
+    </Provider>
+  );
+
+describe('Job wizard footer', () => {
+  it('enables Skip to review when required fields are filled', () => {
+    renderFooterWizard({ canSubmit: true });
+
+    expect(screen.getByText('Skip to review')).not.toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('disables Skip to review when required fields are missing', () => {
+    renderFooterWizard({ canSubmit: false });
+
+    expect(screen.getByText('Skip to review')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('disables Skip to review on the review step', async () => {
+    renderFooterWizard({ canSubmit: true });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Skip to review'));
+    });
+
+    expect(screen.getByText('Submit')).toBeInTheDocument();
+    expect(screen.getByText('Skip to review')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+});


### PR DESCRIPTION

Fixes #[39711](https://projects.theforeman.org/issues/39711)

Skip to review stayed enabled on the last page of the job wizard (Review details / Submit) even though clicking it has no effect there.

## Details

From Hosts -> All Hosts -> hostname -> Schedule Remote Job:

1. Job Category: Command
2. Job Template: Run Command - Script Default
3. Enter a command — Skip to review becomes enabled
4. Click Skip to review — the wizard jumps to the last page (Submit)
5. Skip to review remains enabled on that page, with no useful action

Expected: Skip to review should be disabled (greyed out) on the review/submit page.

The footer only checked whether the form was complete (`canSubmit`). It did not check whether the active step was already Review details. Skip to review is now enabled only when the form is valid and the current step is not the review step. Other footer actions (Submit, Run on selected hosts, Back, Cancel) are unchanged.

https://projects.theforeman.org/issues/39711

## Test cases

### Manual

1. Open Schedule Remote Job for a host.
2. Select Job Category Command and Job Template Run Command - Script Default.
3. Leave the command empty — Skip to review is disabled.
4. Enter a command — Skip to review becomes enabled.
5. Click Skip to review — the wizard goes to Review details / Submit.
6. On that last page, Skip to review is disabled.
7. Submit still works.
8. Run on selected hosts is still enabled on the last page.
9. Click Back from review — Skip to review is enabled again on earlier steps.
10. Repeat with Next instead of Skip to review; on the last page Skip to review is still disabled.

### Automated

`webpack/JobWizard/__tests__/Footer.test.js`

- enables Skip to review when required fields are filled
- disables Skip to review when required fields are missing
- disables Skip to review after jumping to the review step
```