### PR TITLE
Fixes #39754 - Debug output in job invocation details UI is displayed in red

### DIFF
--- a/webpack/JobInvocationDetail/JobInvocationDetail.scss
+++ b/webpack/JobInvocationDetail/JobInvocationDetail.scss
@@ -112,9 +112,12 @@ section.job-additional-info {
     }
 
     div.line.stderr,
-    div.line.error,
-    div.line.debug {
+    div.line.error {
       color: red;
+    }
+
+    div.line.debug {
+      color: var(--pf-v5-global--info-color--100)
     }
 
     div.line span.counter {


### PR DESCRIPTION
Before this commit, job output of type "debug" was displayed in red in the JobInvocationDetail component.

Coloring guidelines suggest reserving the color red for errors and to indicate danger.

In this commit, the color used to display debug output is changed to `--pf-v5-global--info-color--100`, which is the default color used to present informative content.

**Before:**
<img width="969" height="252" alt="image" src="https://github.com/user-attachments/assets/a026c12d-90c7-4489-ab53-c28df982b7f3" />

**After:**
<img width="969" height="252" alt="image" src="https://github.com/user-attachments/assets/01433cc6-6c08-48f4-85b0-f1b35bba2b6e" />
