### PR TITLE
Fixes #39742 - Add allowed_nested_id to ForeignInputSetsController

### DIFF
--- a/app/controllers/api/v2/foreign_input_sets_controller.rb
+++ b/app/controllers/api/v2/foreign_input_sets_controller.rb
@@ -76,6 +76,10 @@ module Api
       def resource_class
         ForeignInputSet
       end
+
+      def allowed_nested_id
+        %w(template_id)
+      end
     end
   end
 end

--- a/lib/foreman_remote_execution/plugin.rb
+++ b/lib/foreman_remote_execution/plugin.rb
@@ -1,5 +1,5 @@
 Foreman::Plugin.register :foreman_remote_execution do
-  requires_foreman '>= 5.0'
+  requires_foreman '>= 5.1'
   register_global_js_file 'global'
   register_gettext
 


### PR DESCRIPTION
https://github.com/theforeman/foreman/pull/11215 had a change that caused REX CI turn red. Previously we treated any `<resource>_id` in params as a parent resource, with that change we check only ones listed in `allowed_nested_id` override. Currently we don't have such override for foreign input sets controller, thus we ignore the parent id.